### PR TITLE
Rename gradle properties.

### DIFF
--- a/.ci-local/credentials-fake.sh
+++ b/.ci-local/credentials-fake.sh
@@ -40,7 +40,7 @@ keytool \
   -validity 2
 
 cat >> "${HOME}/.gradle/gradle.properties" <<EOF
-org.librarysimplified.keyAlias=FAKE
-org.librarysimplified.keyPassword=redherring
-org.librarysimplified.storePassword=redherring
+org.thepalaceproject.keyAlias=FAKE
+org.thepalaceproject.keyPassword=redherring
+org.thepalaceproject.storePassword=redherring
 EOF

--- a/.ci-local/credentials.sh
+++ b/.ci-local/credentials.sh
@@ -54,12 +54,12 @@ then
 fi
 
 cat >> "${HOME}/.gradle/gradle.properties" <<EOF
-org.librarysimplified.drm.enabled=true
+org.thepalaceproject.drm.enabled=true
 
-org.lyrasis.aws.access_key_id=${CI_AWS_ACCESS_ID}
-org.lyrasis.aws.secret_access_key=${CI_AWS_SECRET_KEY}
+org.thepalaceproject.aws.access_key_id=${CI_AWS_ACCESS_ID}
+org.thepalaceproject.aws.secret_access_key=${CI_AWS_SECRET_KEY}
 
-org.librarysimplified.app.assets.palace=${SIMPLYE_CREDENTIALS}
+org.thepalaceproject.app.assets.palace=${SIMPLYE_CREDENTIALS}
 EOF
 
 #------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Once you have your credentials, the following lines must be added to `$HOME/.gra
 ~~~
 # Replace AWS_ACCESS_KEY_ID and AWS_SECRET_KEY appropriately.
 # Do NOT use quotes around either value.
-org.lyrasis.aws.access_key_id=AWS_ACCESS_KEY_ID
-org.lyrasis.aws.secret_access_key=AWS_SECRET_KEY
+org.thepalaceproject.aws.access_key_id=AWS_ACCESS_KEY_ID
+org.thepalaceproject.aws.secret_access_key=AWS_SECRET_KEY
 ~~~
 
 #### APK signing
@@ -146,9 +146,9 @@ a keystore to `release.jks` and set the following values correctly in
 ~~~
 # Replace KEYALIAS, KEYPASSWORD, and STOREPASSWORD appropriately.
 # Do NOT use quotes around values.
-org.librarysimplified.keyAlias=KEYALIAS
-org.librarysimplified.keyPassword=KEYPASSWORD
-org.librarysimplified.storePassword=STOREPASSWORD
+org.thepalaceproject.keyAlias=KEYALIAS
+org.thepalaceproject.keyPassword=KEYPASSWORD
+org.thepalaceproject.storePassword=STOREPASSWORD
 ~~~
 
 Note that APK files are only signed if the code is built in _release_ mode. In other words, you
@@ -169,7 +169,7 @@ correctly configured. Then, add the following property to your
 `$HOME/.gradle/gradle.properties` file:
 
 ```
-org.librarysimplified.drm.enabled=true
+org.thepalaceproject.drm.enabled=true
 ```
 
 This will instruct the build system that you want to build with DRM enabled.
@@ -186,7 +186,7 @@ and the build system will copy in the required secrets at build time:
 
 <!-- org.librarysimplified.app.assets.openebooks=/path/to/openebooks/secrets -->
 ```
-org.librarysimplified.app.assets.palace=/path/to/palace/secrets
+org.thepalaceproject.app.assets.palace=/path/to/palace/secrets
 ```
 
 #### Adobe DRM Support

--- a/build.gradle
+++ b/build.gradle
@@ -32,13 +32,13 @@ plugins {
 
 ext {
   nyplDrmEnabled =
-    project.findProperty('org.librarysimplified.drm.enabled') as Boolean
+    project.findProperty('org.thepalaceproject.drm.enabled') as Boolean
 
   if (nyplDrmEnabled) {
     awsAccessKeyId =
-      project.property("org.lyrasis.aws.access_key_id")
+      project.property("org.thepalaceproject.aws.access_key_id")
     awsSecretKey =
-      project.property("org.lyrasis.aws.secret_access_key")
+      project.property("org.thepalaceproject.aws.secret_access_key")
   } else {
     awsAccessKeyId = ""
     awsSecretKey = ""
@@ -133,7 +133,7 @@ subprojects { project ->
   // Skip tasks for projects that require drm; unless drm is enabled
   //
   def nyplDrmRequired =
-    project.findProperty('org.librarysimplified.drm.required') as Boolean
+    project.findProperty('org.thepalaceproject.drm.required') as Boolean
   if (nyplDrmRequired) {
     project.tasks.all { task ->
       task.onlyIf { nyplDrmEnabled }

--- a/build_apk.gradle
+++ b/build_apk.gradle
@@ -5,7 +5,7 @@ def projectNameSuffix = project.name.split("-").last()
 // Configure extra assets, if provided
 //
 def extraAssetsProperty =
-  "org.librarysimplified.app.assets.$projectNameSuffix"
+  "org.thepalaceproject.app.assets.$projectNameSuffix"
 def extraAssets =
   expandUserHome(project.findProperty(extraAssetsProperty))
 if (extraAssets != null && !file(extraAssets).exists()) {
@@ -20,11 +20,11 @@ if (extraAssets != null && !file(extraAssets).exists()) {
 def nyplKeyStore =
   file("$rootDir/release.jks")
 def nyplKeyAlias =
-  project.findProperty('org.librarysimplified.keyAlias')
+  project.findProperty('org.thepalaceproject.keyAlias')
 def nyplKeyPassword =
-  project.findProperty('org.librarysimplified.keyPassword')
+  project.findProperty('org.thepalaceproject.keyPassword')
 def nyplStorePassword =
-  project.findProperty('org.librarysimplified.storePassword')
+  project.findProperty('org.thepalaceproject.storePassword')
 
 /**
  * This task is run before a release build is assembled.
@@ -40,15 +40,15 @@ task preReleaseCheck(group: 'NYPL') {
     }
     if (!nyplKeyAlias) {
       throw new GradleException(
-        "'org.librarysimplified.keyAlias' must be defined to sign release builds")
+        "'org.thepalaceproject.keyAlias' must be defined to sign release builds")
     }
     if (!nyplKeyPassword) {
       throw new GradleException(
-        "'org.librarysimplified.keyPassword' must be defined to sign release builds")
+        "'org.thepalaceproject.keyPassword' must be defined to sign release builds")
     }
     if (!nyplStorePassword) {
       throw new GradleException(
-        "'org.librarysimplified.storePassword' must be defined to sign release builds")
+        "'org.thepalaceproject.storePassword' must be defined to sign release builds")
     }
   }
 }

--- a/simplified-app-openebooks/gradle.properties
+++ b/simplified-app-openebooks/gradle.properties
@@ -3,7 +3,7 @@ POM_DESCRIPTION=Open eBooks(Application)
 POM_NAME=org.nypl.labs.OpenEbooks.app
 POM_PACKAGING=apk
 
-# Skip this project unless the property `org.librarysimplified.drm.enabled=true`
+# Skip this project unless the property `org.thepalaceproject.drm.enabled=true`
 # is also defined.
 #
-org.librarysimplified.drm.required=true
+org.thepalaceproject.drm.required=true

--- a/simplified-app-palace/gradle.properties
+++ b/simplified-app-palace/gradle.properties
@@ -3,7 +3,7 @@ POM_DESCRIPTION=Palace
 POM_NAME=org.thepalaceproject.palace
 POM_PACKAGING=apk
 
-# Skip this project unless the property `org.librarysimplified.drm.enabled=true`
+# Skip this project unless the property `org.thepalaceproject.drm.enabled=true`
 # is also defined.
 #
-org.librarysimplified.drm.required=true
+org.thepalaceproject.drm.required=true

--- a/simplified-app-simplye/gradle.properties
+++ b/simplified-app-simplye/gradle.properties
@@ -3,7 +3,7 @@ POM_DESCRIPTION=SimplyE (Application)
 POM_NAME=org.librarysimplified.simplye.app
 POM_PACKAGING=apk
 
-# Skip this project unless the property `org.librarysimplified.drm.enabled=true`
+# Skip this project unless the property `org.thepalaceproject.drm.enabled=true`
 # is also defined.
 #
-org.librarysimplified.drm.required=true
+org.thepalaceproject.drm.required=true

--- a/simplified-app-vanilla/build.gradle
+++ b/simplified-app-vanilla/build.gradle
@@ -6,9 +6,9 @@ android {
   }
   sourceSets {
     main {
-      if (project.hasProperty('org.librarysimplified.app.assets.vanilla')) {
+      if (project.hasProperty('org.thepalaceproject.app.assets.vanilla')) {
         assets.srcDirs +=
-          project.getProperty('org.librarysimplified.app.assets.vanilla')
+          project.getProperty('org.thepalaceproject.app.assets.vanilla')
       }
     }
   }


### PR DESCRIPTION
**What's this do?**

Rename gradle properties to `org.thepalaceproject.*`.

**Why are we doing this? (w/ JIRA link if applicable)**

This makes life easier for developers who want to build both the NYPL-Simplified and ThePalaceProject forks, since gradle properties can now be set differently.

**How should this be tested? / Do these changes have associated tests?**

Rename the properties in your gradle.properties file. Local builds should continue to work.

**Dependencies for merging? Releasing to production?**

https://github.com/ThePalaceProject/mobile-certificates/pull/1 should be merged first.

**Has the application documentation been updated for these changes?**

The README is updated.

**Did someone actually run this code to verify it works?**

@ray-lee ran a local build.