### PR TITLE
Incorporate new Adobe cert for Palace.

### DIFF
--- a/.ci-local/credentials.sh
+++ b/.ci-local/credentials.sh
@@ -46,7 +46,7 @@ cat ".ci/credentials/APK Signing/keystore.properties" >> "${HOME}/.gradle/gradle
 CREDENTIALS_PATH=$(realpath ".ci/credentials") ||
   fatal "could not resolve credentials path"
 
-SIMPLYE_CREDENTIALS="${CREDENTIALS_PATH}/Certificates/SimplyE/Android"
+SIMPLYE_CREDENTIALS="${CREDENTIALS_PATH}/Certificates/Palace/Android"
 
 if [ ! -d "${SIMPLYE_CREDENTIALS}" ]
 then

--- a/simplified-app-palace/build.gradle
+++ b/simplified-app-palace/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.google.firebase.crashlytics'
 //
 def requiredFiles = [:]
 requiredFiles["ReaderClientCert.sig"] =
-  "29f5f58e8fa1694892f27c5bd825cbba4da0cfcc9d2367c5d8d89a0bae89e328"
+  "782624e4af51ed1b7f9f65f43c9d49ed719ffc33936bd450309b8454668f3508"
 requiredFiles["secrets.conf"] =
   "9c211ae0d153c29b72baab3bfad9de6c5cecb6b39bcda8206d36a65aaca0db21"
 

--- a/simplified-app-palace/src/main/res/values/features.xml
+++ b/simplified-app-palace/src/main/res/values/features.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
-<!-- Build-time feature flags. -->
-<resources>
-  <!-- TODO: Change to Palace when the certificate is updated -->
-  <string name="featureAdobeDRMPackageOverride" translatable="false">Raybooks</string>
-</resources>


### PR DESCRIPTION
**What's this do?**

Use the new Adobe cert for Palace.

**Why are we doing this? (w/ JIRA link if applicable)**

The new cert has the correct app id and app name for Palace, instead of RayBooks.

**How should this be tested? / Do these changes have associated tests?**

Borrowing and reading Adobe-protected books should continue to work.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the Palace app.