### PR TITLE
Enable account-specificc documentation viewer

### DIFF
--- a/simplified-documents/src/main/java/org/librarysimplified/documents/internal/SimpleDocument.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/internal/SimpleDocument.kt
@@ -1,0 +1,9 @@
+package org.librarysimplified.documents.internal
+
+import org.librarysimplified.documents.DocumentType
+import java.net.URL
+
+class SimpleDocument(override val readableURL: URL) : DocumentType {
+  override fun update() {
+  }
+}

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -52,6 +52,7 @@ import org.nypl.simplified.viewer.api.Viewers
 import org.nypl.simplified.viewer.spi.ViewerPreferences
 import org.slf4j.LoggerFactory
 import java.net.URI
+import java.net.URL
 
 internal class MainFragmentListenerDelegate(
   private val fragment: Fragment,
@@ -285,6 +286,10 @@ internal class MainFragmentListenerDelegate(
         this.openSAML20Login(event.account, event.authenticationDescription)
         state
       }
+      is AccountDetailEvent.OpenDocViewer -> {
+        this.openDocViewer(event.title, event.url)
+        state
+      }
     }
   }
 
@@ -479,6 +484,16 @@ internal class MainFragmentListenerDelegate(
           authenticationDescription = authenticationDescription
         )
       ),
+      tab = this.navigator.currentTab()
+    )
+  }
+
+  private fun openDocViewer(
+    title: String,
+    url: URL
+  ) {
+    this.navigator.addFragment(
+      fragment = SettingsFragmentDocumentViewer.create(title, url.toString()),
       tab = this.navigator.currentTab()
     )
   }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailEvent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailEvent.kt
@@ -3,6 +3,7 @@ package org.nypl.simplified.ui.accounts
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
+import java.net.URL
 
 sealed class AccountDetailEvent {
 
@@ -27,5 +28,13 @@ sealed class AccountDetailEvent {
 
   data class OpenErrorPage(
     val parameters: ErrorPageParameters
+  ) : AccountDetailEvent()
+
+  /**
+   * Open the documentation viewer.
+   */
+  data class OpenDocViewer(
+    val title: String,
+    val url: URL
   ) : AccountDetailEvent()
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
@@ -93,7 +92,9 @@ class AccountDetailFragment : Fragment(R.layout.account) {
   private lateinit var bookmarkSync: ViewGroup
   private lateinit var bookmarkSyncCheck: SwitchCompat
   private lateinit var bookmarkSyncLabel: View
-  private lateinit var eulaCheckbox: CheckBox
+  private lateinit var accountEULA: TextView
+  private lateinit var accountPrivacyPolicy: ViewGroup
+  private lateinit var accountLicenses: ViewGroup
   private lateinit var imageLoader: ImageLoaderType
   private lateinit var loginProgress: ViewGroup
   private lateinit var loginButtonErrorDetails: Button
@@ -180,8 +181,8 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       view.findViewById(R.id.accountLoginProgressText)
     this.loginButtonErrorDetails =
       view.findViewById(R.id.accountLoginButtonErrorDetails)
-    this.eulaCheckbox =
-      view.findViewById(R.id.accountEULACheckbox)
+    this.accountEULA =
+      view.findViewById(R.id.accountEULA)
     this.signUpButton =
       view.findViewById(R.id.accountCardCreatorSignUp)
     this.signUpLabel =
@@ -193,6 +194,11 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       view.findViewById(R.id.accountCustomOPDS)
     this.accountCustomOPDSField =
       this.accountCustomOPDS.findViewById(R.id.accountCustomOPDSField)
+    this.accountPrivacyPolicy =
+      view.findViewById(R.id.accountPrivacyPolicy)
+    this.accountLicenses =
+      view.findViewById(R.id.accountLicenses)
+
 
     this.reportIssueGroup =
       view.findViewById(R.id.accountReportIssue)
@@ -216,19 +222,51 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     }
 
     /*
-    * Only show a EULA checkbox if there's actually a EULA.
+    * Only show a EULA if there's actually a EULA.
     */
-
     val eula = this.viewModel.eula
     if (eula != null) {
-      this.eulaCheckbox.visibility = View.VISIBLE
-      this.eulaCheckbox.isChecked = eula.hasAgreed
-      this.eulaCheckbox.setOnCheckedChangeListener { _, checked ->
-        eula.hasAgreed = checked
-        this.setLoginButtonStatus(this.determineLoginIsSatisfied())
+      this.accountEULA.visibility = View.VISIBLE
+      this.accountEULA.setOnClickListener {
+        this.listener.post(
+          AccountDetailEvent.OpenDocViewer(
+            getString(R.string.accountEULA),
+            eula.readableURL
+          )
+        )
       }
     } else {
-      this.eulaCheckbox.visibility = View.GONE
+      this.accountEULA.visibility = View.GONE
+    }
+
+    val privacyPolicy = this.viewModel.privacyPolicy
+    if (privacyPolicy != null) {
+      this.accountPrivacyPolicy.visibility = View.VISIBLE
+      this.accountPrivacyPolicy.setOnClickListener {
+        this.listener.post(
+          AccountDetailEvent.OpenDocViewer(
+            getString(R.string.accountPrivacyPolicy),
+            privacyPolicy.readableURL
+          )
+        )
+      }
+    } else {
+      this.accountPrivacyPolicy.visibility = View.GONE
+    }
+
+    val licenses = this.viewModel.licenses
+    if (licenses != null) {
+      this.accountLicenses.visibility = View.VISIBLE
+      this.accountLicenses.setOnClickListener {
+        this.listener.post(
+          AccountDetailEvent.OpenDocViewer(
+            getString(R.string.accountLicenses),
+            licenses.readableURL
+          )
+        )
+      }
+    } else {
+      this.accountLicenses.visibility = View.GONE
     }
 
     this.hideCardCreatorForNonNYPL()
@@ -298,8 +336,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
   }
 
   private fun determineEULAIsSatisfied(): Boolean {
-    val eula = this.viewModel.eula
-    return eula?.hasAgreed ?: true
+    return true
   }
 
   private fun shouldSignUpBeEnabled(): Boolean {
@@ -869,7 +906,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     )
 
     this.authenticationViews.lock()
-    this.eulaCheckbox.isEnabled = false
 
     this.setLoginButtonStatus(AsLoginButtonDisabled)
     this.authenticationAlternativesHide()
@@ -882,7 +918,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     )
 
     this.authenticationViews.unlock()
-    this.eulaCheckbox.isEnabled = true
 
     val loginSatisfied = this.determineLoginIsSatisfied()
     this.setLoginButtonStatus(loginSatisfied)

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailViewModel.kt
@@ -6,7 +6,9 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import org.joda.time.DateTime
 import org.librarysimplified.documents.DocumentStoreType
+import org.librarysimplified.documents.DocumentType
 import org.librarysimplified.documents.EULAType
+import org.librarysimplified.documents.internal.SimpleDocument
 import org.librarysimplified.services.api.Services
 import org.nypl.simplified.accounts.api.AccountEvent
 import org.nypl.simplified.accounts.api.AccountID
@@ -69,13 +71,19 @@ class AccountDetailViewModel(
   val buildConfig =
     services.requireService(BuildConfigurationServiceType::class.java)
 
-  val eula: EULAType? =
-    this.documents.eula
-
   val account =
     this.profilesController
       .profileCurrent()
       .account(this.accountId)
+
+  val eula: SimpleDocument? =
+    this.account.provider.eula?.let { SimpleDocument(it.toURL()) }
+
+  val privacyPolicy: DocumentType? =
+    this.account.provider.privacyPolicy?.let { SimpleDocument(it.toURL()) }
+
+  val licenses: DocumentType? =
+    this.account.provider.license?.let { SimpleDocument(it.toURL()) }
 
   /**
    * Logging in was explicitly requested. This is tracked in order to allow for optionally

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -55,20 +55,25 @@
       android:layout_width="match_parent"
       android:layout_height="16dp" />
 
-    <CheckBox
-      android:id="@+id/accountEULACheckbox"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginStart="16dp"
-      android:layout_marginEnd="16dp"
-      android:gravity="center"
-      android:text="@string/accountEULAStatement" />
-
-    <Space
-      android:layout_width="match_parent"
-      android:layout_height="16dp" />
-
     <include layout="@layout/auth" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?android:attr/listDivider" />
+
+    <TextView
+        android:id="@+id/accountEULA"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:gravity="center"
+        android:linksClickable="true"
+        android:autoLink="all"
+        android:textColorLink="@color/simplified_material_blue_primary"
+        android:textColor="@color/simplified_material_blue_primary"
+        android:background="?attr/selectableItemBackground"
+        android:text="@string/accountEULAStatement" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:id="@+id/accountLoginProgress"
@@ -288,6 +293,53 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+      <FrameLayout
+          android:id="@+id/accountPrivacyPolicy"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:background="?attr/selectableItemBackground"
+          android:visibility="visible">
+
+          <View
+              android:layout_width="match_parent"
+              android:layout_height="1dp"
+              android:background="?android:attr/listDivider"
+              android:layout_gravity="top" />
+
+          <TextView
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:padding="16dp"
+              android:text="@string/accountPrivacyPolicy"
+              app:layout_constraintEnd_toEndOf="parent"
+              app:layout_constraintStart_toStartOf="parent"
+              app:layout_constraintTop_toTopOf="parent" />
+
+      </FrameLayout>
+
+      <FrameLayout
+      android:id="@+id/accountLicenses"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="?attr/selectableItemBackground"
+      android:visibility="visible">
+
+          <View
+              android:layout_width="match_parent"
+              android:layout_height="1dp"
+              android:background="?android:attr/listDivider"
+              android:layout_gravity="top" />
+
+          <TextView
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:padding="16dp"
+              android:text="@string/accountLicenses"
+              app:layout_constraintEnd_toEndOf="parent"
+              app:layout_constraintStart_toStartOf="parent"
+              app:layout_constraintTop_toTopOf="parent" />
+      </FrameLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:id="@+id/accountCustomOPDS"

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
   <string name="accountCreationFailed">Account creation failed</string>
   <string name="accountCreationFailedMessage">The account could not be created.</string>
   <string name="accountDelete">Delete</string>
-  <string name="accountEULAStatement">I agree to the terms of the End User License Agreement.</string>
+  <string name="accountEULAStatement">By signing in, you agree to the End User License Agreement.</string>
   <string name="accountLogin">Log in</string>
   <string name="accountWantChildCard">Want a card for your child?</string>
   <string name="accountCreateCard">Create Card</string>
@@ -46,4 +46,7 @@
   <string name="accountSearchHint">Search accounts&#8230;</string>
   <string name="accountMore">More options</string>
   <string name="accountReportFailed">Sorry, we weren\'t able to find a usable email app. Please send email to %1$s if you need to report an issue.</string>
+  <string name="accountPrivacyPolicy">Privacy Policy</string>
+  <string name="accountLicenses">Content Licenses</string>
+  <string name="accountEULA">End User License Agreement</string>
 </resources>


### PR DESCRIPTION
**What's this do?**
Allow users to view library documents from account screen 

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/Allow-users-to-view-library-documents-from-account-screen-779d77a7d24d4794a42b833101cb308e

**How should this be tested? / Do these changes have associated tests?**
Try to add a new library (New York Public library) and check if you can open EULA, Privacy Policy and Content Licenses docs

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@talesgurjao ran the Palace app.