### PR TITLE
Display current library in the action bar

### DIFF
--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
   <string name="accountLogout">Log out</string>
   <string name="accountPassword">Password</string>
   <string name="accountPasswordShow">Show %1$s</string>
-  <string name="accountPickerTitle">Switch catalog</string>
+  <string name="accountPickerTitle">Switch library</string>
   <string name="accountPlaceholder">Lorem ipsum dolor sit amet, probatus volutpat has at, vis adhuc iuvaret omittantur an, sadipscing conclusionemque his ad. Eam ut simul tempor. Primis consetetur appellantur vim eu, eum an iudico dolorum. Ad vis utamur honestatis, sanctus debitis referrentur an eam.</string>
   <string name="accountRegistryCreating">Creating an account…</string>
   <string name="accountRegistryEmpty">No accounts are available.</string>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedArguments.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedArguments.kt
@@ -57,7 +57,7 @@ sealed class CatalogFeedArguments : Serializable {
 
   data class CatalogFeedArgumentsLocalBooks(
     override val title: String,
-    override val ownership: CatalogFeedOwnership.CollectedFromAccounts,
+    override val ownership: CatalogFeedOwnership,
     val sortBy: SortBy = SortBy.SORT_BY_TITLE,
     val searchTerms: String?,
     val selection: FeedBooksSelection,

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -255,7 +255,7 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
         true
       }
       android.R.id.home -> {
-        if (this.viewModel.isAccountCatalogRoot()) {
+        if (this.viewModel.isAccountCatalogRoot() || this.viewModel.showCurrentLibrary()) {
           this.openAccountPickerDialog()
           true
         } else {
@@ -467,7 +467,7 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
     }
 
     try {
-      if (this.viewModel.isAccountCatalogRoot()) {
+      if (this.viewModel.isAccountCatalogRoot() || this.viewModel.showCurrentLibrary()) {
         showAccountPickerAction()
       }
     } catch (e: Exception) {

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -613,6 +613,12 @@ class CatalogFeedViewModel(
     return account.feedIsRoot(parameters.feedURI)
   }
 
+  fun showCurrentLibrary(): Boolean {
+    val ownedByAccount = this.feedArguments.ownership is CatalogFeedOwnership.OwnedByAccount
+    val showAll = buildConfiguration.showBooksFromAllAccounts
+    return !showAll && ownedByAccount
+  }
+
   /**
    * Set synthesized birthdate based on if user is over 13
    */

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/BottomNavigators.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/BottomNavigators.kt
@@ -200,10 +200,14 @@ object BottomNavigators {
         pickDefaultAccount(profilesController, defaultProvider).id
       }
 
+    val ownership =
+      if (filterAccountId == null) CatalogFeedOwnership.CollectedFromAccounts
+      else CatalogFeedOwnership.OwnedByAccount(filterAccountId)
+
     return CatalogFeedFragment.create(
       CatalogFeedArguments.CatalogFeedArgumentsLocalBooks(
         filterAccount = filterAccountId,
-        ownership = CatalogFeedOwnership.CollectedFromAccounts,
+        ownership = ownership,
         searchTerms = null,
         selection = FeedBooksSelection.BOOKS_FEED_HOLDS,
         sortBy = FeedFacet.FeedFacetPseudo.Sorting.SortBy.SORT_BY_TITLE,
@@ -232,10 +236,14 @@ object BottomNavigators {
         pickDefaultAccount(profilesController, defaultProvider).id
       }
 
+    val ownership =
+      if (filterAccountId == null) CatalogFeedOwnership.CollectedFromAccounts
+      else CatalogFeedOwnership.OwnedByAccount(filterAccountId)
+
     return CatalogFeedFragment.create(
       CatalogFeedArguments.CatalogFeedArgumentsLocalBooks(
         filterAccount = filterAccountId,
-        ownership = CatalogFeedOwnership.CollectedFromAccounts,
+        ownership = ownership,
         searchTerms = null,
         selection = FeedBooksSelection.BOOKS_FEED_LOANED,
         sortBy = FeedFacet.FeedFacetPseudo.Sorting.SortBy.SORT_BY_TITLE,


### PR DESCRIPTION
**What's this do?**
Enables the library name/switch action in the action bar

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/Show-current-library-on-Books-and-Holds-31ab7396246d44df9e2af3a9adf8b560

**How should this be tested? / Do these changes have associated tests?**
Open the books/hold tabs and observe the library name and action icon (need to set showBooksFromAllAccounts to false)

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@talesgurjao ran the Palace app.