### PR TITLE
Fix SAML download endless loop.

### DIFF
--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/BorrowContextType.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/BorrowContextType.kt
@@ -217,4 +217,10 @@ interface BorrowContextType {
    */
 
   fun bookLoanFailed()
+
+  /**
+   * Information about the current SAML download, if one is in progress.
+   */
+
+  val samlDownloadContext: SAMLDownloadContext?
 }

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/BorrowRequest.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/BorrowRequest.kt
@@ -29,12 +29,19 @@ sealed class BorrowRequest {
   abstract val profileId: ProfileID
 
   /**
+   * Information about the current SAML download, if one is in progress.
+   */
+
+  abstract val samlDownloadContext: SAMLDownloadContext?
+
+  /**
    * Start borrowing a book.
    */
 
   data class Start(
     override val accountId: AccountID,
     override val profileId: ProfileID,
-    override val opdsAcquisitionFeedEntry: OPDSAcquisitionFeedEntry
+    override val opdsAcquisitionFeedEntry: OPDSAcquisitionFeedEntry,
+    override val samlDownloadContext: SAMLDownloadContext? = null
   ) : BorrowRequest()
 }

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/BorrowTask.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/BorrowTask.kt
@@ -162,7 +162,7 @@ class BorrowTask private constructor(
     this.account = this.findAccount(profile, bookInitial)
     val book = this.createBookDatabaseEntry(bookInitial, start.opdsAcquisitionFeedEntry)
     val path = this.pickAcquisitionPath(book, start.opdsAcquisitionFeedEntry)
-    this.executeSubtasksForPath(book, path)
+    this.executeSubtasksForPath(book, path, start.samlDownloadContext)
     return this.taskRecorder.finishSuccess(Unit)
   }
 
@@ -172,7 +172,8 @@ class BorrowTask private constructor(
 
   private fun executeSubtasksForPath(
     book: Book,
-    path: OPDSAcquisitionPath
+    path: OPDSAcquisitionPath,
+    samlDownloadContext: SAMLDownloadContext?
   ) {
     val context =
       BorrowContext(
@@ -193,6 +194,7 @@ class BorrowTask private constructor(
         httpClient = this.requirements.httpClient,
         logger = this.logger,
         opdsAcquisitionPath = path,
+        samlDownloadContext = samlDownloadContext,
         services = this.requirements.services,
         taskRecorder = this.taskRecorder,
         temporaryDirectory = this.requirements.temporaryDirectory
@@ -395,6 +397,7 @@ class BorrowTask private constructor(
     override val httpClient: LSHTTPClientType,
     override val taskRecorder: TaskRecorderType,
     override val opdsAcquisitionPath: OPDSAcquisitionPath,
+    override val samlDownloadContext: SAMLDownloadContext? = null,
     bookInitial: Book,
     private val bookRegistry: BookRegistryType,
     private val logger: Logger,

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/SAMLDownloadContext.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/SAMLDownloadContext.kt
@@ -1,0 +1,27 @@
+package org.nypl.simplified.books.borrowing
+
+import java.net.URI
+
+data class SAMLDownloadContext(
+
+  /**
+   * Indicates if the required SAML authentication for the download is complete.
+   */
+
+  val isSAMLAuthComplete: Boolean = false,
+
+  /**
+   * The original URI used to download the book, which may be interrupted by a login/approval form
+   * from the IdP. Typically, this is the fulfillment URL from the feed.
+   */
+
+  val downloadURI: URI,
+
+  /**
+   * The URI from which to download the book when authentication is complete. Typically, this
+   * is the URL to which the browser is redirected, after a submitting a login form presented by
+   * the IdP when attempting to retrieve the original download URI.
+   */
+
+  val authCompleteDownloadURI: URI
+)

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowSubtaskDirectory.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowSubtaskDirectory.kt
@@ -14,9 +14,10 @@ class BorrowSubtaskDirectory : BorrowSubtaskDirectoryType {
       BorrowAxisNow,
       BorrowBearerToken,
       BorrowCopy,
+      // BorrowSAMLDownload must precede BorrowDirectDownload in precedence.
+      BorrowSAMLDownload,
       BorrowDirectDownload,
       BorrowLCP,
-      BorrowLoanCreate,
-      BorrowSAMLDownload
+      BorrowLoanCreate
     )
 }

--- a/simplified-books-controller-api/build.gradle
+++ b/simplified-books-controller-api/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   api project(":simplified-books-api")
   api project(":simplified-feeds-api")
 
+  implementation project(":simplified-books-borrowing")
   implementation libraries.kotlin_stdlib
   implementation libraries.kotlin_reflect
 

--- a/simplified-books-controller-api/src/main/java/org/nypl/simplified/books/controller/api/BooksControllerType.kt
+++ b/simplified-books-controller-api/src/main/java/org/nypl/simplified/books/controller/api/BooksControllerType.kt
@@ -3,6 +3,7 @@ package org.nypl.simplified.books.controller.api
 import com.google.common.util.concurrent.FluentFuture
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.books.api.BookID
+import org.nypl.simplified.books.borrowing.SAMLDownloadContext
 import org.nypl.simplified.feeds.api.FeedEntry
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import org.nypl.simplified.taskrecorder.api.TaskResult
@@ -22,7 +23,8 @@ interface BooksControllerType {
 
   fun bookBorrow(
     accountID: AccountID,
-    entry: OPDSAcquisitionFeedEntry
+    entry: OPDSAcquisitionFeedEntry,
+    samlDownloadContext: SAMLDownloadContext? = null
   ): FluentFuture<TaskResult<*>>
 
   /**

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
@@ -33,6 +33,7 @@ import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.borrowing.BorrowRequest
 import org.nypl.simplified.books.borrowing.BorrowRequirements
 import org.nypl.simplified.books.borrowing.BorrowTask
+import org.nypl.simplified.books.borrowing.SAMLDownloadContext
 import org.nypl.simplified.books.controller.api.BookRevokeStringResourcesType
 import org.nypl.simplified.books.controller.api.BooksControllerType
 import org.nypl.simplified.crashlytics.api.CrashlyticsServiceType
@@ -547,7 +548,8 @@ class Controller private constructor(
 
   override fun bookBorrow(
     accountID: AccountID,
-    entry: OPDSAcquisitionFeedEntry
+    entry: OPDSAcquisitionFeedEntry,
+    samlDownloadContext: SAMLDownloadContext?
   ): FluentFuture<TaskResult<*>> {
     return this.submitTask(
       Callable<TaskResult<*>> {
@@ -555,7 +557,8 @@ class Controller private constructor(
           BorrowRequest.Start(
             accountId = accountID,
             profileId = this.profileCurrent().id,
-            opdsAcquisitionFeedEntry = entry
+            opdsAcquisitionFeedEntry = entry,
+            samlDownloadContext = samlDownloadContext
           )
         BorrowTask.createBorrowTask(this.borrowRequirements, request)
           .execute()

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBorrowContext.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBorrowContext.kt
@@ -14,6 +14,7 @@ import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.borrowing.BorrowContextType
 import org.nypl.simplified.books.borrowing.BorrowTimeoutConfiguration
+import org.nypl.simplified.books.borrowing.SAMLDownloadContext
 import org.nypl.simplified.books.bundled.api.BundledContentResolverType
 import org.nypl.simplified.content.api.ContentResolverType
 import org.nypl.simplified.opds.core.OPDSAcquisitionPath
@@ -40,7 +41,8 @@ class MockBorrowContext(
   override var taskRecorder: TaskRecorderType,
   override var isCancelled: Boolean,
   override var bookDatabaseEntry: BookDatabaseEntryType,
-  bookInitial: Book
+  override var samlDownloadContext: SAMLDownloadContext? = null,
+  bookInitial: Book,
 ) : BorrowContextType {
 
   var cacheDirectory = TestDirectories.temporaryDirectory()

--- a/simplified-ui-catalog/build.gradle
+++ b/simplified-ui-catalog/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation project(":simplified-adobe-extensions")
   implementation project(":simplified-analytics-api")
   implementation project(":simplified-android-ktx")
+  implementation project(":simplified-books-borrowing")
   implementation project(":simplified-books-controller-api")
   implementation project(":simplified-books-registry-api")
   implementation project(":simplified-buildconfig-api")

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/saml20/CatalogSAML20Fragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/saml20/CatalogSAML20Fragment.kt
@@ -66,7 +66,7 @@ class CatalogSAML20Fragment : Fragment(R.layout.book_saml20) {
     this.webView.webChromeClient = CatalogSAML20ChromeClient(this.progress)
     this.webView.webViewClient = this.viewModel.webViewClient
     this.webView.settings.javaScriptEnabled = true
-    this.webView.setDownloadListener { _, _, _, mime, _ -> this.viewModel.downloadStarted(mime) }
+    this.webView.setDownloadListener { url, _, _, mime, _ -> this.viewModel.downloadStarted(url, mime) }
 
     this.viewModel.webviewRequest.observe(this.viewLifecycleOwner) {
       this.webView.loadUrl(it.url, it.headers)


### PR DESCRIPTION
**What's this do?**

This adds a SAML download context object to the borrowing context, to track information about the current SAML download. This is used by the SAML download subtask. When that subtask runs, it may find HTML content, which means that it should exit so that a login can happen in a webview. Once login is complete, the download subtask will run again, this time with a SAML download context that indicates that authentication is complete, and contains a different URL to use to retrieve the download. The download can then proceed with the new URL instead of the original.

**Why are we doing this? (w/ JIRA link if applicable)**

Fixes an endless loop that can occur when doing SAML downloads: https://www.notion.so/lyrasis/Borrowing-from-SAML-testbed-causes-endless-loop-56303fd7b2044498981b16d6cad5947a

**How should this be tested? / Do these changes have associated tests?**

Download a book from the "SAML" library. A form from the IdP should be displayed, to approve federating the authentication. When submitted, the download should succeed (instead of looping endlessly).

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the Palace app.