### PR TITLE
Persist custom library registry to shared preferences

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -37,6 +37,7 @@ import org.nypl.simplified.accounts.database.AccountBundledCredentialsEmpty
 import org.nypl.simplified.accounts.database.AccountsDatabases
 import org.nypl.simplified.accounts.json.AccountBundledCredentialsJSON
 import org.nypl.simplified.accounts.registry.AccountProviderRegistry
+import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryDebugging
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.accounts.source.spi.AccountProviderSourceResolutionStrings
 import org.nypl.simplified.adobe.extensions.AdobeConfigurationServiceType
@@ -644,6 +645,8 @@ internal object MainServices {
       message = strings.bootingGeneral("Crashlytics"),
       interfaceType = CrashlyticsServiceType::class.java
     )
+
+    AccountProviderRegistryDebugging.load(context.applicationContext)
 
     val lsHTTP =
       addService(


### PR DESCRIPTION
**What's this do?**
This change makes the account registry debugging properties persistent
by using shared preferences. Typically we would _not_ use shared
preferences in the app, because they aren't profile-aware. In this
case, though, the debugging properties are truly app-global anyway.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://www.notion.so/lyrasis/Android-build-that-can-persistently-uses-QA-library-registry-9874931996be425e8bbc378bcbbf3a1e

**How should this be tested? / Do these changes have associated tests?**
Check that the registry setting persists after an app restart.
Check that clearing the registry value results in a blank value after an app restart.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tested setting and unsetting, and restarting the app several times.