### PR TITLE
Hide the default library from users.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <c:changelog project="org.thepalaceproject.palace" xmlns:c="urn:com.io7m.changelog:4.0">
   <c:releases>
-    <c:release date="2021-07-15T21:00:39+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.0">
+    <c:release date="2021-07-19T18:00:47+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.0">
       <c:changes>
         <c:change date="2021-04-16T00:00:00+00:00" summary="Remove default library option on startup"/>
         <c:change date="2021-04-29T00:00:00+00:00" summary="Add app documentation viewers"/>
@@ -30,7 +30,8 @@
         </c:change>
         <c:change date="2021-07-13T00:00:00+00:00" summary="Fix audiobook player not retaining position after exiting app"/>
         <c:change date="2021-07-15T00:00:00+00:00" summary="Configure legal document locations"/>
-        <c:change date="2021-07-15T21:00:39+00:00" summary="Add privacy policy to settings"/>
+        <c:change date="2021-07-15T00:00:00+00:00" summary="Add privacy policy to settings"/>
+        <c:change date="2021-07-19T18:00:47+00:00" summary="Hide default library"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceAccountFallback.kt
+++ b/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceAccountFallback.kt
@@ -23,7 +23,9 @@ class PalaceAccountFallback : AccountProviderFallbackType {
       catalogURI = URI.create("https://openbookshelf.dp.la/OB/groups/3"),
       displayName = "Digital Public Library of America",
       eula = null,
-      id = URI.create("urn:uuid:6b849570-070f-43b4-9dcc-7ebb4bca292e"),
+      // This id is intentionally different than the id for the "real" DPLA library retrieved from
+      // the registry, so that it doesn't prevent that library from being added.
+      id = URI.create("urn:uuid:e0c621fa-424c-49e6-a6bb-0601def66cf8"),
       idNumeric = -1,
       isProduction = true,
       license = null,

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/Profile.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/Profile.kt
@@ -111,6 +111,10 @@ internal class Profile internal constructor(
   override fun createAccount(accountProvider: AccountProviderType): AccountType {
     this.checkNotDeleted()
     return this.accounts.createAccount(accountProvider).also {
+      // When an account is added, automatically delete the default account (if present). This
+      // allows Palace to hide the default account from end users. This will not be necessary if
+      // the requirement for a profile to have an account, and the automatic adding of the default,
+      // is ever removed.
       this.deleteDefaultAccount()
     }
   }

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/Profile.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/Profile.kt
@@ -110,7 +110,17 @@ internal class Profile internal constructor(
   @Throws(AccountsDatabaseException::class)
   override fun createAccount(accountProvider: AccountProviderType): AccountType {
     this.checkNotDeleted()
-    return this.accounts.createAccount(accountProvider)
+    return this.accounts.createAccount(accountProvider).also {
+      this.deleteDefaultAccount()
+    }
+  }
+
+  private fun deleteDefaultAccount(): AccountID? {
+    return try {
+      this.deleteAccountByProvider(this.owner!!.defaultAccountProvider.id)
+    } catch (e: AccountsDatabaseNonexistentException) {
+      null
+    }
   }
 
   @Throws(AccountsDatabaseException::class)

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryViewModel.kt
@@ -156,6 +156,7 @@ class AccountListRegistryViewModel(private val locationManager: LocationManager)
     val availableAccountProviders =
       this.accountRegistry.accountProviderDescriptions()
         .values
+        // Palace hides the default account from end users.
         .filter { it.id != accountRegistry.defaultProvider.id }
         .toMutableList()
     availableAccountProviders.removeAll(usedAccountProviders)

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryViewModel.kt
@@ -156,6 +156,7 @@ class AccountListRegistryViewModel(private val locationManager: LocationManager)
     val availableAccountProviders =
       this.accountRegistry.accountProviderDescriptions()
         .values
+        .filter { it.id != accountRegistry.defaultProvider.id }
         .toMutableList()
     availableAccountProviders.removeAll(usedAccountProviders)
 


### PR DESCRIPTION
**What's this do?**

This hides the default library from being seen by users.

1. Configure the default library to be a “fake” library (one whose uuid isn’t the same as any library in the registry). This makes every library in the registry able to be selected.
1. When a library is added, automatically delete the default library from the profile. Since the user must select a library when the app starts (and before they can do anything else), this means they never see the default library.
1. Filter the default library out of the library selection list, so it can’t be added by the user in the future.

**Why are we doing this? (w/ JIRA link if applicable)**

Fixes: https://www.notion.so/lyrasis/DPLA-library-doesn-t-appear-in-library-selection-list-31741e673f594e74b7fc54da0dc78e00

Also, users not understanding, or unintentionally being in, the default library has been causing support headaches.

**How should this be tested? / Do these changes have associated tests?**

On a fresh install of the app, tap the "Find Your Library" button. The "Digital Public Library of America" library should be selectable. After adding a library, there should only be one library in the list. Adding more libraries, and removing them, should continue to work normally.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the Palace app.