### PR TITLE
Do not fail if position parsing fails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,7 @@ subprojects { project ->
   repositories {
     mavenLocal()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+    maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
     mavenCentral()
     google()
 

--- a/build_libraries.gradle
+++ b/build_libraries.gradle
@@ -48,7 +48,7 @@ ext.versions = [
   mockito_core                  : '3.4.4',
   mockito_kotlin                : '2.2.0',
   moshi                         : '1.8.0',
-  nypl_audiobook_api            : '6.6.0',
+  nypl_audiobook_api            : '6.7.0-SNAPSHOT',
   nypl_drm_adobe                : '1.2.4',
   nypl_drm_axis                 : '1.0.0-SNAPSHOT',
   nypl_drm_core                 : '1.2.2',

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
@@ -239,6 +239,9 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
 
   companion object {
 
+    private val logger =
+      LoggerFactory.getLogger(DatabaseFormatHandleAudioBook::class.java)
+
     private fun loadInitial(
       objectMapper: ObjectMapper,
       fileManifest: File,
@@ -285,7 +288,8 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
       } catch (e: FileNotFoundException) {
         null
       } catch (e: Exception) {
-        throw IOException(e)
+        this.logger.debug("failed to parse position value: ", e)
+        null
       }
     }
 


### PR DESCRIPTION
**What's this do?**
This upgrades to a version of the audio books API that will not fail
to parse positions that contain explicitly `null` titles. It also logs
an error and returns nothing instead of loudly raising an exception
if the saved position turns out to be malformed.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://www.notion.so/lyrasis/Error-opening-app-after-exiting-from-audiobook-player-5694f5b2d40c4baea0d97782a3141cef

**How should this be tested? / Do these changes have associated tests?**
Try the behaviour in the ticket, and make sure the app no longer goes insane.

**Dependencies for merging? Releasing to production?**
We shouldn't release a version of the app pointing at a snapshot version of the audiobook API. A new release should be tagged there if all goes well.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m's app refused to break