### PR TITLE
Improve webview cookie handling in saml auth

### DIFF
--- a/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabase.kt
+++ b/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabase.kt
@@ -40,6 +40,8 @@ abstract class WebViewCookieDatabase(
       logger.debug("found cookie database version {}", version)
 
       return when (version) {
+        "14" -> WebViewCookieDatabaseV14(db)
+        "13" -> WebViewCookieDatabaseV13(db)
         "12" -> WebViewCookieDatabaseV12(db)
         "11" -> WebViewCookieDatabaseV11(db)
         "10" -> WebViewCookieDatabaseV10(db)

--- a/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseV10.kt
+++ b/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseV10.kt
@@ -69,7 +69,11 @@ class WebViewCookieDatabaseV10 internal constructor(
       val pairs = mutableListOf<List<String>>()
 
       pairs.add(listOf(this.name, this.value))
-      pairs.add(listOf("Domain", this.hostKey))
+
+      if (this.hostKey.startsWith(".")) {
+        pairs.add(listOf("Domain", this.hostKey))
+      }
+
       pairs.add(listOf("Path", this.path))
 
       if (this.expiresUTC > 0) {

--- a/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseV12.kt
+++ b/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseV12.kt
@@ -78,7 +78,11 @@ class WebViewCookieDatabaseV12 internal constructor(
       val pairs = mutableListOf<List<String>>()
 
       pairs.add(listOf(this.name, this.value))
-      pairs.add(listOf("Domain", this.hostKey))
+
+      if (this.hostKey.startsWith(".")) {
+        pairs.add(listOf("Domain", this.hostKey))
+      }
+
       pairs.add(listOf("Path", this.path))
 
       if (this.expiresUTC > 0) {

--- a/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseV13.kt
+++ b/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseV13.kt
@@ -2,7 +2,7 @@ package org.nypl.simplified.webview
 
 import android.database.sqlite.SQLiteDatabase
 
-class WebViewCookieDatabaseV11 internal constructor(
+class WebViewCookieDatabaseV13 internal constructor(
   private val db: SQLiteDatabase
 ) : WebViewCookieDatabase(db) {
   override fun getAll(): List<WebViewCookieType> {
@@ -16,7 +16,8 @@ class WebViewCookieDatabaseV11 internal constructor(
       "expires_utc",
       "is_secure",
       "is_httponly",
-      "samesite"
+      "samesite",
+      "source_scheme"
     )
 
     this.db.query(
@@ -38,7 +39,8 @@ class WebViewCookieDatabaseV11 internal constructor(
             expiresUTC = cursor.getLong(4),
             isSecure = cursor.getInt(5),
             isHttpOnly = cursor.getInt(6),
-            sameSite = cursor.getInt(7)
+            sameSite = cursor.getInt(7),
+            sourceScheme = cursor.getInt(8),
           )
         )
       }
@@ -55,14 +57,21 @@ class WebViewCookieDatabaseV11 internal constructor(
     val expiresUTC: Long,
     val isSecure: Int,
     val isHttpOnly: Int,
-    val sameSite: Int
+    val sameSite: Int,
+    val sourceScheme: Int,
   ) : WebViewCookieType {
 
     override val sourceURL: String
       get() {
         val domain = this.hostKey.trimStart('.')
 
-        return (if (this.isSecure > 0) "https" else "http") + "://$domain"
+        val scheme = when (this.sourceScheme) {
+          1 -> "http"
+          2 -> "https"
+          else -> "http"
+        }
+
+        return "$scheme://$domain"
       }
 
     override fun toSetCookieString(): String {

--- a/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseV14.kt
+++ b/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseV14.kt
@@ -2,7 +2,7 @@ package org.nypl.simplified.webview
 
 import android.database.sqlite.SQLiteDatabase
 
-class WebViewCookieDatabaseV11 internal constructor(
+class WebViewCookieDatabaseV14 internal constructor(
   private val db: SQLiteDatabase
 ) : WebViewCookieDatabase(db) {
   override fun getAll(): List<WebViewCookieType> {
@@ -16,7 +16,8 @@ class WebViewCookieDatabaseV11 internal constructor(
       "expires_utc",
       "is_secure",
       "is_httponly",
-      "samesite"
+      "samesite",
+      "source_scheme"
     )
 
     this.db.query(
@@ -38,7 +39,8 @@ class WebViewCookieDatabaseV11 internal constructor(
             expiresUTC = cursor.getLong(4),
             isSecure = cursor.getInt(5),
             isHttpOnly = cursor.getInt(6),
-            sameSite = cursor.getInt(7)
+            sameSite = cursor.getInt(7),
+            sourceScheme = cursor.getInt(8),
           )
         )
       }
@@ -55,14 +57,21 @@ class WebViewCookieDatabaseV11 internal constructor(
     val expiresUTC: Long,
     val isSecure: Int,
     val isHttpOnly: Int,
-    val sameSite: Int
+    val sameSite: Int,
+    val sourceScheme: Int,
   ) : WebViewCookieType {
 
     override val sourceURL: String
       get() {
         val domain = this.hostKey.trimStart('.')
 
-        return (if (this.isSecure > 0) "https" else "http") + "://$domain"
+        val scheme = when (this.sourceScheme) {
+          1 -> "http"
+          2 -> "https"
+          else -> "http"
+        }
+
+        return "$scheme://$domain"
       }
 
     override fun toSetCookieString(): String {

--- a/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseV9.kt
+++ b/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseV9.kt
@@ -69,7 +69,11 @@ class WebViewCookieDatabaseV9 internal constructor(
       val pairs = mutableListOf<List<String>>()
 
       pairs.add(listOf(this.name, this.value))
-      pairs.add(listOf("Domain", this.hostKey))
+
+      if (this.hostKey.startsWith(".")) {
+        pairs.add(listOf("Domain", this.hostKey))
+      }
+
       pairs.add(listOf("Path", this.path))
 
       if (this.expiresUTC > 0) {

--- a/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseVUnknown.kt
+++ b/simplified-webview/src/main/java/org/nypl/simplified/webview/WebViewCookieDatabaseVUnknown.kt
@@ -63,7 +63,11 @@ class WebViewCookieDatabaseVUnknown internal constructor(
       val pairs = mutableListOf<List<String>>()
 
       pairs.add(listOf(this.name, this.value))
-      pairs.add(listOf("Domain", this.hostKey))
+
+      if (this.hostKey.startsWith(".")) {
+        pairs.add(listOf("Domain", this.hostKey))
+      }
+
       pairs.add(listOf("Path", this.path))
 
       return pairs.map({ pair ->


### PR DESCRIPTION
**What's this do?**

Fixes a couple small issues with reading cookies out of the WebView cookie database.
- Modify cookie readers to only set the `domain` attribute when the `hostKey` starts with `.`.
- Add cookie readers for database versions 13 and 14.

**Why are we doing this? (w/ JIRA link if applicable)**

Fixes: https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=90916a8dfd7b4981bcb327f9362d7ea0&p=169e08657c8c4b21886a6a4fe0258883

This is not currently causing a problem, but I'm fixing now just in case.

**How should this be tested? / Do these changes have associated tests?**

SAML auth and borrowing should continue to work.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested authenticating and borrowing some books against the SAML, Columbia Demo, and NYU libraries.