### PR TITLE
Gracefully handle expired certificates

### DIFF
--- a/simplified-boot-api/src/main/java/org/nypl/simplified/boot/api/BootEvent.kt
+++ b/simplified-boot-api/src/main/java/org/nypl/simplified/boot/api/BootEvent.kt
@@ -19,15 +19,6 @@ sealed class BootEvent {
   ) : BootEvent(), PresentableType
 
   /**
-   * Booting is in progress, and something in the boot process wants to publish a dialog box.
-   */
-
-  data class BootWantsDialog(
-    override val message: String,
-    override val attributes: Map<String, String> = mapOf()
-  ) : BootEvent(), PresentableType
-
-  /**
    * Booting has completed.
    */
 

--- a/simplified-boot-api/src/main/java/org/nypl/simplified/boot/api/BootEvent.kt
+++ b/simplified-boot-api/src/main/java/org/nypl/simplified/boot/api/BootEvent.kt
@@ -19,6 +19,15 @@ sealed class BootEvent {
   ) : BootEvent(), PresentableType
 
   /**
+   * Booting is in progress, and something in the boot process wants to publish a dialog box.
+   */
+
+  data class BootWantsDialog(
+    override val message: String,
+    override val attributes: Map<String, String> = mapOf()
+  ) : BootEvent(), PresentableType
+
+  /**
    * Booting has completed.
    */
 

--- a/simplified-boot-api/src/main/java/org/nypl/simplified/boot/api/BootLoader.kt
+++ b/simplified-boot-api/src/main/java/org/nypl/simplified/boot/api/BootLoader.kt
@@ -43,7 +43,10 @@ class BootLoader<T>(
       }
     )
 
-  private val eventsActual = BehaviorSubject.create<BootEvent>()
+  private val eventsActual =
+    BehaviorSubject.create<BootEvent>()
+      .toSerialized()
+
   private val bootLock: Any = Any()
   private var boot: FluentFuture<T>? = null
 

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainAdobeWarnings.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainAdobeWarnings.kt
@@ -1,0 +1,40 @@
+package org.nypl.simplified.main
+
+import android.content.Context
+import androidx.annotation.UiThread
+import androidx.appcompat.app.AlertDialog
+import org.librarysimplified.services.api.ServiceDirectoryType
+import org.nypl.drm.core.AdobeAdeptExecutorType
+import org.nypl.simplified.adobe.extensions.AdobeDRMServices
+
+/**
+ * Functions to display Adobe DRM related warnings.
+ */
+
+object MainAdobeWarnings {
+
+  @Volatile
+  private var hasDisplayed: Boolean = false
+
+  @UiThread
+  fun showWarningDialogIfNecessary(
+    context: Context,
+    services: ServiceDirectoryType
+  ) {
+    try {
+      if (!this.hasDisplayed) {
+        val drmService = services.optionalService(AdobeAdeptExecutorType::class.java)
+        if (drmService == null) {
+          if (AdobeDRMServices.isIntendedToBePresent(context)) {
+            AlertDialog.Builder(context)
+              .setMessage(R.string.bootAdobeDRMFailed)
+              .create()
+              .show()
+          }
+        }
+      }
+    } finally {
+      this.hasDisplayed = true
+    }
+  }
+}

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import io.reactivex.disposables.CompositeDisposable
+import org.librarysimplified.services.api.Services
 import org.nypl.simplified.accounts.api.AccountEvent
 import org.nypl.simplified.accounts.api.AccountEventDeletion
 import org.nypl.simplified.accounts.api.AccountEventUpdated
@@ -164,6 +165,15 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
      */
 
     this.supportActionBar?.show()
+
+    /*
+     * Show the Adobe DRM warning dialog if necessary,
+     */
+
+    MainAdobeWarnings.showWarningDialogIfNecessary(
+      this.requireActivity(),
+      Services.serviceDirectory()
+    )
   }
 
   private fun onAccountEvent(event: AccountEvent) {

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -666,9 +666,7 @@ internal object MainServices {
         serviceConstructor = {
           this.createAdobeExecutor(
             context = context,
-            adobeConfiguration = adobeConfiguration,
-            strings = strings,
-            onProgress = onProgress
+            adobeConfiguration = adobeConfiguration
           )
         }
       )
@@ -1062,16 +1060,10 @@ internal object MainServices {
 
   private fun createAdobeExecutor(
     context: Context,
-    adobeConfiguration: AdobeConfigurationServiceType,
-    strings: MainServicesStrings,
-    onProgress: (BootEvent) -> Unit
+    adobeConfiguration: AdobeConfigurationServiceType
   ): AdobeAdeptExecutorType? {
     return if (AdobeDRMServices.isIntendedToBePresent(context)) {
-      val executor = AdobeDRMServices.newAdobeDRMOrNull(context, adobeConfiguration)
-      if (executor == null) {
-        onProgress.invoke(BootEvent.BootWantsDialog(strings.bootAdobeDRMFailed))
-      }
-      executor
+      AdobeDRMServices.newAdobeDRMOrNull(context, adobeConfiguration)
     } else {
       null
     }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServicesStrings.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServicesStrings.kt
@@ -13,6 +13,9 @@ internal class MainServicesStrings(
   override val bootCompleted: String =
     "Startup completed!"
 
+  val bootAdobeDRMFailed: String =
+    resources.getString(R.string.bootAdobeDRMFailed)
+
   fun bootingGeneral(kind: String): String =
     "Initializing $kind..."
 }

--- a/simplified-main/src/main/res/values/stringsBoot.xml
+++ b/simplified-main/src/main/res/values/stringsBoot.xml
@@ -2,4 +2,5 @@
 
 <resources>
   <string name="bootFailedGeneric">We found a problem. Please check your connection or close and reopen the app to retry.</string>
+  <string name="bootAdobeDRMFailed">Something went wrong with the Adobe DRM system: Some books will be unavailable in this version of the application. Please try updating to the latest version of the application.</string>
 </resources>

--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/BootFragment.kt
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/BootFragment.kt
@@ -7,6 +7,7 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
@@ -77,7 +78,7 @@ class BootFragment : Fragment(R.layout.splash_boot) {
   }
 
   private fun onBootEvent(event: BootEvent) {
-    when (event) {
+    return when (event) {
       is BootEvent.BootInProgress -> {
         text.text = event.message
       }
@@ -86,6 +87,12 @@ class BootFragment : Fragment(R.layout.splash_boot) {
       }
       is BootEvent.BootFailed -> {
         onBootFailed(event)
+      }
+      is BootEvent.BootWantsDialog -> {
+        AlertDialog.Builder(requireContext())
+          .setMessage(event.message)
+          .create()
+          .show()
       }
     }
   }

--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/BootFragment.kt
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/BootFragment.kt
@@ -7,7 +7,6 @@ import android.widget.Button
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
@@ -87,12 +86,6 @@ class BootFragment : Fragment(R.layout.splash_boot) {
       }
       is BootEvent.BootFailed -> {
         onBootFailed(event)
-      }
-      is BootEvent.BootWantsDialog -> {
-        AlertDialog.Builder(requireContext())
-          .setMessage(event.message)
-          .create()
-          .show()
       }
     }
   }


### PR DESCRIPTION
**What's this do?**
This updates the boot code and DRM service to check for and reject
expired certificates. It adds a new boot event type that allows for
displaying a dialog if something important but not fatal occurs on
boot, and then publishes an event if the DRM fails.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://www.notion.so/lyrasis/Android-Properly-handle-expired-Adobe-certificate-427ab218209d40d3856246cb220fdbca
Affects: https://www.notion.so/lyrasis/App-crashes-on-login-when-Adobe-cert-is-expired-e71eda890b034802ae6ceab83d363d1a

**How should this be tested? / Do these changes have associated tests?**
If everything goes well, you should never see the effects of this code. If you want to see what happens, try using the currently-expired certificate.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Used the expired certificate today.