### PR TITLE
Update adobe cert.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <c:changelog project="org.thepalaceproject.palace" xmlns:c="urn:com.io7m.changelog:4.0">
   <c:releases>
-    <c:release date="2021-07-19T18:00:47+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.0">
+    <c:release date="2021-07-23T16:10:30+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.0">
       <c:changes>
         <c:change date="2021-04-16T00:00:00+00:00" summary="Remove default library option on startup"/>
         <c:change date="2021-04-29T00:00:00+00:00" summary="Add app documentation viewers"/>
@@ -31,7 +31,9 @@
         <c:change date="2021-07-13T00:00:00+00:00" summary="Fix audiobook player not retaining position after exiting app"/>
         <c:change date="2021-07-15T00:00:00+00:00" summary="Configure legal document locations"/>
         <c:change date="2021-07-15T00:00:00+00:00" summary="Add privacy policy to settings"/>
-        <c:change date="2021-07-19T18:00:47+00:00" summary="Hide default library"/>
+        <c:change date="2021-07-19T00:00:00+00:00" summary="Hide default library"/>
+        <c:change date="2021-07-23T00:00:00+00:00" summary="Fix crash when Adobe certificate is expired"/>
+        <c:change date="2021-07-23T16:10:30+00:00" summary="Update Adobe certificate"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-palace/build.gradle
+++ b/simplified-app-palace/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.google.firebase.crashlytics'
 //
 def requiredFiles = [:]
 requiredFiles["ReaderClientCert.sig"] =
-  "ac000b9942b782752bbf32918d34363d5da4e8df0b3fb617c923bcbad3996c6a"
+  "b46e2fbc1cccd8230f7a9c10bb656dc7ddd30eede3f7ecc6454b02814c60cee6"
 requiredFiles["secrets.conf"] =
   "9c211ae0d153c29b72baab3bfad9de6c5cecb6b39bcda8206d36a65aaca0db21"
 


### PR DESCRIPTION
**What's this do?**

This updates the hash of the Adobe certificate so that we can build using the updated certificate. Also updates the change log.

**Why are we doing this? (w/ JIRA link if applicable)**

Our development certificate expired, so we got a new one.

**How should this be tested? / Do these changes have associated tests?**

Adobe DRM should be enabled, and reading Adobe-protected books should work.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the Palace app.