### PR TITLE
Remove constraint on font scale when building reader preferences.

### DIFF
--- a/simplified-reader-api/src/main/java/org/nypl/simplified/reader/api/ReaderPreferences.java
+++ b/simplified-reader-api/src/main/java/org/nypl/simplified/reader/api/ReaderPreferences.java
@@ -101,7 +101,6 @@ public abstract class ReaderPreferences {
      */
 
     public final ReaderPreferences build() {
-      this.setFontScale(Math.min(200.0, Math.max(50.0, fontScale())));
       this.setBrightness(Math.min(1.0, Math.max(0.0, brightness())));
       return autoBuild();
     }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
@@ -144,6 +144,29 @@ class ProfileDescriptionJSONTest {
     assertEquals("5310437f-db1a-492e-a09f-1ceaa43303dd", description.preferences.mostRecentAccount.uuid.toString())
   }
 
+  /**
+   * A large font scale value should not be constrained during deserialization.
+   */
+
+  @Test
+  fun testLargeFontScale() {
+    val mapper = ObjectMapper()
+    val mostRecentAccount = AccountID.generate()
+    val description =
+      ProfileDescriptionJSON.deserializeFromText(
+        mapper,
+        this.ofResource("profile-large-font-scale.json"),
+        mostRecentAccount
+      )
+
+    assertEquals("", description.displayName)
+    assertEquals(1.0, description.preferences.readerPreferences.brightness())
+    assertEquals(800.0, description.preferences.readerPreferences.fontScale())
+    assertEquals(ReaderFontSelection.READER_FONT_SANS_SERIF, description.preferences.readerPreferences.fontFamily())
+    assertEquals(ReaderColorScheme.SCHEME_BLACK_ON_WHITE, description.preferences.readerPreferences.colorScheme())
+    assertEquals(mostRecentAccount, description.preferences.mostRecentAccount)
+  }
+
   private fun ofResource(name: String): String {
     val bytes =
       ProfileDescriptionJSONTest::class.java.getResourceAsStream(

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-large-font-scale.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-large-font-scale.json
@@ -1,0 +1,13 @@
+{
+  "@version" : 20210605,
+  "displayName" : "",
+  "preferences" : {
+    "showTestingLibraries" : false,
+    "readerPreferences" : {
+      "font_scale" : 800.0,
+      "font_family" : "READER_FONT_SANS_SERIF",
+      "color_scheme" : "SCHEME_BLACK_ON_WHITE"
+    }
+  },
+  "attributes" : { }
+}


### PR DESCRIPTION
**What's this do?**

Removes the constraint on the font scale when building reader preferences, which limits the value to be between 50 and 200.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes a bug where the user can select a font scale greater than 200 in Readium, but it is limited to a max of 200 when the Readium settings are converted to user preferences. Since the user preferences are what get saved and restored when the user closes and re-opens the app, this causes the scale to be restored to 200, instead of the user's actual selection.

When the preferences are converted back to Readium settings, the font scale is already being constrained to the min and max values allowed by the Readium theme: https://github.com/ThePalaceProject/android-core/blob/04e0b9c26182dcd9f380c82aedb155d68d355f6f/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Themes.kt#L71-L75

So there's no need to have this additional constraint that isn't aware of what Readium allows.

Addresses part of this Notion ticket: https://www.notion.so/lyrasis/Font-size-button-Android-f49da8f869b84d1c80755c6c0e8c4937

**How should this be tested? / Do these changes have associated tests?**

Read an epub book. In the reader settings, select a large font size (at least 10 steps up from the default). Exit and restart the app. The font size should appear to be the same as it was before exiting.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the Palace app.