### PR TITLE
Use the new palaceproject.io registry

### DIFF
--- a/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceBuildConfigurationService.kt
+++ b/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceBuildConfigurationService.kt
@@ -9,8 +9,8 @@ import java.net.URI
 class PalaceBuildConfigurationService : BuildConfigurationServiceType {
   override val libraryRegistry: BuildConfigurationAccountsRegistryURIs
     get() = BuildConfigurationAccountsRegistryURIs(
-      registry = URI("https://libraryregistry.librarysimplified.org/libraries"),
-      registryQA = URI("https://libraryregistry.librarysimplified.org/libraries/qa")
+      registry = URI("https://registry.palaceproject.io/libraries"),
+      registryQA = URI("https://registry.palaceproject.io/libraries/qa")
     )
   override val allowAccountsAccess: Boolean
     get() = true


### PR DESCRIPTION
**What's this do?**
This sets the Palace app library registry URI to the new registry.

**Why are we doing this? (w/ JIRA link if applicable)**
The old registry is being purged!

**How should this be tested? / Do these changes have associated tests?**
Check that there are accounts listed in the "Create An Account" section of the app. Right now, there are only non-production libraries in the registry, so you'll need to toggle the switch in the debug menu to enable testing/QA libraries.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m 

![device-2021-09-01-182121](https://user-images.githubusercontent.com/612494/131723494-9e536f7a-67f4-49ab-abe5-b2420b654da3.png)
