### PR TITLE
Accounts -> Libraries terminology

### DIFF
--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <resources>
-  <string name="accountAdd">Add account</string>
+  <string name="accountAdd">Add Library</string>
   <string name="accountCancel">Cancel</string>
   <string name="accountCardCreatorLabel">Don\'t have a library card?</string>
   <string name="accountCardCreatorSignUp">Create Card</string>
   <string name="accountCOPPADeleteBooks">Delete books?</string>
   <string name="accountCOPPADeleteBooksConfirm">Changing your age will remove all books downloaded from the current account.</string>
   <string name="accountAgeVerification">Age Verification</string>
-  <string name="accountCreationFailed">Account creation failed</string>
-  <string name="accountCreationFailedMessage">The account could not be created.</string>
+  <string name="accountCreationFailed">Library creation failed</string>
+  <string name="accountCreationFailedMessage">The library could not be created.</string>
   <string name="accountDelete">Delete</string>
   <string name="accountEULAStatement">By signing in, you agree to the End User License Agreement.</string>
   <string name="accountLogin">Log in</string>
@@ -23,19 +23,19 @@
   <string name="accountPasswordShow">Show %1$s</string>
   <string name="accountPickerTitle">Switch library</string>
   <string name="accountPlaceholder">Lorem ipsum dolor sit amet, probatus volutpat has at, vis adhuc iuvaret omittantur an, sadipscing conclusionemque his ad. Eam ut simul tempor. Primis consetetur appellantur vim eu, eum an iudico dolorum. Ad vis utamur honestatis, sanctus debitis referrentur an eam.</string>
-  <string name="accountRegistryCreating">Creating an account…</string>
-  <string name="accountRegistryEmpty">No accounts are available.</string>
+  <string name="accountRegistryCreating">Creating a library…</string>
+  <string name="accountRegistryEmpty">No libraries are available.</string>
   <string name="accountRegistryRefresh">Refresh</string>
-  <string name="accountRegistryRetrieving">Retrieving accounts from registry…</string>
+  <string name="accountRegistryRetrieving">Retrieving libraries from registry…</string>
   <string name="accountRegistrySelect">Please select a library…</string>
   <string name="accountRegistryNoLocation">You can search for your library by name, branch location, or your own location.</string>
   <string name="accountReportIssue">Report an issue…</string>
-  <string name="accounts">Accounts</string>
+  <string name="accounts">Libraries</string>
   <string name="accountsDelete">@string/accountDelete</string>
   <string name="accountsDeleteConfirm">Are you sure you want to remove \"%1$s\" from this device?</string>
-  <string name="accountsDeleteConfirmTitle">Remove account</string>
-  <string name="accountsDeletionFailed">Account deletion failed</string>
-  <string name="accountsDeletionFailedMessage">The account could not be deleted.</string>
+  <string name="accountsDeleteConfirmTitle">Remove library</string>
+  <string name="accountsDeletionFailed">Library deletion failed</string>
+  <string name="accountsDeletionFailedMessage">The library could not be deleted.</string>
   <string name="accountsDetails">Details</string>
   <string name="accountSyncBookmarks">Sync bookmarks</string>
   <string name="accountUserName">User Name</string>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -543,12 +543,8 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
   }
 
   private fun configureToolbar() {
-    this.configureToolbarNavigation()
-    this.configureToolbarTitles()
-  }
-
-  private fun configureToolbarNavigation() {
     try {
+      this.toolbar.setTitle(this.viewModel.title())
       val actionBar = this.supportActionBar ?: return
 
       /*
@@ -590,13 +586,6 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
       }
     } catch (e: Exception) {
       // Nothing to do
-    }
-  }
-
-  private fun configureToolbarTitles() {
-    this.supportActionBar?.let {
-      it.title = this.viewModel.accountProvider?.displayName
-      it.subtitle = null
     }
   }
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -937,6 +937,15 @@ class CatalogFeedViewModel(
     this.borrowViewModel.tryRevokeMaybeAuthenticated(book)
   }
 
+  fun title(): String {
+    return when (val arguments = this.feedArguments) {
+      is CatalogFeedArgumentsLocalBooks ->
+        arguments.title
+      is CatalogFeedArgumentsRemote ->
+        this.resources.getString(R.string.feedTitleCatalog)
+    }
+  }
+
   private fun openLoginDialogIfNecessary(accountID: AccountID) {
     if (this.borrowViewModel.isLoginRequired(accountID)) {
       this.listener.post(

--- a/simplified-ui-settings/src/main/res/values/strings.xml
+++ b/simplified-ui-settings/src/main/res/values/strings.xml
@@ -4,8 +4,8 @@
   <string name="settings">Settings</string>
   <string name="settingsAbout">About</string>
   <string name="settingsAboutSummary" />
-  <string name="settingsAccounts">Accounts</string>
-  <string name="settingsAccountsSummary">Add, remove, or configure accounts</string>
+  <string name="settingsAccounts">Libraries</string>
+  <string name="settingsAccountsSummary">Add, remove, or configure libraries</string>
   <string name="settingsAcknowledgements">Acknowledgements</string>
   <string name="settingsAcknowledgementsSummary" />
   <string name="settingsCommit">Commit</string>


### PR DESCRIPTION
**What's this do?**
This adjusts all occurrences in the UI of the word "account" and
changes it to "library". This also adjusts the toolbar to display
the tab label rather than the library name.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://www.notion.so/lyrasis/Android-Update-Title-menu-Bar-lable-to-for-view-names-vs-library-names-and-catalog-breadcrumbs-cfdfbdb03614475984eef1b70a937f3a
Affects: https://www.notion.so/lyrasis/Android-Update-UI-label-for-Accounts-to-Libraries-90cfef17026044549c7b55c3b50451a2

**How should this be tested? / Do these changes have associated tests?**
Check that you can't find the word Account in the UI.
Check that the toolbar displays generic terms such as "Catalog", "Books", etc.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m tested it.