### PR TITLE
Automatically switch to catalog

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -228,7 +228,9 @@ internal class MainFragmentListenerDelegate(
   ): MainFragmentState {
     return when (event) {
       is AccountListRegistryEvent.AccountCreated -> {
+        this.setMostRecentAccount(event.accountID)
         this.popBackStack()
+        this.openCatalog()
         state
       }
       is AccountListRegistryEvent.OpenErrorPage -> {
@@ -236,6 +238,12 @@ internal class MainFragmentListenerDelegate(
         state
       }
     }
+  }
+
+  private fun setMostRecentAccount(accountID: AccountID) {
+    this.profilesController.profileUpdate { description ->
+      description.copy(preferences = description.preferences.copy(mostRecentAccount = accountID))
+    }.get()
   }
 
   private fun handleAccountListEvent(
@@ -265,7 +273,7 @@ internal class MainFragmentListenerDelegate(
     return when (event) {
       AccountDetailEvent.LoginSucceeded ->
         if (state is MainFragmentState.CatalogWaitingForLogin) {
-          this.openCatalogAfterAuthentication()
+          this.openCatalog()
           MainFragmentState.EmptyState
         } else {
           state
@@ -534,7 +542,7 @@ internal class MainFragmentListenerDelegate(
     )
   }
 
-  private fun openCatalogAfterAuthentication() {
+  private fun openCatalog() {
     this.navigator.popBackStack()
     this.navigator.reset(R.id.tabCatalog, false)
   }


### PR DESCRIPTION
**What's this do?**
This adds some code to the main fragment listener delegate that
switches back to the catalog automatically when an account is created.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://www.notion.so/lyrasis/Switch-library-catalog-when-adding-new-library-cc488ba037fa4704960b08cbd03262cc

**How should this be tested? / Do these changes have associated tests?**
1. Open the "Add a new library" screen
2. Select any library
3. Note that you're left looking at the Catalog, with the new library selected

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried it with a few libraries.