### PR TITLE
Adjust toolbar handling

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
@@ -154,14 +154,6 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
       .let { subscriptions.add(it) }
 
     /*
-     * Show the Toolbar
-     */
-
-    this.supportActionBar?.setLogo(this.viewModel.buildConfig.brandingAppIcon)
-    this.supportActionBar?.setTitle(R.string.app_name)
-    this.supportActionBar?.show()
-
-    /*
      * Show the Adobe DRM warning dialog if necessary,
      */
 

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
@@ -13,7 +13,6 @@ import org.librarysimplified.services.api.Services
 import org.nypl.simplified.accounts.api.AccountEvent
 import org.nypl.simplified.accounts.api.AccountEventDeletion
 import org.nypl.simplified.accounts.api.AccountEventUpdated
-import org.nypl.simplified.android.ktx.supportActionBar
 import org.nypl.simplified.books.api.BookID
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookStatusEvent

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -219,6 +219,10 @@ internal class MainFragmentListenerDelegate(
         this.openFeed(event.feedArguments)
         state
       }
+      CatalogBookDetailEvent.GoUpwards -> {
+        this.goUpwards()
+        state
+      }
     }
   }
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailEvent.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailEvent.kt
@@ -7,6 +7,8 @@ import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 
 sealed class CatalogBookDetailEvent {
 
+  object GoUpwards : CatalogBookDetailEvent()
+
   data class OpenErrorPage(
     val parameters: ErrorPageParameters
   ) : CatalogBookDetailEvent()

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -224,13 +224,20 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     this.configureToolbar()
   }
 
+  override fun onStart() {
+    super.onStart()
+    this.configureToolbar()
+  }
+
   private fun configureToolbar() {
     val actionBar = this.supportActionBar ?: return
     actionBar.setDisplayHomeAsUpEnabled(true)
     actionBar.setHomeActionContentDescription(null)
+    actionBar.show()
     this.toolbar.setLogoOnClickListener {
-      // Do nothing
+      this.viewModel.goUpwards()
     }
+    return
   }
 
   private fun configureOPDSEntry(feedEntry: FeedEntryOPDS) {

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
@@ -281,6 +281,10 @@ class CatalogBookDetailViewModel(
     )
   }
 
+  fun goUpwards() {
+    this.listener.post(CatalogBookDetailEvent.GoUpwards)
+  }
+
   fun showError(result: TaskResult.Failure<*>) {
     this.logger.debug("showing error: {}", this.bookWithStatus.book.id)
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -546,6 +546,7 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
     try {
       this.toolbar.setTitle(this.viewModel.title())
       val actionBar = this.supportActionBar ?: return
+      actionBar.show()
 
       /*
        * If we're not at the root of a feed, then display a back arrow in the toolbar.


### PR DESCRIPTION
**What's this do?**
This adjusts how the toolbar is handled for book detail fragments and for other
screens. It fixes two main problems:

  * The MainFragment's handling of the toolbar could override the handling
    implemented by other fragments when the activity is resumed.
  * The BookDetailFragment's handling of the toolbar was outright insufficient,
    and didn't implement the proper back button behaviour.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://www.notion.so/lyrasis/Toolbar-changes-when-going-back-from-epub-9db3750264324816987e4df1de8baebd
Affects: https://www.notion.so/lyrasis/Back-button-does-not-work-when-trying-to-go-back-from-Book-Details-View-fb88a9c983c64c09818dd2d88dc921b7

**How should this be tested? / Do these changes have associated tests?**
Try the steps given in both tickets.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m tried the steps in the tickets.