### PR TITLE
Upgrade android-audiobook library

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -45,12 +45,12 @@
         <c:change date="2021-09-02T00:00:00+00:00" summary="Use palaceproject.io library registry"/>
       </c:changes>
     </c:release>
-    <c:release date="2021-09-10T19:42:47+00:00" is-open="false" ticket-system="org.nypl.jira" version="1.0.2">
+    <c:release date="2021-09-10T00:00:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="1.0.2">
       <c:changes>
         <c:change date="2021-09-10T00:00:00+00:00" summary="Introduced a new color scheme for the application."/>
       </c:changes>
     </c:release>
-    <c:release date="2021-08-31T00:00:00+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
+    <c:release date="2021-09-28T22:20:51+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
       <c:changes>
         <c:change date="2021-07-14T00:00:00+00:00" summary="Improve fixed-layout EPUB handling.">
           <c:tickets>
@@ -83,11 +83,12 @@
             <c:ticket id="SMA-200"/>
           </c:tickets>
         </c:change>
-        <c:change date="2021-09-02T12:27:18+00:00" summary="Treat publisher default as a font in the settings screen">
+        <c:change date="2021-09-02T00:00:00+00:00" summary="Treat publisher default as a font in the settings screen">
           <c:tickets>
             <c:ticket id="SMA-237"/>
           </c:tickets>
         </c:change>
+        <c:change date="2021-09-28T22:20:51+00:00" summary="Fix long chapter titles overlapping elapsed/total time displays in audiobook player"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/build_libraries.gradle
+++ b/build_libraries.gradle
@@ -48,7 +48,7 @@ ext.versions = [
   mockito_core                  : '3.4.4',
   mockito_kotlin                : '2.2.0',
   moshi                         : '1.8.0',
-  nypl_audiobook_api            : '6.7.0',
+  nypl_audiobook_api            : '6.8.0-SNAPSHOT',
   nypl_drm_adobe                : '1.2.4',
   nypl_drm_axis                 : '1.0.1',
   nypl_drm_core                 : '1.2.2',


### PR DESCRIPTION
**What's this do?**

Upgrade android-audiobook to the latest snapshot version.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes long titles overlapping with the elapsed/total times when playing audiobooks. Notion: https://www.notion.so/lyrasis/Long-audiobook-chapter-titles-overlap-play-times-f5f1ee89fa204194a147ee24fd31dd18

**How should this be tested? / Do these changes have associated tests?**

Play "The Shadow Conspiracy" audiobook from Lyrasis Reads. On the player, the chapter title should appear on its own line, instead of the same line as the elapsed/total time displays. The chapter title should not overlap the times at all.

**Dependencies for merging? Releasing to production?**

n/a

**Have you updated the changelog?**

Yes

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the Palace app.
