### PR TITLE
Fix back button on document viewer screens.

### DIFF
--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentDefaultViewModelFactory.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentDefaultViewModelFactory.kt
@@ -13,6 +13,7 @@ import org.nypl.simplified.ui.catalog.CatalogFeedEvent
 import org.nypl.simplified.ui.catalog.saml20.CatalogSAML20Event
 import org.nypl.simplified.ui.profiles.ProfileTabEvent
 import org.nypl.simplified.ui.settings.SettingsDebugEvent
+import org.nypl.simplified.ui.settings.SettingsDocumentViewerEvent
 import org.nypl.simplified.ui.settings.SettingsMainEvent
 
 class MainFragmentDefaultViewModelFactory(fallbackFactory: ViewModelProvider.Factory) :
@@ -31,6 +32,7 @@ class MainFragmentDefaultViewModelFactory(fallbackFactory: ViewModelProvider.Fac
     repository.registerListener(AccountPickerEvent::class, MainFragmentListenedEvent::AccountPickerEvent)
     repository.registerListener(SettingsMainEvent::class, MainFragmentListenedEvent::SettingsMainEvent)
     repository.registerListener(SettingsDebugEvent::class, MainFragmentListenedEvent::SettingsDebugEvent)
+    repository.registerListener(SettingsDocumentViewerEvent::class, MainFragmentListenedEvent::SettingsDocumentViewerEvent)
     repository.registerListener(ProfileTabEvent::class, MainFragmentListenedEvent::ProfileTabEvent)
   }
 }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenedEvent.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenedEvent.kt
@@ -42,6 +42,10 @@ sealed class MainFragmentListenedEvent {
     val event: org.nypl.simplified.ui.settings.SettingsDebugEvent
   ) : MainFragmentListenedEvent()
 
+  data class SettingsDocumentViewerEvent(
+    val event: org.nypl.simplified.ui.settings.SettingsDocumentViewerEvent
+  ) : MainFragmentListenedEvent()
+
   data class ProfileTabEvent(
     val event: org.nypl.simplified.ui.profiles.ProfileTabEvent
   ) : MainFragmentListenedEvent()

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -43,7 +43,8 @@ import org.nypl.simplified.ui.profiles.ProfileTabEvent
 import org.nypl.simplified.ui.settings.SettingsCustomOPDSFragment
 import org.nypl.simplified.ui.settings.SettingsDebugEvent
 import org.nypl.simplified.ui.settings.SettingsDebugFragment
-import org.nypl.simplified.ui.settings.SettingsFragmentDocumentViewer
+import org.nypl.simplified.ui.settings.SettingsDocumentViewerEvent
+import org.nypl.simplified.ui.settings.SettingsDocumentViewerFragment
 import org.nypl.simplified.ui.settings.SettingsMainEvent
 import org.nypl.simplified.viewer.api.Viewers
 import org.nypl.simplified.viewer.spi.ViewerPreferences
@@ -135,6 +136,8 @@ internal class MainFragmentListenerDelegate(
         this.handleSettingsMainEvent(event.event, state)
       is MainFragmentListenedEvent.SettingsDebugEvent ->
         this.handleSettingsDebugEvent(event.event, state)
+      is MainFragmentListenedEvent.SettingsDocumentViewerEvent ->
+        this.handleSettingsDocumentViewerEvent(event.event, state)
       is MainFragmentListenedEvent.AccountListRegistryEvent ->
         this.handleAccountListRegistryEvent(event.event, state)
       is MainFragmentListenedEvent.AccountListEvent ->
@@ -397,6 +400,18 @@ internal class MainFragmentListenerDelegate(
     }
   }
 
+  private fun handleSettingsDocumentViewerEvent(
+    event: SettingsDocumentViewerEvent,
+    state: MainFragmentState
+  ): MainFragmentState {
+    return when (event) {
+      SettingsDocumentViewerEvent.GoUpwards -> {
+        this.goUpwards()
+        state
+      }
+    }
+  }
+
   private fun handleProfileTabEvent(
     event: ProfileTabEvent,
     state: MainFragmentState
@@ -415,7 +430,7 @@ internal class MainFragmentListenerDelegate(
 
   private fun openSettingsAbout(title: String, url: String) {
     this.navigator.addFragment(
-      fragment = SettingsFragmentDocumentViewer.create(title, url),
+      fragment = SettingsDocumentViewerFragment.create(title, url),
       tab = R.id.tabSettings
     )
   }
@@ -433,35 +448,35 @@ internal class MainFragmentListenerDelegate(
 
   private fun openSettingsAcknowledgements(title: String, url: String) {
     this.navigator.addFragment(
-      fragment = SettingsFragmentDocumentViewer.create(title, url),
+      fragment = SettingsDocumentViewerFragment.create(title, url),
       tab = R.id.tabSettings
     )
   }
 
   private fun openSettingsEULA(title: String, url: String) {
     this.navigator.addFragment(
-      fragment = SettingsFragmentDocumentViewer.create(title, url),
+      fragment = SettingsDocumentViewerFragment.create(title, url),
       tab = R.id.tabSettings
     )
   }
 
   private fun openSettingsFaq(title: String, url: String) {
     this.navigator.addFragment(
-      fragment = SettingsFragmentDocumentViewer.create(title, url),
+      fragment = SettingsDocumentViewerFragment.create(title, url),
       tab = R.id.tabSettings
     )
   }
 
   private fun openSettingsLicense(title: String, url: String) {
     this.navigator.addFragment(
-      fragment = SettingsFragmentDocumentViewer.create(title, url),
+      fragment = SettingsDocumentViewerFragment.create(title, url),
       tab = R.id.tabSettings
     )
   }
 
   private fun openSettingsPrivacy(title: String, url: String) {
     this.navigator.addFragment(
-      fragment = SettingsFragmentDocumentViewer.create(title, url),
+      fragment = SettingsDocumentViewerFragment.create(title, url),
       tab = R.id.tabSettings
     )
   }
@@ -524,7 +539,7 @@ internal class MainFragmentListenerDelegate(
     url: URL
   ) {
     this.navigator.addFragment(
-      fragment = SettingsFragmentDocumentViewer.create(title, url.toString()),
+      fragment = SettingsDocumentViewerFragment.create(title, url.toString()),
       tab = this.navigator.currentTab()
     )
   }

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDocumentViewerEvent.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDocumentViewerEvent.kt
@@ -1,0 +1,10 @@
+package org.nypl.simplified.ui.settings
+
+sealed class SettingsDocumentViewerEvent {
+
+  /*
+   * The document viewer screen wants to close.
+   */
+
+  object GoUpwards : SettingsDocumentViewerEvent()
+}

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDocumentViewerFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDocumentViewerFragment.kt
@@ -9,12 +9,17 @@ import android.webkit.WebViewClient
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import org.nypl.simplified.android.ktx.supportActionBar
+import org.nypl.simplified.listeners.api.FragmentListenerType
+import org.nypl.simplified.listeners.api.fragmentListeners
+import org.nypl.simplified.ui.neutrality.NeutralToolbar
 import org.nypl.simplified.ui.settings.databinding.SettingsDocumentViewerBinding
 
-class SettingsFragmentDocumentViewer : Fragment() {
+class SettingsDocumentViewerFragment : Fragment() {
 
   private lateinit var binding: SettingsDocumentViewerBinding
+  private lateinit var toolbar: NeutralToolbar
 
+  private val listener: FragmentListenerType<SettingsDocumentViewerEvent> by fragmentListeners()
   private val title by lazy { arguments?.getString(TITLE_ID) }
   private val url by lazy { arguments?.getString(URL_ID) }
 
@@ -26,10 +31,8 @@ class SettingsFragmentDocumentViewer : Fragment() {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
-    supportActionBar?.apply {
-      title = this@SettingsFragmentDocumentViewer.title
-      subtitle = null
-    }
+    this.toolbar =
+      view.rootView.findViewWithTag(NeutralToolbar.neutralToolbarName)
 
     if (!url.isNullOrBlank()) {
       binding.documentViewerWebView.webViewClient = WebViewClient()
@@ -38,11 +41,27 @@ class SettingsFragmentDocumentViewer : Fragment() {
     }
   }
 
-  companion object {
-    private const val TITLE_ID = "org.nypl.simplified.ui.settings.SettingsFragmentDocumentViewer.title"
-    private const val URL_ID = "org.nypl.simplified.ui.settings.SettingsFragmentDocumentViewer.url"
+  override fun onStart() {
+    super.onStart()
+    this.configureToolbar()
+  }
 
-    fun create(title: String, url: String) = SettingsFragmentDocumentViewer().apply {
+  private fun configureToolbar() {
+    val actionBar = this.supportActionBar ?: return
+    actionBar.show()
+    actionBar.setDisplayHomeAsUpEnabled(true)
+    actionBar.setHomeActionContentDescription(null)
+    actionBar.setTitle(this@SettingsDocumentViewerFragment.title)
+    this.toolbar.setLogoOnClickListener {
+      this.listener.post(SettingsDocumentViewerEvent.GoUpwards)
+    }
+  }
+
+  companion object {
+    private const val TITLE_ID = "org.nypl.simplified.ui.settings.SettingsDocumentViewerFragment.title"
+    private const val URL_ID = "org.nypl.simplified.ui.settings.SettingsDocumentViewerFragment.url"
+
+    fun create(title: String, url: String) = SettingsDocumentViewerFragment().apply {
       arguments = bundleOf(TITLE_ID to title, URL_ID to url)
     }
   }


### PR DESCRIPTION
**What's this do?**

This is a continuation of the toolbar adjustments from https://github.com/ThePalaceProject/android-core/pull/34 and https://github.com/ThePalaceProject/android-core/pull/37. It applies those adjustments to one more fragment that was previously missed.

**Why are we doing this? (w/ JIRA link if applicable)**

This makes the back button functional again in the toolbars of the document viewer screens under Settings (User Agreement, Software Licenses, Privacy Policy).

**How should this be tested? / Do these changes have associated tests?**

In Settings, tap on the documentation items (User Agreement, Software Licenses, Privacy Policy). In the documentation viewer screen that opens, tap on the back button in the toolbar. The app should return to the Settings screen.

**Dependencies for merging? Releasing to production?**

n/a

**Have you updated the changelog?**

No, because the back button worked in the last release. This fixes a bug that was introduced since that release.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the Palace app.
