### PR TITLE
Enable back button in reader toolbar.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -50,7 +50,7 @@
         <c:change date="2021-09-10T00:00:00+00:00" summary="Introduced a new color scheme for the application."/>
       </c:changes>
     </c:release>
-    <c:release date="2021-09-30T15:57:34+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
+    <c:release date="2021-10-01T03:32:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
       <c:changes>
         <c:change date="2021-07-14T00:00:00+00:00" summary="Improve fixed-layout EPUB handling.">
           <c:tickets>
@@ -89,8 +89,10 @@
           </c:tickets>
         </c:change>
         <c:change date="2021-09-28T00:00:00+00:00" summary="Fix long chapter titles overlapping elapsed/total time displays in audiobook player"/>
-        <c:change date="2021-09-30T11:42:43+00:00" summary="Add icons and descriptions to Add Library screen"/>
-        <c:change date="2021-09-30T15:57:34+00:00" summary="Add book loan duration to buttons"/>
+        <c:change date="2021-09-30T00:00:00+00:00" summary="Add icons and descriptions to Add Library screen"/>
+        <c:change date="2021-09-30T00:00:00+00:00" summary="Add book loan duration to buttons"/>
+        <c:change date="2021-10-01T00:00:00+00:00" summary="Change order of reader menu icons to TOC, Settings, Bookmarks"/>
+        <c:change date="2021-10-01T03:32:31+00:00" summary="Add back button to reader toolbar"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
@@ -302,7 +302,7 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
 
     return when (event) {
       SR2ReaderViewNavigationClose ->
-        this.tocClose()
+        this.onBackPressed()
       SR2ReaderViewNavigationOpenTOC ->
         this.tocOpen()
       is SR2ControllerBecameAvailable ->


### PR DESCRIPTION
**What's this do?**

This enables the newly added back button in the reader toolbar. The latest build of android-r2 adds a back button to the reader toolbar, which fires the `SR2ReaderViewNavigationClose` event. Currently, the `SR2ReaderViewNavigationClose` event handler assumes that the TOC is open, and all it does is attempt to close the TOC. This adjusts the handler to actually return to the previous screen when the TOC is not open.

**Why are we doing this? (w/ JIRA link if applicable)**

This makes the toolbar behave more like it does on iOS. It also makes it easier for users to exit a book when the OS-provided back button is not enabled. Notion: https://www.notion.so/lyrasis/Add-back-button-to-reader-toolbar-0f25bf9b71fc4eae99b042a521d34c7e

**How should this be tested? / Do these changes have associated tests?**

Read an epub book. If the toolbar is not visible, tap in the middle of the page to open it. On the left side of the toolbar, there should be a back arrow. Tapping on the back arrow should exit the book, and return to the screen from which the book was opened (the bookshelf or book detail screen). When reading a book, opening and closing the TOC should continue to work as normal.

**Dependencies for merging? Releasing to production?**

https://github.com/ThePalaceProject/android-r2/pull/4 should be merged first. This PR won't do anything if that isn't merged first, but it won't do any harm either.

**Have you updated the changelog?**

Yes. The changelog is updated with this change, as well as the other android-r2 change (reordering the toolbar menu items).

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the Palace app.