### PR TITLE
Fix cropped button text on smaller devices

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
@@ -2,6 +2,7 @@ package org.nypl.simplified.ui.catalog
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.util.TypedValue
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -122,7 +123,7 @@ class CatalogButtons(
     val mainText = this.createCenteredTextForButtons(res).apply {
       this.layoutParams = wrapContentParameters()
       this.setTextColor(colorStateListForButtonItems())
-      this.textSize = 12f
+      this.setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
       this.isDuplicateParentStateEnabled = true
       this.movementMethod = null
       this.isVerticalScrollBarEnabled = false
@@ -131,14 +132,16 @@ class CatalogButtons(
     val textLoanDuration = this.createCenteredTextForButtons(loanDuration).apply {
       this.layoutParams = wrapContentParameters()
       this.setTextColor(colorStateListForButtonItems())
-      this.textSize = 12f
+      this.setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
       this.isDuplicateParentStateEnabled = true
       this.movementMethod = null
       this.isVerticalScrollBarEnabled = false
     }
 
+    val imageViewDimension = this.screenSizeInformation.dpToPixels(8).toInt()
+
     val imageView = AppCompatImageView(this.context).apply {
-      this.layoutParams = ViewGroup.MarginLayoutParams(25, 25).apply {
+      this.layoutParams = ViewGroup.MarginLayoutParams(imageViewDimension, imageViewDimension).apply {
         this.bottomMargin = 4
       }
       this.isDuplicateParentStateEnabled = true


### PR DESCRIPTION
**What's this do?**
This PR changes how the text size value is set to both textviews on the button with the missing loan duration and how the clock image layout parameters are initialized. Instead of using direct values, we use the converter in order to get the corresponding value in _sp_ (for the text size) and in _dp_ (for the image).

**Why are we doing this? (w/ JIRA link if applicable)**
[A bug](https://www.notion.so/lyrasis/Time-left-on-loan-being-cutoff-on-Android-6bc0f1a88ff64e969c58ae651b7c61a2) was reported saying the missing loan duration text was being cropped in some devices with smaller screens.

**How should this be tested? / Do these changes have associated tests?**
Open the "Books" tab;
On the catalog, if you have books with loan durations (for instance, in Lyrasis library, **Companions** from _Christina Hesselholdt_ and **In the Neighborhood of True** from _Susan Kaplan Carlton_) you can see the button "Read" / "Download" / "Listen" is displaying an image with a clock and the [missing loan duration without any cutoff text](https://user-images.githubusercontent.com/79104027/135688991-3f65f0dc-fb59-4fed-ab8a-bdb19f8c1174.png).

**Dependencies for merging? Releasing to production?**
n/a

**Did someone actually run this code to verify it works?**
Tested by @nunommts 