### PR TITLE
Updated "Books" tab

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -50,7 +50,7 @@
         <c:change date="2021-09-10T00:00:00+00:00" summary="Introduced a new color scheme for the application."/>
       </c:changes>
     </c:release>
-    <c:release date="2021-10-01T03:32:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
+    <c:release date="2021-10-05T13:59:50+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
       <c:changes>
         <c:change date="2021-07-14T00:00:00+00:00" summary="Improve fixed-layout EPUB handling.">
           <c:tickets>
@@ -93,7 +93,8 @@
         <c:change date="2021-09-30T00:00:00+00:00" summary="Add icons and descriptions to Add Library screen"/>
         <c:change date="2021-09-30T00:00:00+00:00" summary="Add book loan duration to buttons"/>
         <c:change date="2021-10-01T00:00:00+00:00" summary="Change order of reader menu icons to TOC, Settings, Bookmarks"/>
-        <c:change date="2021-10-01T03:32:31+00:00" summary="Add back button to reader toolbar"/>
+        <c:change date="2021-10-01T00:00:00+00:00" summary="Add back button to reader toolbar"/>
+        <c:change date="2021-10-05T13:59:50+00:00" summary="Updated Books tab"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedFacet.kt
+++ b/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedFacet.kt
@@ -68,5 +68,31 @@ sealed class FeedFacet : Serializable {
         SORT_BY_TITLE
       }
     }
+
+    /**
+     * A filtering facet.
+     */
+
+    data class FilteringForStatus(
+      override val title: String,
+      override val isActive: Boolean,
+      val filterStatus: Status
+    ) : FeedFacetPseudo() {
+
+      enum class Status {
+
+        /**
+         * Filter the feed to show all the status.
+         */
+
+        ALL,
+
+        /**
+         * Filter the feed to show the on loan books.
+         */
+
+        ON_LOAN
+      }
+    }
   }
 }

--- a/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedFacetPseudoTitleProviderType.kt
+++ b/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedFacetPseudoTitleProviderType.kt
@@ -14,4 +14,7 @@ interface FeedFacetPseudoTitleProviderType {
   val sortBy: String
   val sortByAuthor: String
   val sortByTitle: String
+  val show: String
+  val showAll: String
+  val showOnLoan: String
 }

--- a/simplified-profiles-controller-api/src/main/java/org/nypl/simplified/profiles/controller/api/ProfileFeedRequest.kt
+++ b/simplified-profiles-controller-api/src/main/java/org/nypl/simplified/profiles/controller/api/ProfileFeedRequest.kt
@@ -4,6 +4,7 @@ import org.joda.time.DateTime
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.feeds.api.FeedBooksSelection
 import org.nypl.simplified.feeds.api.FeedBooksSelection.BOOKS_FEED_LOANED
+import org.nypl.simplified.feeds.api.FeedFacet.FeedFacetPseudo.FilteringForStatus.Status
 import org.nypl.simplified.feeds.api.FeedFacet.FeedFacetPseudo.Sorting.SortBy
 import org.nypl.simplified.feeds.api.FeedFacetPseudoTitleProviderType
 import java.net.URI
@@ -43,6 +44,12 @@ data class ProfileFeedRequest(
    */
 
   val sortBy: SortBy = SortBy.SORT_BY_TITLE,
+
+  /**
+   * The active status filtering facet.
+   */
+
+  val filterStatus: Status = Status.ALL,
 
   /**
    * The title provider for facets.

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/ProfilesControllerContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/ProfilesControllerContract.kt
@@ -458,6 +458,14 @@ abstract class ProfilesControllerContract {
               get() = "Author"
             override val sortByTitle: String
               get() = "Title"
+            override val show: String
+              get() = "Show"
+            override val showAll: String
+              get() = "All"
+            override val showEBooks: String
+              get() = "eBooks"
+            override val showAudioBooks: String
+              get() = "AudioBooks"
           }
         )
       ).get()

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -446,9 +446,11 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     this.buttons.removeAllViews()
     this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.buttons.addView(
-      this.buttonCreator.createGetButton {
-        this.viewModel.borrowMaybeAuthenticated()
-      }
+      this.buttonCreator.createGetButton(
+        onClick = {
+          this.viewModel.borrowMaybeAuthenticated()
+        }
+      )
     )
     this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.checkButtonViewCount()
@@ -467,9 +469,11 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     this.buttons.removeAllViews()
     this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.buttons.addView(
-      this.buttonCreator.createReserveButton {
-        this.viewModel.reserveMaybeAuthenticated()
-      }
+      this.buttonCreator.createReserveButton(
+        onClick = {
+          this.viewModel.reserveMaybeAuthenticated()
+        }
+      )
     )
     this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.checkButtonViewCount()
@@ -492,9 +496,11 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
         if (bookStatus.isRevocable) {
           this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
           this.buttons.addView(
-            this.buttonCreator.createRevokeHoldButton {
-              this.viewModel.revokeMaybeAuthenticated()
-            }
+            this.buttonCreator.createRevokeHoldButton(
+              onClick = {
+                this.viewModel.revokeMaybeAuthenticated()
+              }
+            )
           )
           this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
         } else {
@@ -506,15 +512,19 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       is BookStatus.Held.HeldReady -> {
         if (bookStatus.isRevocable) {
           this.buttons.addView(
-            this.buttonCreator.createRevokeHoldButton {
-              this.viewModel.revokeMaybeAuthenticated()
-            }
+            this.buttonCreator.createRevokeHoldButton(
+              onClick = {
+                this.viewModel.revokeMaybeAuthenticated()
+              }
+            )
           )
         }
         this.buttons.addView(
-          this.buttonCreator.createGetButton {
-            this.viewModel.borrowMaybeAuthenticated()
-          }
+          this.buttonCreator.createGetButton(
+            onClick = {
+              this.viewModel.borrowMaybeAuthenticated()
+            }
+          )
         )
       }
     }
@@ -535,9 +545,11 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     when (bookStatus) {
       is BookStatus.Loaned.LoanedNotDownloaded ->
         this.buttons.addView(
-          this.buttonCreator.createDownloadButton {
-            this.viewModel.borrowMaybeAuthenticated()
-          }
+          this.buttonCreator.createDownloadButton(
+            onClick = {
+              this.viewModel.borrowMaybeAuthenticated()
+            }
+          )
         )
 
       is BookStatus.Loaned.LoanedDownloaded ->
@@ -545,16 +557,20 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
           is BookFormat.BookFormatPDF,
           is BookFormat.BookFormatEPUB -> {
             this.buttons.addView(
-              this.buttonCreator.createReadButton {
-                this.viewModel.openViewer(format)
-              }
+              this.buttonCreator.createReadButton(
+                onClick = {
+                  this.viewModel.openViewer(format)
+                }
+              )
             )
           }
           is BookFormat.BookFormatAudioBook -> {
             this.buttons.addView(
-              this.buttonCreator.createListenButton {
-                this.viewModel.openViewer(format)
-              }
+              this.buttonCreator.createListenButton(
+                onClick = {
+                  this.viewModel.openViewer(format)
+                }
+              )
             )
           }
         }
@@ -563,9 +579,11 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     if (this.viewModel.bookCanBeRevoked && this.buildConfig.allowReturns()) {
       this.buttons.addView(this.buttonCreator.createButtonSpace())
       this.buttons.addView(
-        this.buttonCreator.createRevokeLoanButton {
-          this.viewModel.revokeMaybeAuthenticated()
-        }
+        this.buttonCreator.createRevokeLoanButton(
+          onClick = {
+            this.viewModel.revokeMaybeAuthenticated()
+          }
+        )
       )
     }
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
@@ -75,12 +75,13 @@ class CatalogButtons(
     context: Context,
     text: Int,
     description: Int,
+    heightMatchParent: Boolean = false,
     onClick: (Button) -> Unit
   ): Button {
     val button = AppCompatButton(this.context)
     button.text = context.getString(text)
     button.contentDescription = context.getString(description)
-    button.layoutParams = this.buttonLayoutParameters()
+    button.layoutParams = this.buttonLayoutParameters(heightMatchParent)
     button.setOnClickListener {
       button.isEnabled = false
       onClick.invoke(button)
@@ -182,60 +183,70 @@ class CatalogButtons(
 
   @UiThread
   fun createReadButton(
-    onClick: (Button) -> Unit
+    onClick: (Button) -> Unit,
+    heightMatchParent: Boolean = false
   ): Button {
     return this.createButton(
       context = this.context,
       text = R.string.catalogRead,
       description = R.string.catalogAccessibilityBookRead,
+      heightMatchParent = heightMatchParent,
       onClick = onClick
     )
   }
 
   @UiThread
   fun createListenButton(
-    onClick: (Button) -> Unit
+    onClick: (Button) -> Unit,
+    heightMatchParent: Boolean = false
   ): Button {
     return this.createButton(
       context = this.context,
       text = R.string.catalogListen,
       description = R.string.catalogAccessibilityBookListen,
+      heightMatchParent = heightMatchParent,
       onClick = onClick
     )
   }
 
   @UiThread
   fun createDownloadButton(
-    onClick: (Button) -> Unit
+    onClick: (Button) -> Unit,
+    heightMatchParent: Boolean = false
   ): Button {
     return this.createButton(
       context = this.context,
       text = R.string.catalogDownload,
       description = R.string.catalogAccessibilityBookDownload,
+      heightMatchParent = heightMatchParent,
       onClick = onClick
     )
   }
 
   @UiThread
   fun createRevokeHoldButton(
-    onClick: (Button) -> Unit
+    onClick: (Button) -> Unit,
+    heightMatchParent: Boolean = false
   ): Button {
     return this.createButton(
       context = this.context,
       text = R.string.catalogCancelHold,
       description = R.string.catalogAccessibilityBookRevokeHold,
+      heightMatchParent = heightMatchParent,
       onClick = onClick
     )
   }
 
   @UiThread
   fun createRevokeLoanButton(
-    onClick: (Button) -> Unit
+    onClick: (Button) -> Unit,
+    heightMatchParent: Boolean = false
   ): Button {
     return this.createButton(
       context = this.context,
       text = R.string.catalogReturn,
       description = R.string.catalogAccessibilityBookRevokeLoan,
+      heightMatchParent = heightMatchParent,
       onClick = onClick
     )
   }
@@ -254,24 +265,28 @@ class CatalogButtons(
 
   @UiThread
   fun createReserveButton(
-    onClick: (Button) -> Unit
+    onClick: (Button) -> Unit,
+    heightMatchParent: Boolean = false
   ): Button {
     return this.createButton(
       context = this.context,
       text = R.string.catalogReserve,
       description = R.string.catalogAccessibilityBookReserve,
+      heightMatchParent = heightMatchParent,
       onClick = onClick
     )
   }
 
   @UiThread
   fun createGetButton(
-    onClick: (Button) -> Unit
+    onClick: (Button) -> Unit,
+    heightMatchParent: Boolean = false
   ): Button {
     return this.createButton(
       context = this.context,
       text = R.string.catalogGet,
       description = R.string.catalogAccessibilityBookBorrow,
+      heightMatchParent = heightMatchParent,
       onClick = onClick
     )
   }
@@ -342,10 +357,14 @@ class CatalogButtons(
   }
 
   @UiThread
-  fun buttonLayoutParameters(): LinearLayout.LayoutParams {
+  fun buttonLayoutParameters(heightMatchParent: Boolean = false): LinearLayout.LayoutParams {
     val buttonLayoutParams = LinearLayout.LayoutParams(0, 0)
     buttonLayoutParams.weight = 1.0f
-    buttonLayoutParams.height = LinearLayout.LayoutParams.WRAP_CONTENT
+    buttonLayoutParams.height = if (heightMatchParent) {
+      LinearLayout.LayoutParams.MATCH_PARENT
+    } else {
+      LinearLayout.LayoutParams.WRAP_CONTENT
+    }
     buttonLayoutParams.width = this.screenSizeInformation.dpToPixels(80).toInt()
     return buttonLayoutParams
   }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedArguments.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedArguments.kt
@@ -2,6 +2,7 @@ package org.nypl.simplified.ui.catalog
 
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.feeds.api.FeedBooksSelection
+import org.nypl.simplified.feeds.api.FeedFacet.FeedFacetPseudo.FilteringForStatus.Status
 import org.nypl.simplified.feeds.api.FeedFacet.FeedFacetPseudo.Sorting.SortBy
 import java.io.Serializable
 import java.net.URI
@@ -59,6 +60,7 @@ sealed class CatalogFeedArguments : Serializable {
     override val title: String,
     override val ownership: CatalogFeedOwnership,
     val sortBy: SortBy = SortBy.SORT_BY_TITLE,
+    val filterStatus: Status = Status.ALL,
     val searchTerms: String?,
     val selection: FeedBooksSelection,
     val filterAccount: AccountID?

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -404,7 +404,8 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
       facetTabs = this.feedWithoutGroupsTabs,
       facetLayoutScroller = this.feedWithoutGroupsFacetsScroll,
       facetLayout = this.feedWithoutGroupsFacets,
-      facetsByGroup = feedState.facetsByGroup
+      facetsByGroup = feedState.facetsByGroup,
+      sortFacets = false
     )
     this.configureLogoHeader(feedState)
 
@@ -440,7 +441,8 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
       facetTabs = this.feedWithGroupsTabs,
       facetLayoutScroller = this.feedWithGroupsFacetsScroll,
       facetLayout = this.feedWithGroupsFacets,
-      facetsByGroup = feedState.feed.facetsByGroup
+      facetsByGroup = feedState.feed.facetsByGroup,
+      sortFacets = true
     )
     this.configureLogoHeader(feedState)
 
@@ -646,7 +648,8 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
     facetTabs: RadioGroup,
     facetLayoutScroller: ViewGroup,
     facetLayout: LinearLayout,
-    facetsByGroup: Map<String, List<FeedFacet>>
+    facetsByGroup: Map<String, List<FeedFacet>>,
+    sortFacets: Boolean
   ) {
     /*
      * If the facet groups are empty, hide the header entirely.
@@ -706,7 +709,11 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
         LinearLayout.LayoutParams.MATCH_PARENT
       )
 
-    val sortedNames = remainingGroups.keys.sorted()
+    val sortedNames = if (sortFacets) {
+      remainingGroups.keys.sorted()
+    } else {
+      remainingGroups.keys
+    }
     val context = this.requireContext()
 
     facetLayout.removeAllViews()

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -38,6 +38,7 @@ import org.nypl.simplified.feeds.api.FeedEntry
 import org.nypl.simplified.feeds.api.FeedFacet
 import org.nypl.simplified.feeds.api.FeedFacet.FeedFacetPseudo
 import org.nypl.simplified.feeds.api.FeedFacet.FeedFacetPseudo.FilteringForAccount
+import org.nypl.simplified.feeds.api.FeedFacet.FeedFacetPseudo.FilteringForStatus
 import org.nypl.simplified.feeds.api.FeedFacet.FeedFacetPseudo.Sorting
 import org.nypl.simplified.feeds.api.FeedFacetPseudoTitleProviderType
 import org.nypl.simplified.feeds.api.FeedLoaderResult
@@ -333,6 +334,7 @@ class CatalogFeedViewModel(
         filterByAccountID = arguments.filterAccount,
         search = arguments.searchTerms,
         sortBy = arguments.sortBy,
+        filterStatus = arguments.filterStatus,
         title = arguments.title,
         uri = booksUri
       )
@@ -578,6 +580,12 @@ class CatalogFeedViewModel(
       get() = this.resources.getString(R.string.feedCollectionAll)
     override val sortBy: String
       get() = this.resources.getString(R.string.feedSortBy)
+    override val show: String
+      get() = "Show"
+    override val showAll: String
+      get() = "All"
+    override val showOnLoan: String
+      get() = "On Loan"
   }
 
   val accountProvider: AccountProviderType?
@@ -849,8 +857,20 @@ class CatalogFeedViewModel(
               searchTerms = currentArguments.searchTerms,
               selection = currentArguments.selection,
               sortBy = facet.sortBy,
+              filterStatus = currentArguments.filterStatus,
               title = facet.title
             )
+
+          is FilteringForStatus -> {
+            CatalogFeedArgumentsLocalBooks(
+              filterAccount = currentArguments.filterAccount,
+              ownership = currentArguments.ownership,
+              searchTerms = currentArguments.searchTerms,
+              selection = currentArguments.selection,
+              filterStatus = facet.filterStatus,
+              title = currentArguments.title
+            )
+          }
 
           is FilteringForAccount ->
             CatalogFeedArgumentsLocalBooks(
@@ -859,6 +879,7 @@ class CatalogFeedViewModel(
               searchTerms = currentArguments.searchTerms,
               selection = currentArguments.selection,
               sortBy = currentArguments.sortBy,
+              filterStatus = currentArguments.filterStatus,
               title = facet.title
             )
         }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -285,12 +285,26 @@ class CatalogPagedViewHolder(
           this.listener.borrowMaybeAuthenticated(book)
         }
       } else {
-        this.buttonCreator.createDownloadButton {
-          this.listener.borrowMaybeAuthenticated(book)
-        }
+        this.buttonCreator.createDownloadButton(
+          onClick = {
+            this.listener.borrowMaybeAuthenticated(book)
+          },
+          heightMatchParent = true
+        )
       }
     )
-    this.idleButtons.addView(this.buttonCreator.createButtonSizedSpace())
+    this.idleButtons.addView(
+      this.buttonCreator.createButtonSpace()
+    )
+
+    this.idleButtons.addView(
+      this.buttonCreator.createRevokeLoanButton(
+        onClick = {
+          this.listener.revokeMaybeAuthenticated(book)
+        },
+        heightMatchParent = true
+      )
+    )
   }
 
   private fun onBookStatusLoanable(book: Book) {
@@ -301,9 +315,11 @@ class CatalogPagedViewHolder(
 
     this.idleButtons.removeAllViews()
     this.idleButtons.addView(
-      this.buttonCreator.createGetButton {
-        this.listener.borrowMaybeAuthenticated(book)
-      }
+      this.buttonCreator.createGetButton(
+        onClick = {
+          this.listener.borrowMaybeAuthenticated(book)
+        }
+      )
     )
     this.idleButtons.addView(this.buttonCreator.createButtonSizedSpace())
     this.idleButtons.addView(this.buttonCreator.createButtonSizedSpace())
@@ -317,9 +333,11 @@ class CatalogPagedViewHolder(
 
     this.idleButtons.removeAllViews()
     this.idleButtons.addView(
-      this.buttonCreator.createReserveButton {
-        this.listener.reserveMaybeAuthenticated(book)
-      }
+      this.buttonCreator.createReserveButton(
+        onClick = {
+          this.listener.reserveMaybeAuthenticated(book)
+        }
+      )
     )
     this.idleButtons.addView(this.buttonCreator.createButtonSizedSpace())
     this.idleButtons.addView(this.buttonCreator.createButtonSizedSpace())
@@ -337,15 +355,19 @@ class CatalogPagedViewHolder(
     this.idleButtons.removeAllViews()
     if (status.isRevocable) {
       this.idleButtons.addView(
-        this.buttonCreator.createRevokeHoldButton {
-          this.listener.revokeMaybeAuthenticated(book)
-        }
+        this.buttonCreator.createRevokeHoldButton(
+          onClick = {
+            this.listener.revokeMaybeAuthenticated(book)
+          }
+        )
       )
     }
     this.idleButtons.addView(
-      this.buttonCreator.createGetButton {
-        this.listener.borrowMaybeAuthenticated(book)
-      }
+      this.buttonCreator.createGetButton(
+        onClick = {
+          this.listener.borrowMaybeAuthenticated(book)
+        }
+      )
     )
   }
 
@@ -361,9 +383,11 @@ class CatalogPagedViewHolder(
     this.idleButtons.removeAllViews()
     if (status.isRevocable) {
       this.idleButtons.addView(
-        this.buttonCreator.createRevokeHoldButton {
-          this.listener.revokeMaybeAuthenticated(book)
-        }
+        this.buttonCreator.createRevokeHoldButton(
+          onClick = {
+            this.listener.revokeMaybeAuthenticated(book)
+          }
+        )
       )
       this.idleButtons.addView(this.buttonCreator.createButtonSizedSpace())
       this.idleButtons.addView(this.buttonCreator.createButtonSizedSpace())
@@ -392,9 +416,12 @@ class CatalogPagedViewHolder(
               this.listener.openViewer(book, format)
             }
           } else {
-            this.buttonCreator.createReadButton {
-              this.listener.openViewer(book, format)
-            }
+            this.buttonCreator.createReadButton(
+              onClick = {
+                this.listener.openViewer(book, format)
+              },
+              heightMatchParent = true
+            )
           }
         )
       }
@@ -406,9 +433,12 @@ class CatalogPagedViewHolder(
               this.listener.openViewer(book, format)
             }
           } else {
-            this.buttonCreator.createListenButton {
-              this.listener.openViewer(book, format)
-            }
+            this.buttonCreator.createListenButton(
+              onClick = {
+                this.listener.openViewer(book, format)
+              },
+              heightMatchParent = true
+            )
           }
         )
       }
@@ -416,9 +446,18 @@ class CatalogPagedViewHolder(
         this.idleButtons.addView(this.buttonCreator.createButtonSizedSpace())
       }
     }
+    this.idleButtons.addView(
+      this.buttonCreator.createButtonSpace()
+    )
 
-    this.idleButtons.addView(this.buttonCreator.createButtonSizedSpace())
-    this.idleButtons.addView(this.buttonCreator.createButtonSizedSpace())
+    this.idleButtons.addView(
+      this.buttonCreator.createRevokeLoanButton(
+        onClick = {
+          this.listener.revokeMaybeAuthenticated(book)
+        },
+        heightMatchParent = true
+      )
+    )
   }
 
   @Suppress("UNUSED_PARAMETER")

--- a/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_cell_idle.xml
@@ -1,128 +1,129 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:id="@+id/bookCellIdle"
-  android:layout_width="match_parent"
-  android:layout_height="@dimen/catalogFeedCellHeight">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/bookCellIdle"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/catalogFeedCellHeight">
 
-  <ImageView
-    android:id="@+id/bookCellIdleCover"
-    android:layout_width="@dimen/catalogFeedCellImageWidth"
-    android:layout_height="@dimen/catalogFeedCellHeight"
-    android:layout_marginStart="16dp"
-    android:contentDescription="@null"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+    <ImageView
+        android:id="@+id/bookCellIdleCover"
+        android:layout_width="@dimen/catalogFeedCellImageWidth"
+        android:layout_height="@dimen/catalogFeedCellHeight"
+        android:layout_marginStart="16dp"
+        android:contentDescription="@null"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-  <ProgressBar
-    android:id="@+id/bookCellIdleCoverProgress"
-    style="?android:attr/progressBarStyle"
-    android:layout_width="32dp"
-    android:layout_height="32dp"
-    app:layout_constraintBottom_toBottomOf="@id/bookCellIdleCover"
-    app:layout_constraintEnd_toEndOf="@id/bookCellIdleCover"
-    app:layout_constraintStart_toStartOf="@id/bookCellIdleCover"
-    app:layout_constraintTop_toTopOf="@id/bookCellIdleCover" />
+    <ProgressBar
+        android:id="@+id/bookCellIdleCoverProgress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        app:layout_constraintBottom_toBottomOf="@id/bookCellIdleCover"
+        app:layout_constraintEnd_toEndOf="@id/bookCellIdleCover"
+        app:layout_constraintStart_toStartOf="@id/bookCellIdleCover"
+        app:layout_constraintTop_toTopOf="@id/bookCellIdleCover" />
 
-  <TextView
-    android:id="@+id/bookCellIdleTitle"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="16dp"
-    android:layout_marginEnd="16dp"
-    android:layout_marginTop="8dp"
-    android:ellipsize="end"
-    android:maxLines="1"
-    android:textSize="16sp"
-    android:textStyle="bold"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
-    app:layout_constraintTop_toTopOf="parent"
-    tools:text="The Modern Prometheus" />
+    <TextView
+        android:id="@+id/bookCellIdleTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="The Modern Prometheus" />
 
-  <TextView
-    android:id="@+id/bookCellIdleAuthor"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="16dp"
-    android:layout_marginEnd="16dp"
-    android:ellipsize="end"
-    android:maxLines="1"
-    android:textSize="14sp"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
-    app:layout_constraintTop_toBottomOf="@id/bookCellIdleTitle"
-    tools:text="Mary Shelley" />
+    <TextView
+        android:id="@+id/bookCellIdleAuthor"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
+        app:layout_constraintTop_toBottomOf="@id/bookCellIdleTitle"
+        tools:text="Mary Shelley" />
 
-  <TextView
-    android:id="@+id/bookCellIdleMeta"
-    android:layout_width="0dp"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="16dp"
-    android:layout_marginEnd="16dp"
-    android:ellipsize="end"
-    android:maxLines="1"
-    android:textSize="12sp"
-    android:textStyle="italic"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
-    app:layout_constraintTop_toBottomOf="@id/bookCellIdleAuthor"
-    tools:text="eBook - The New York Public Library" />
+    <TextView
+        android:id="@+id/bookCellIdleMeta"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textSize="12sp"
+        android:textStyle="italic"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
+        app:layout_constraintTop_toBottomOf="@id/bookCellIdleAuthor"
+        tools:text="eBook - The New York Public Library" />
 
-  <LinearLayout
-    android:id="@+id/bookCellIdleButtons"
-    android:layout_width="0dp"
-    android:layout_height="@dimen/catalogFeedCellButtonsHeight"
-    android:layout_marginStart="16dp"
-    android:layout_marginEnd="16dp"
-    android:layout_marginBottom="8dp"
-    android:orientation="horizontal"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toEndOf="@id/bookCellIdleCover"
-    app:layout_constraintBottom_toBottomOf="parent">
+    <LinearLayout
+        android:id="@+id/bookCellIdleButtons"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/catalogFeedCellButtonsHeight"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/bookCellIdleCover">
 
-    <!-- These views are removed at runtime and are just present for the sake of the UI editor preview -->
+        <!-- These views are removed at runtime and are just present for the sake of the UI editor preview -->
 
-    <Button
-      android:layout_width="0dp"
-      android:layout_height="@dimen/catalogFeedCellButtonsHeight"
-      android:layout_weight="1"
-      android:maxWidth="64dp"
-      android:visibility="gone"
-      tools:text="@string/catalogDismiss"
-      tools:visibility="visible" />
+        <Button
+            android:layout_width="0dp"
+            android:layout_height="@dimen/catalogFeedCellButtonsHeight"
+            android:layout_weight="1"
+            android:maxWidth="64dp"
+            android:visibility="gone"
+            tools:text="@string/catalogDismiss"
+            tools:visibility="visible" />
 
-    <Space
-      android:layout_width="16dp"
-      android:layout_height="wrap_content"
-      android:visibility="gone"
-      tools:visibility="visible" />
+        <Space
+            android:layout_width="16dp"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
-    <Button
-      android:layout_width="0dp"
-      android:layout_height="@dimen/catalogFeedCellButtonsHeight"
-      android:layout_weight="1"
-      android:maxWidth="64dp"
-      android:visibility="gone"
-      tools:text="@string/catalogDetails"
-      tools:visibility="visible" />
+        <Button
+            android:layout_width="0dp"
+            android:layout_height="@dimen/catalogFeedCellButtonsHeight"
+            android:layout_weight="1"
+            android:maxWidth="64dp"
+            android:visibility="gone"
+            tools:text="@string/catalogDetails"
+            tools:visibility="visible" />
 
-    <Space
-      android:layout_width="16dp"
-      android:layout_height="wrap_content"
-      android:visibility="gone"
-      tools:visibility="visible" />
+        <Space
+            android:layout_width="16dp"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
-    <Button
-      android:layout_width="0dp"
-      android:layout_height="@dimen/catalogFeedCellButtonsHeight"
-      android:layout_weight="1"
-      android:maxWidth="64dp"
-      android:visibility="gone"
-      tools:text="@string/catalogRetry"
-      tools:visibility="visible" />
-  </LinearLayout>
+        <Button
+            android:layout_width="0dp"
+            android:layout_height="@dimen/catalogFeedCellButtonsHeight"
+            android:layout_weight="1"
+            android:maxWidth="64dp"
+            android:visibility="gone"
+            tools:text="@string/catalogRetry"
+            tools:visibility="visible" />
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/BottomNavigators.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/BottomNavigators.kt
@@ -242,6 +242,7 @@ object BottomNavigators {
         searchTerms = null,
         selection = FeedBooksSelection.BOOKS_FEED_LOANED,
         sortBy = FeedFacet.FeedFacetPseudo.Sorting.SortBy.SORT_BY_TITLE,
+        filterStatus = FeedFacet.FeedFacetPseudo.FilteringForStatus.Status.ALL,
         title = context.getString(R.string.tabBooks)
       )
     )

--- a/simplified-ui-navigation-tabs/src/main/res/values/strings.xml
+++ b/simplified-ui-navigation-tabs/src/main/res/values/strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <resources>
-  <string name="tabBooks">Books</string>
+  <string name="tabBooks">My Books</string>
   <string name="tabCatalog">Catalog</string>
-  <string name="tabHolds">Holds</string>
+  <string name="tabHolds">Reservations</string>
   <string name="tabProfile">Profile</string>
   <string name="tabSettings">Settings</string>
 </resources>


### PR DESCRIPTION
**What's this do?**
This PR changes the text of two of the tabs ("Books" is now "My Books" and "Holds" is now "Reservations"). It also adds a return button to the right of a book action ("Read" / "Download" / "Listen") in the user's bookshelf.
Finally, the PR also adds a button to the right of the "Sort By" option in the "My Books" tab with a label "Show" that filters the existing books by loaned or all.

**Why are we doing this? (w/ JIRA link if applicable)**
There were some details that the iOS version had differently from the Android one and we needed to make the app more coherent between the two versions. The changes in this PR come after reporting this [task](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=32b300218b974ecdb2054533a8b4a6d2&p=b8b3bd4937344fd9a3788098a246c740).

**How should this be tested? / Do these changes have associated tests?**
By opening the app and select the LYRASIS library, it's possible to see the new tab names in the bottom bar.
Then, select the "My Books" tab and if you have any books you'll see a ["Return" button right next to the book's action button](https://user-images.githubusercontent.com/79104027/136039493-ccad4e0f-c879-428a-8898-1def7be86f2a.png).
At the top of the screen, it's possible to see the "Show" label that [shows a dialog](https://user-images.githubusercontent.com/79104027/136039588-cf1925a2-9813-4505-a3fd-879a7374ea28.png) with the existing options and filters the catalog with the user's selected option

**Dependencies for merging? Releasing to production?**
n/a

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 