### PR TITLE
Added screen orientation value to manifest

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -50,7 +50,7 @@
         <c:change date="2021-09-10T00:00:00+00:00" summary="Introduced a new color scheme for the application."/>
       </c:changes>
     </c:release>
-    <c:release date="2021-10-12T18:43:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
+    <c:release date="2021-10-15T23:37:01+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
       <c:changes>
         <c:change date="2021-07-14T00:00:00+00:00" summary="Improve fixed-layout EPUB handling.">
           <c:tickets>
@@ -104,7 +104,8 @@
         <c:change date="2021-10-06T00:00:00+00:00" summary="Add 'Show' button to filter My Books by loan status"/>
         <c:change date="2021-10-07T00:00:00+00:00" summary="Always show progress bar when reading a book"/>
         <c:change date="2021-10-07T00:00:00+00:00" summary="Prevent page size from changing when the reader toolbar is shown and hidden"/>
-        <c:change date="2021-10-12T18:43:38+00:00" summary="Updated libraries logo loading to be asynchronous"/>
+        <c:change date="2021-10-12T00:00:00+00:00" summary="Updated libraries logo loading to be asynchronous"/>
+        <c:change date="2021-10-15T23:37:01+00:00" summary="Added portrait screen orientation to AudioBookActivity on manifest"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-vanilla/src/main/AndroidManifest.xml
+++ b/simplified-app-vanilla/src/main/AndroidManifest.xml
@@ -71,6 +71,7 @@
 
     <activity
       android:name="org.nypl.simplified.viewer.audiobook.AudioBookPlayerActivity"
+      android:screenOrientation="portrait"
       android:exported="false" />
 
     <activity


### PR DESCRIPTION
**What's this do?**
This PR adds a flag to the AudioBookActivity's declaration on the AndroidManifest file to prevent its contents to rotate when the user rotates the mobile phone.

**Why are we doing this? (w/ JIRA link if applicable)**
This change was made in order to prevent the audiobook from being automatically paused when the user rotated the screen. This behavior was reported [here](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=c5596de5b57d4027bf2984acfa70f930&p=3db59b210b394b769403e13140b5b2ce)

**How should this be tested? / Do these changes have associated tests?**
Open an audiobook
Click to play the audiobook
Rotate the screen
Confirm the audiobook is still being played

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 