### PR TITLE
Use palace's r2 libs instead of nypl's.

### DIFF
--- a/simplified-viewer-epub-readium2/build.gradle
+++ b/simplified-viewer-epub-readium2/build.gradle
@@ -14,7 +14,7 @@ dependencies {
   implementation libs.androidx.lifecycle.viewmodel
   implementation libs.kotlin.stdlib
   implementation libs.kotlin.reflect
-  implementation libs.nypl.readium2.api
-  implementation libs.nypl.readium2.vanilla
-  implementation libs.nypl.readium2.views
+  implementation libs.palace.readium2.api
+  implementation libs.palace.readium2.vanilla
+  implementation libs.palace.readium2.views
 }


### PR DESCRIPTION
**What's this do?**

Uses the Readium2 libraries from ThePalaceProject instead of NYPL.

**Why are we doing this? (w/ JIRA link if applicable)**

#45 caused the epub reader to use NYPL's r2 libraries instead of ours.

**How should this be tested? / Do these changes have associated tests?**

Read an epub book. The toolbar should have a back button, and the order of buttons should be TOC, Settings, Bookmarks. Also, the page should not reflow when the toolbar is toggled.

**Dependencies for merging? Releasing to production?**

n/a

**Have you updated the changelog?**

No, this bug was introduced since the last release.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee read some epubs.
