### PR TITLE
Fix audiobook stop playing after rotation

### DIFF
--- a/simplified-app-openebooks/src/main/AndroidManifest.xml
+++ b/simplified-app-openebooks/src/main/AndroidManifest.xml
@@ -76,6 +76,7 @@
         <activity
             android:name="org.nypl.simplified.viewer.audiobook.AudioBookPlayerActivity"
             android:contentDescription="@string/appName"
+            android:screenOrientation="portrait"
             android:exported="false"
             android:label="@string/appName" />
 

--- a/simplified-app-palace/src/main/AndroidManifest.xml
+++ b/simplified-app-palace/src/main/AndroidManifest.xml
@@ -72,6 +72,7 @@
       android:name="org.nypl.simplified.viewer.audiobook.AudioBookPlayerActivity"
       android:contentDescription="@string/app_name"
       android:exported="false"
+      android:screenOrientation="portrait"
       android:label="@string/app_name" />
 
     <activity

--- a/simplified-app-simplye/src/main/AndroidManifest.xml
+++ b/simplified-app-simplye/src/main/AndroidManifest.xml
@@ -72,6 +72,7 @@
       android:name="org.nypl.simplified.viewer.audiobook.AudioBookPlayerActivity"
       android:contentDescription="@string/appName"
       android:exported="false"
+      android:screenOrientation="portrait"
       android:label="@string/appName" />
 
     <activity


### PR DESCRIPTION
**What's this do?**
This PR adds a flag to the AudioBookActivity's declaration to the remaining AndroidManifest files where the activity was declared

**Why are we doing this? (w/ JIRA link if applicable)**
This change was made because there were reports of the audiobook being automatically paused when the user rotated the screen. This reincidence was reported [here](https://www.notion.so/lyrasis/Audiobook-playback-stops-when-screen-orientation-is-changed-3db59b210b394b769403e13140b5b2ce)

**How should this be tested? / Do these changes have associated tests?**
Open an audiobook
Click to play the audiobook
Rotate the screen
Confirm the audiobook is still being played

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 