### PR TITLE
Fixed crash when tapping to enable debug options

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -50,7 +50,7 @@
         <c:change date="2021-09-10T00:00:00+00:00" summary="Introduced a new color scheme for the application."/>
       </c:changes>
     </c:release>
-    <c:release date="2021-10-20T11:10:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
+    <c:release date="2021-10-21T13:52:11+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
       <c:changes>
         <c:change date="2021-07-14T00:00:00+00:00" summary="Improve fixed-layout EPUB handling.">
           <c:tickets>
@@ -106,7 +106,8 @@
         <c:change date="2021-10-07T00:00:00+00:00" summary="Prevent page size from changing when the reader toolbar is shown and hidden"/>
         <c:change date="2021-10-12T00:00:00+00:00" summary="Updated libraries logo loading to be asynchronous"/>
         <c:change date="2021-10-15T00:00:00+00:00" summary="Added portrait screen orientation to AudioBookActivity on manifest"/>
-        <c:change date="2021-10-20T11:10:38+00:00" summary="Adjusted catalog buttons dimension to prevent weird UI displaying"/>
+        <c:change date="2021-10-20T00:00:00+00:00" summary="Adjusted catalog buttons dimension to prevent weird UI displaying"/>
+        <c:change date="2021-10-21T13:52:11+00:00" summary="Fixed crash when tapping to enable debug options"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsMainFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsMainFragment.kt
@@ -1,7 +1,6 @@
 package org.nypl.simplified.ui.settings
 
 import android.os.Bundle
-import android.view.Gravity
 import android.view.View
 import android.widget.Toast
 import androidx.fragment.app.viewModels
@@ -273,16 +272,9 @@ class SettingsMainFragment : PreferenceFragmentCompat() {
         val message =
           context.getString(R.string.settingsTapToDebug, this.tapToDebugSettings)
 
-        val toast =
-          this.toast ?: Toast.makeText(context, message, Toast.LENGTH_LONG)
-
-        this.toast = toast.apply {
-          this.setText(message)
-          if (!this.view!!.isShown) {
-            this.setGravity(Gravity.CENTER_HORIZONTAL or Gravity.CENTER_VERTICAL, 0, 0)
-            this.show()
-          }
-        }
+        this.toast?.cancel()
+        this.toast = Toast.makeText(context, message, Toast.LENGTH_LONG)
+        this.toast?.show()
       }
       this.tapToDebugSettings -= 1
     }


### PR DESCRIPTION
**What's this do?**
This PR changes the logic of displaying a toast message when the user taps on the commit version in the settings screen. Now it just cancels an existing toast, updates its message and shows it again.

**Why are we doing this? (w/ JIRA link if applicable)**
There was a crash happening on some devices [when tapping on the commit version](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=32b300218b974ecdb2054533a8b4a6d2&p=c861f8f8807b46f58fc84a4e7381dd11) in the settings screen to enable the debug options

**How should this be tested? / Do these changes have associated tests?**
Open the app
Go to the settings screen
Tap several times on the commit version and see the messages being displayed until the debug options are finally enabled

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 