### PR TITLE
Fixed "Send report" button not performing any action

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -50,7 +50,7 @@
         <c:change date="2021-09-10T00:00:00+00:00" summary="Introduced a new color scheme for the application."/>
       </c:changes>
     </c:release>
-    <c:release date="2021-10-25T10:51:15+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
+    <c:release date="2021-10-26T21:54:28+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
       <c:changes>
         <c:change date="2021-07-14T00:00:00+00:00" summary="Improve fixed-layout EPUB handling.">
           <c:tickets>
@@ -108,11 +108,12 @@
         <c:change date="2021-10-15T00:00:00+00:00" summary="Added portrait screen orientation to AudioBookActivity on manifest"/>
         <c:change date="2021-10-20T00:00:00+00:00" summary="Adjusted catalog buttons dimension to prevent weird UI displaying"/>
         <c:change date="2021-10-21T00:00:00+00:00" summary="Fixed crash when tapping to enable debug options"/>
-        <c:change date="2021-10-23T23:41:43+00:00" summary="Added back button to the Audiobook details screen"/>
+        <c:change date="2021-10-23T00:00:00+00:00" summary="Added back button to the Audiobook details screen"/>
         <c:change date="2021-10-25T00:00:00+00:00" summary="Changed &quot;switch library&quot; language to &quot;find your library&quot;"/>
         <c:change date="2021-10-25T00:00:00+00:00" summary="Implemented swipe-to-refresh in catalog feeds"/>
         <c:change date="2021-10-25T00:00:00+00:00" summary="Correctly use Open Sans in the toolbar"/>
-        <c:change date="2021-10-25T10:51:15+00:00" summary="Library logos are now clickable links"/>
+        <c:change date="2021-10-25T00:00:00+00:00" summary="Library logos are now clickable links"/>
+        <c:change date="2021-10-26T21:54:28+00:00" summary="Fixed send report button not opening the action options"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-reports/src/main/java/org/nypl/simplified/reports/Reports.kt
+++ b/simplified-reports/src/main/java/org/nypl/simplified/reports/Reports.kt
@@ -115,6 +115,7 @@ object Reports {
           this.putExtra(Intent.EXTRA_TEXT, extendBody(body))
           this.putExtra(Intent.EXTRA_STREAM, ArrayList(contentUris))
           this.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+          this.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
         context.startActivity(intent)
         Sent


### PR DESCRIPTION
**What's this do?**
This PR adds a flag to the intent that launches the sharing options for the logs when the user presses the "Send Report" button or the "Send Error Logs" option in the Debug settings.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [reported bug](https://www.notion.so/lyrasis/Send-Error-Logs-button-not-working-98239079523d4244b645bb17b442e529) that describes the issue: the user presses the "Send Error Logs" button and nothing happens.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Go to settings
If the Debug Options are not enabled, tap 7 times on the commit version option
Open Debug Options
Press the "Send Error Logs" and verify the sharing options [are being displayed](https://user-images.githubusercontent.com/79104027/138967484-296e242d-3f0c-4e1b-80c7-64f2d72baa40.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 