### PR TITLE
Implement an accounts graveyard

### DIFF
--- a/simplified-accounts-database-api/src/main/java/org/nypl/simplified/accounts/database/api/AccountsDatabaseFactoryType.kt
+++ b/simplified-accounts-database-api/src/main/java/org/nypl/simplified/accounts/database/api/AccountsDatabaseFactoryType.kt
@@ -24,6 +24,7 @@ interface AccountsDatabaseFactoryType {
    * @param bookFormatSupport The book format support information
    * @param accountAuthenticationCredentialsStore The credentials store
    * @param directory The directory
+   * @param directoryGraveyard The graveyard directory for broken accounts
    * @return A profile database
    * @throws AccountsDatabaseException If any errors occurred whilst trying to open the database
    */
@@ -36,7 +37,8 @@ interface AccountsDatabaseFactoryType {
     bookDatabases: BookDatabaseFactoryType,
     bookFormatSupport: BookFormatSupportType,
     context: Context,
-    directory: File
+    directory: File,
+    directoryGraveyard: File
   ): AccountsDatabaseType
 
   /**
@@ -47,6 +49,7 @@ interface AccountsDatabaseFactoryType {
    * @param accountAuthenticationCredentialsStore The credentials store
    * @param bookFormatSupport The book format support information
    * @param directory The directory
+   * @param directoryGraveyard The graveyard directory for broken accounts
    * @return A profile database
    * @throws AccountsDatabaseException If any errors occurred whilst trying to open the database
    */
@@ -58,6 +61,7 @@ interface AccountsDatabaseFactoryType {
     accountProviders: AccountProviderRegistryType,
     bookFormatSupport: BookFormatSupportType,
     context: Context,
-    directory: File
+    directory: File,
+    directoryGraveyard: File
   ): AccountsDatabaseType
 }

--- a/simplified-accounts-database/src/main/java/org/nypl/simplified/accounts/database/AccountsDatabases.kt
+++ b/simplified-accounts-database/src/main/java/org/nypl/simplified/accounts/database/AccountsDatabases.kt
@@ -27,7 +27,8 @@ object AccountsDatabases : AccountsDatabaseFactoryType {
     bookDatabases: BookDatabaseFactoryType,
     bookFormatSupport: BookFormatSupportType,
     context: Context,
-    directory: File
+    directory: File,
+    directoryGraveyard: File
   ): AccountsDatabaseType {
     return AccountsDatabase.open(
       context = context,
@@ -36,7 +37,8 @@ object AccountsDatabases : AccountsDatabaseFactoryType {
       bookFormatSupport = bookFormatSupport,
       accountCredentials = accountAuthenticationCredentialsStore,
       accountProviders = accountProviders,
-      directory = directory
+      directory = directory,
+      directoryGraveyard = directoryGraveyard
     )
   }
 
@@ -47,7 +49,8 @@ object AccountsDatabases : AccountsDatabaseFactoryType {
     accountProviders: AccountProviderRegistryType,
     bookFormatSupport: BookFormatSupportType,
     context: Context,
-    directory: File
+    directory: File,
+    directoryGraveyard: File
   ): AccountsDatabaseType {
     return AccountsDatabase.open(
       context = context,
@@ -56,7 +59,8 @@ object AccountsDatabases : AccountsDatabaseFactoryType {
       bookFormatSupport = bookFormatSupport,
       accountCredentials = accountAuthenticationCredentialsStore,
       accountProviders = accountProviders,
-      directory = directory
+      directory = directory,
+      directoryGraveyard = directoryGraveyard
     )
   }
 }

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
@@ -355,7 +355,10 @@ object ProfilesDatabases {
       return null
     }
 
-    val profileAccountsDir = File(profileDir, "accounts")
+    val profileAccountsDir =
+      File(profileDir, "accounts")
+    val profileAccountsGraveyardDir =
+      File(profileDir, "accounts-graveyard")
 
     val accountsDatabase: AccountsDatabaseType =
       try {
@@ -366,7 +369,8 @@ object ProfilesDatabases {
             accountProviders = accountProviders,
             bookFormatSupport = bookFormatSupport,
             context = context,
-            directory = profileAccountsDir
+            directory = profileAccountsDir,
+            directoryGraveyard = profileAccountsGraveyardDir
           )
 
         this.createAutomaticAccounts(
@@ -456,6 +460,8 @@ object ProfilesDatabases {
         File(directory, id.uuid.toString())
       val profileAccountsDir =
         File(profileDir, "accounts")
+      val profileAccountsGraveyardDir =
+        File(profileDir, "accounts-graveyard")
 
       try {
         val accounts =
@@ -465,7 +471,8 @@ object ProfilesDatabases {
             accountProviders = accountProviders,
             bookFormatSupport = bookFormatSupport,
             context = context,
-            directory = profileAccountsDir
+            directory = profileAccountsDir,
+            directoryGraveyard = profileAccountsGraveyardDir
           )
 
         this.createAutomaticAccounts(

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountsDatabaseContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountsDatabaseContract.kt
@@ -90,18 +90,20 @@ abstract class AccountsDatabaseContract {
     val f_p = File(fileProfiles, "0")
     f_p.mkdirs()
     val f_acc = File(f_p, "accounts")
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
 
     FileUtilities.fileWriteUTF8(f_acc, "Hello!")
 
     val ex = Assertions.assertThrows(AccountsDatabaseException::class.java) {
       AccountsDatabase.open(
-        this.context(),
-        this.accountEvents,
-        this.bookDatabases(),
-        BookFormatsTesting.supportsEverything,
-        this.credentialStore,
-        this.accountProviders,
-        f_acc
+        context = this.context(),
+        accountEvents = this.accountEvents,
+        bookDatabases = this.bookDatabases(),
+        bookFormatSupport = BookFormatsTesting.supportsEverything,
+        accountCredentials = this.credentialStore,
+        accountProviders = this.accountProviders,
+        directory = f_acc,
+        directoryGraveyard = fAccGraveyard
       )
     }
 
@@ -137,18 +139,23 @@ abstract class AccountsDatabaseContract {
     f_p.mkdirs()
     val f_acc = File(f_p, "accounts")
     f_acc.mkdirs()
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
+    fAccGraveyard.mkdirs()
     val f_a = File(f_acc, "xyz")
     f_a.mkdirs()
 
+    Assertions.assertEquals(0, fAccGraveyard.list()!!.size)
+
     val ex = Assertions.assertThrows(AccountsDatabaseException::class.java) {
       val database = AccountsDatabase.open(
-        this.context(),
-        this.accountEvents,
-        this.bookDatabases(),
-        BookFormatsTesting.supportsEverything,
-        this.credentialStore,
-        this.accountProviders,
-        f_acc
+        context = this.context(),
+        accountEvents = this.accountEvents,
+        bookDatabases = this.bookDatabases(),
+        bookFormatSupport = BookFormatsTesting.supportsEverything,
+        accountCredentials = this.credentialStore,
+        accountProviders = this.accountProviders,
+        directory = f_acc,
+        directoryGraveyard = fAccGraveyard
       )
     }
 
@@ -157,6 +164,8 @@ abstract class AccountsDatabaseContract {
         .filterIsInstance<IOException>()
         .find { ex -> ex.message!!.contains("Could not parse account: ") }
     Assertions.assertTrue(causes != null)
+
+    Assertions.assertEquals(1, fAccGraveyard.list()!!.size)
   }
 
   @Test
@@ -171,16 +180,18 @@ abstract class AccountsDatabaseContract {
     f_acc.mkdirs()
     val f_a = File(f_acc, "64e606e8-e242-4c5f-9bfb-63df11b187bd")
     f_a.mkdirs()
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
 
     val ex = Assertions.assertThrows(AccountsDatabaseException::class.java) {
       AccountsDatabase.open(
-        this.context(),
-        this.accountEvents,
-        this.bookDatabases(),
-        BookFormatsTesting.supportsEverything,
-        this.credentialStore,
-        this.accountProviders,
-        f_acc
+        context = this.context(),
+        accountEvents = this.accountEvents,
+        bookDatabases = this.bookDatabases(),
+        bookFormatSupport = BookFormatsTesting.supportsEverything,
+        accountCredentials = this.credentialStore,
+        accountProviders = this.accountProviders,
+        directory = f_acc,
+        directoryGraveyard = fAccGraveyard
       )
     }
 
@@ -203,19 +214,24 @@ abstract class AccountsDatabaseContract {
     f_acc.mkdirs()
     val f_a = File(f_acc, "0")
     f_a.mkdirs()
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
+    fAccGraveyard.mkdirs()
 
     val f_f = File(f_a, "account.json")
     FileUtilities.fileWriteUTF8(f_f, "} { this is not JSON { } { }")
 
+    Assertions.assertEquals(0, fAccGraveyard.list()!!.size)
+
     val ex = Assertions.assertThrows(AccountsDatabaseException::class.java) {
       AccountsDatabase.open(
-        this.context(),
-        this.accountEvents,
-        this.bookDatabases(),
-        BookFormatsTesting.supportsEverything,
-        this.credentialStore,
-        this.accountProviders,
-        f_acc
+        context = this.context(),
+        accountEvents = this.accountEvents,
+        bookDatabases = this.bookDatabases(),
+        bookFormatSupport = BookFormatsTesting.supportsEverything,
+        accountCredentials = this.credentialStore,
+        accountProviders = this.accountProviders,
+        directory = f_acc,
+        directoryGraveyard = fAccGraveyard
       )
     }
 
@@ -224,6 +240,8 @@ abstract class AccountsDatabaseContract {
         .filterIsInstance<IOException>()
         .find { ex -> ex.message!!.contains("Could not parse account: ") }
     Assertions.assertTrue(causes != null)
+
+    Assertions.assertEquals(1, fAccGraveyard.list()!!.size)
   }
 
   @Test
@@ -235,15 +253,17 @@ abstract class AccountsDatabaseContract {
     val f_p = File(fileProfiles, "0")
     f_p.mkdirs()
     val f_acc = File(f_p, "accounts")
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
 
     val db = AccountsDatabase.open(
-      this.context(),
-      this.accountEvents,
-      this.bookDatabases(),
-      BookFormatsTesting.supportsEverything,
-      this.credentialStore,
-      this.accountProviders,
-      f_acc
+      context = this.context(),
+      accountEvents = this.accountEvents,
+      bookDatabases = this.bookDatabases(),
+      bookFormatSupport = BookFormatsTesting.supportsEverything,
+      accountCredentials = this.credentialStore,
+      accountProviders = this.accountProviders,
+      directory = f_acc,
+      directoryGraveyard = fAccGraveyard
     )
 
     Assertions.assertEquals(0, db.accounts().size.toLong())
@@ -259,18 +279,20 @@ abstract class AccountsDatabaseContract {
     val f_p = File(fileProfiles, "0")
     f_p.mkdirs()
     val f_acc = File(f_p, "accounts")
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
 
     val accountProviders =
       MockAccountProviders.fakeAccountProviders()
 
     val db = AccountsDatabase.open(
-      this.context(),
-      this.accountEvents,
-      this.bookDatabases(),
-      BookFormatsTesting.supportsEverything,
-      this.credentialStore,
-      this.accountProviders,
-      f_acc
+      context = this.context(),
+      accountEvents = this.accountEvents,
+      bookDatabases = this.bookDatabases(),
+      bookFormatSupport = BookFormatsTesting.supportsEverything,
+      accountCredentials = this.credentialStore,
+      accountProviders = this.accountProviders,
+      directory = f_acc,
+      directoryGraveyard = fAccGraveyard
     )
 
     val provider0 =
@@ -305,16 +327,18 @@ abstract class AccountsDatabaseContract {
     val f_p = File(fileProfiles, "0")
     f_p.mkdirs()
     val f_acc = File(f_p, "accounts")
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
 
     val db =
       AccountsDatabase.open(
-        this.context(),
-        this.accountEvents,
-        this.bookDatabases(),
-        BookFormatsTesting.supportsEverything,
-        this.credentialStore,
-        this.accountProviders,
-        f_acc
+        context = this.context(),
+        accountEvents = this.accountEvents,
+        bookDatabases = this.bookDatabases(),
+        bookFormatSupport = BookFormatsTesting.supportsEverything,
+        accountCredentials = this.credentialStore,
+        accountProviders = this.accountProviders,
+        directory = f_acc,
+        directoryGraveyard = fAccGraveyard
       )
 
     val provider0 =
@@ -336,15 +360,17 @@ abstract class AccountsDatabaseContract {
     val f_p = File(fileProfiles, "0")
     f_p.mkdirs()
     val f_acc = File(f_p, "accounts")
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
 
     val db0 = AccountsDatabase.open(
-      this.context(),
-      this.accountEvents,
-      this.bookDatabases(),
-      BookFormatsTesting.supportsEverything,
-      this.credentialStore,
-      this.accountProviders,
-      f_acc
+      context = this.context(),
+      accountEvents = this.accountEvents,
+      bookDatabases = this.bookDatabases(),
+      bookFormatSupport = BookFormatsTesting.supportsEverything,
+      accountCredentials = this.credentialStore,
+      accountProviders = this.accountProviders,
+      directory = f_acc,
+      directoryGraveyard = fAccGraveyard
     )
 
     val provider0 =
@@ -356,13 +382,14 @@ abstract class AccountsDatabaseContract {
     val acc1 = db0.createAccount(provider1)
 
     val db1 = AccountsDatabase.open(
-      this.context(),
-      this.accountEvents,
-      this.bookDatabases(),
-      BookFormatsTesting.supportsEverything,
-      this.credentialStore,
-      this.accountProviders,
-      f_acc
+      context = this.context(),
+      accountEvents = this.accountEvents,
+      bookDatabases = this.bookDatabases(),
+      bookFormatSupport = BookFormatsTesting.supportsEverything,
+      accountCredentials = this.credentialStore,
+      accountProviders = this.accountProviders,
+      directory = f_acc,
+      directoryGraveyard = fAccGraveyard
     )
 
     val acr0 = db1.accounts()[acc0.id]!!
@@ -385,15 +412,17 @@ abstract class AccountsDatabaseContract {
     val f_p = File(fileProfiles, "0")
     f_p.mkdirs()
     val f_acc = File(f_p, "accounts")
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
 
     val db0 = AccountsDatabase.open(
-      this.context(),
-      this.accountEvents,
-      this.bookDatabases(),
-      BookFormatsTesting.supportsEverything,
-      this.credentialStore,
-      this.accountProviders,
-      f_acc
+      context = this.context(),
+      accountEvents = this.accountEvents,
+      bookDatabases = this.bookDatabases(),
+      bookFormatSupport = BookFormatsTesting.supportsEverything,
+      accountCredentials = this.credentialStore,
+      accountProviders = this.accountProviders,
+      directory = f_acc,
+      directoryGraveyard = fAccGraveyard
     )
 
     val provider0 =
@@ -438,15 +467,17 @@ abstract class AccountsDatabaseContract {
     val f_p = File(fileProfiles, "0")
     f_p.mkdirs()
     val f_acc = File(f_p, "accounts")
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
 
     val db0 = AccountsDatabase.open(
-      this.context(),
-      this.accountEvents,
-      this.bookDatabases(),
-      BookFormatsTesting.supportsEverything,
-      this.credentialStore,
-      this.accountProviders,
-      f_acc
+      context = this.context(),
+      accountEvents = this.accountEvents,
+      bookDatabases = this.bookDatabases(),
+      bookFormatSupport = BookFormatsTesting.supportsEverything,
+      accountCredentials = this.credentialStore,
+      accountProviders = this.accountProviders,
+      directory = f_acc,
+      directoryGraveyard = fAccGraveyard
     )
 
     val provider0 =
@@ -470,15 +501,17 @@ abstract class AccountsDatabaseContract {
     val f_p = File(fileProfiles, "0")
     f_p.mkdirs()
     val f_acc = File(f_p, "accounts")
+    val fAccGraveyard = File(f_p, "accounts-graveyard")
 
     val db0 = AccountsDatabase.open(
-      this.context(),
-      this.accountEvents,
-      this.bookDatabases(),
-      BookFormatsTesting.supportsEverything,
-      this.credentialStore,
-      this.accountProviders,
-      f_acc
+      context = this.context(),
+      accountEvents = this.accountEvents,
+      bookDatabases = this.bookDatabases(),
+      bookFormatSupport = BookFormatsTesting.supportsEverything,
+      accountCredentials = this.credentialStore,
+      accountProviders = this.accountProviders,
+      directory = f_acc,
+      directoryGraveyard = fAccGraveyard
     )
 
     val provider0 =


### PR DESCRIPTION
**What's this do?**
This changes the behaviour around deleting corrupted accounts. Now,
if an account is deleted because the app believes it to be corrupt,
it is instead moved into an "accounts-graveyard" directory stored next
to the normal "accounts" directory.  This will give us the opportunity
to grab corrupted accounts and see what caused them to break in the
first place.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://www.notion.so/lyrasis/Error-code-51000-An-error-occurred-during-playback-on-Android-Audiobooks-db0d12b05e8f4d269011a776224b049a

**How should this be tested? / Do these changes have associated tests?**
Not a feature, but hopefully someone who's experiencing the startup crash will be able to get us the files off their device afterwards.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Mildly updated some of the tests and ran the app, but didn't have a crash to test with.