### PR TITLE
Bugfix/fix buttons inconsistency

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -50,7 +50,7 @@
         <c:change date="2021-09-10T00:00:00+00:00" summary="Introduced a new color scheme for the application."/>
       </c:changes>
     </c:release>
-    <c:release date="2021-10-26T21:54:28+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
+    <c:release date="2021-10-29T18:42:54+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
       <c:changes>
         <c:change date="2021-07-14T00:00:00+00:00" summary="Improve fixed-layout EPUB handling.">
           <c:tickets>
@@ -113,7 +113,8 @@
         <c:change date="2021-10-25T00:00:00+00:00" summary="Implemented swipe-to-refresh in catalog feeds"/>
         <c:change date="2021-10-25T00:00:00+00:00" summary="Correctly use Open Sans in the toolbar"/>
         <c:change date="2021-10-25T00:00:00+00:00" summary="Library logos are now clickable links"/>
-        <c:change date="2021-10-26T21:54:28+00:00" summary="Fixed send report button not opening the action options"/>
+        <c:change date="2021-10-26T00:00:00+00:00" summary="Fixed send report button not opening the action options"/>
+        <c:change date="2021-10-29T18:42:54+00:00" summary="Fixed UI buttons inconsistency"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -598,7 +598,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
         )
       )
       // if the book is not revocable and can't be deleted, we need to add an "empty button" before
-    //and after the action button
+      // and after the action button
     } else if (!isRevocable) {
       this.buttons.addView(this.buttonCreator.createButtonSizedSpace(), 0)
       this.buttons.addView(this.buttonCreator.createButtonSizedSpace())

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -490,6 +490,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     bookStatus: BookStatus.Held,
     book: Book
   ) {
+    this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.buttons.removeAllViews()
     when (bookStatus) {
       is BookStatus.Held.HeldInQueue ->
@@ -526,6 +527,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
         )
       }
     }
+    this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.checkButtonViewCount()
 
     this.statusInProgress.visibility = View.INVISIBLE
@@ -574,7 +576,8 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
         }
     }
 
-    if (this.viewModel.bookCanBeRevoked && this.buildConfig.allowReturns()) {
+    val isRevocable = this.viewModel.bookCanBeRevoked && this.buildConfig.allowReturns()
+    if (isRevocable) {
       this.buttons.addView(this.buttonCreator.createButtonSpace())
       this.buttons.addView(
         this.buttonCreator.createRevokeLoanButton(
@@ -594,6 +597,11 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
           }
         )
       )
+      // if the book is not revocable and can't be deleted, we need to add an "empty button" before
+    //and after the action button
+    } else if (!isRevocable) {
+      this.buttons.addView(this.buttonCreator.createButtonSizedSpace(), 0)
+      this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     }
 
     this.checkButtonViewCount()

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
@@ -215,8 +215,8 @@ class CatalogButtons(
   ): Button {
     return this.createButton(
       context = this.context,
-      text = R.string.catalogDownload,
-      description = R.string.catalogAccessibilityBookDownload,
+      text = R.string.catalogGet,
+      description = R.string.catalogAccessibilityBookBorrow,
       heightMatchParent = heightMatchParent,
       onClick = onClick
     )

--- a/simplified-ui-catalog/src/main/res/values/dimensions.xml
+++ b/simplified-ui-catalog/src/main/res/values/dimensions.xml
@@ -6,7 +6,7 @@
   <dimen name="catalogFeedCoversSpace">8dp</dimen>
   <dimen name="catalogFeedCellImageWidth">80dp</dimen>
   <dimen name="catalogFeedCellHeight">128dp</dimen>
-  <dimen name="catalogFeedCellButtonsHeight">40dp</dimen>
+  <dimen name="catalogFeedCellButtonsHeight">45dp</dimen>
   <dimen name="catalogFacetTabStroke">1dp</dimen>
   <dimen name="catalogFacetTabCornerRadius">3dp</dimen>
   <dimen name="catalogFacetTabPaddingLeft">32dp</dimen>

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -11,7 +11,7 @@
   <string name="catalogAccessibilityBookListen">Listen Button</string>
   <string name="catalogAccessibilityBookRead">Read Button</string>
   <string name="catalogAccessibilityBookReserve">Reserve Button</string>
-  <string name="catalogAccessibilityBookRevokeHold">Cancel Reservation Button</string>
+  <string name="catalogAccessibilityBookRevokeHold">Remove Button</string>
   <string name="catalogAccessibilityBookRevokeLoan">Return Now Button</string>
   <string name="catalogAccessibilityBookSync">Sync Button</string>
   <string name="catalogAccessibilityCoverAudiobook">%1$s, audiobook, by %2$s</string>
@@ -44,7 +44,7 @@
   <string name="catalogBookIntervalWeeksShort">w</string>
   <string name="catalogBookIntervalYearsShort">y</string>
   <string name="catalogCancel">Cancel</string>
-  <string name="catalogCancelHold">Cancel Reservation</string>
+  <string name="catalogCancelHold">Remove</string>
   <string name="catalogCancelling">Cancelling…</string>
   <string name="catalogCorrupted">The metadata for this book is damaged and cannot be displayed. Reloading the feed or syncing your account might fix the problem.</string>
   <string name="catalogDescription">Description</string>


### PR DESCRIPTION
**What's this do?**
This PR does the following changes:

1. Increases the buttons container height;
2. Changes the "Download" button text to "Get";
3. Adds invisible buttons to each side of a "Get" button on the book details page
4. Changes the "Cancel reservation" button text to "Remove";

**Why are we doing this? (w/ JIRA link if applicable)**
Regarding the above section, we are doing these changes to:
1. Fix this text being cropped when the [book's reserve can be cancelled](https://user-images.githubusercontent.com/79104027/139486855-d02e9e0f-fb0d-4bff-a9f2-37086ed63e6c.png) or [there's a loan duration for the book](https://user-images.githubusercontent.com/79104027/139486819-c16b1236-4349-4961-bdb7-4446af17309b.png)
**UPDATE** - This error no longer happens because that string was updated, but this fix can be used for future longer texts in the button

2. Fix the inconsistency between Android and iOS in this action button, as reported [here](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=c5596de5b57d4027bf2984acfa70f930&p=fb1084c7928e4f9e8db55a42f1d2b3f4)
3. Prevent the button to fill the entire screen width as we can see [here](https://user-images.githubusercontent.com/79104027/139487023-1c777549-0e37-4de0-b67f-a022bf85e4ad.png)
4. Fix the inconsistency between Android and iOS in this action button, as reported [here](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=c5596de5b57d4027bf2984acfa70f930&p=dd41e02a85ca4b3ea5cd3adfb1c070f2)

**How should this be tested? / Do these changes have associated tests?**
Open the app

- Choose Lyrasis library
Search for the audiobook "A Little Princess" and reserve it.
Verify the button now says "Remove" instead of "Cancel reservation"
 - Search for the book "Gone Girl" from Gillian Flynn and get it on loan
Verify the loan duration is not cropped on the button
 - Choose PalaceBookshelf library
Open any book
Verify the button says "Get" instead of "Download"

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 
