### PR TITLE
Added "Return" option to all loaned books

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -115,9 +115,10 @@
         <c:change date="2021-10-29T00:00:00+00:00" summary="Change 'Download' button label to 'Get'"/>
       </c:changes>
     </c:release>
-    <c:release date="2021-11-03T15:24:55+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.4">
+    <c:release date="2021-11-03T16:18:33+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.4">
       <c:changes>
-        <c:change date="2021-11-03T15:24:55+00:00" summary="Fix a startup crash involving malformed bookmarks"/>
+        <c:change date="2021-11-03T00:00:00+00:00" summary="Fix a startup crash involving malformed bookmarks"/>
+        <c:change date="2021-11-03T16:18:33+00:00" summary="Added return option to all loaned books"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -576,7 +576,11 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
         }
     }
 
-    val isRevocable = this.viewModel.bookCanBeRevoked && this.buildConfig.allowReturns()
+    val isRevocable = (
+      bookStatus is BookStatus.Loaned.LoanedNotDownloaded ||
+        this.viewModel.bookCanBeRevoked
+      ) && this.buildConfig.allowReturns()
+
     if (isRevocable) {
       this.buttons.addView(this.buttonCreator.createButtonSpace())
       this.buttons.addView(

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
@@ -103,7 +103,7 @@ class CatalogButtons(
     loanDuration: String,
     onClick: () -> Unit
   ): LinearLayout {
-    return createButtonWithDuration(loanDuration, R.string.catalogDownload, onClick)
+    return createButtonWithDuration(loanDuration, R.string.catalogGet, onClick)
   }
 
   @UiThread

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -306,23 +306,22 @@ class CatalogPagedViewHolder(
         )
       }
     )
-
-    if (isBookReturnable(book)) {
-      this.idleButtons.addView(this.buttonCreator.createButtonSpace())
-      this.idleButtons.addView(
-        this.buttonCreator.createRevokeLoanButton(
-          onClick = {
-            this.listener.revokeMaybeAuthenticated(book)
-          },
-          heightMatchParent = true
-        )
-      )
-    } else if (isBookDeletable(book)) {
+    if (isBookDeletable(book)) {
       this.idleButtons.addView(this.buttonCreator.createButtonSpace())
       this.idleButtons.addView(
         this.buttonCreator.createDeleteButton(
           onClick = {
             this.listener.delete(this.feedEntry as FeedEntryOPDS)
+          },
+          heightMatchParent = true
+        )
+      )
+    } else {
+      this.idleButtons.addView(this.buttonCreator.createButtonSpace())
+      this.idleButtons.addView(
+        this.buttonCreator.createRevokeLoanButton(
+          onClick = {
+            this.listener.revokeMaybeAuthenticated(book)
           },
           heightMatchParent = true
         )


### PR DESCRIPTION
**What's this do?**
This PR adds a "Return" button option to a book when it's loaned but not downloaded because of some error or status inconsistency. This PR also changes a button text from "Download" to "Get" on the catalog page in order to be consistent with what we seen in the book details screen.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [reported feature](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=c5596de5b57d4027bf2984acfa70f930&p=ccbe812c04924653b14877a4f567847f) that's asking for this option so the user doesn't have to download the book before returning it.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Choose the "Lyrasis" library
Choose any book and press the "Get" option. As soon as the download percentage shows up, close the app
Reopen the app
Verify you have the "Get" option [here](https://user-images.githubusercontent.com/79104027/140122432-148d06e2-e50c-4479-9858-aabb41715081.png) and [here](https://user-images.githubusercontent.com/79104027/140123798-1cf70d31-fa34-46c5-b9d4-b98b356b5e3c.png)
Press the "Get" button and wait.
See the book is not on your bookshelf anymore

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 