### PR TITLE
Changed user redirect screen to a book details screen after logging in from there

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -115,9 +115,10 @@
         <c:change date="2021-10-29T00:00:00+00:00" summary="Change 'Download' button label to 'Get'"/>
       </c:changes>
     </c:release>
-    <c:release date="2021-11-03T15:24:55+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.4">
+    <c:release date="2021-11-08T22:36:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.4">
       <c:changes>
-        <c:change date="2021-11-03T15:24:55+00:00" summary="Fix a startup crash involving malformed bookmarks"/>
+        <c:change date="2021-11-03T00:00:00+00:00" summary="Fix a startup crash involving malformed bookmarks"/>
+        <c:change date="2021-11-08T22:36:45+00:00" summary="Changed user redirect screen to a book details screen  after logging in from there"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -208,7 +208,7 @@ internal class MainFragmentListenerDelegate(
     return when (event) {
       is CatalogBookDetailEvent.LoginRequired -> {
         this.openSettingsAccount(event.account, showPleaseLogInTitle = true)
-        MainFragmentState.CatalogWaitingForLogin
+        MainFragmentState.BookDetailsWaitingForLogin
       }
       is CatalogBookDetailEvent.OpenErrorPage -> {
         this.openErrorPage(event.parameters)
@@ -283,11 +283,18 @@ internal class MainFragmentListenerDelegate(
   ): MainFragmentState {
     return when (event) {
       AccountDetailEvent.LoginSucceeded ->
-        if (state is MainFragmentState.CatalogWaitingForLogin) {
-          this.openCatalog()
-          MainFragmentState.EmptyState
-        } else {
-          state
+        when (state) {
+            is MainFragmentState.CatalogWaitingForLogin -> {
+              this.openCatalog()
+              MainFragmentState.EmptyState
+            }
+          is MainFragmentState.BookDetailsWaitingForLogin -> {
+            this.returnToCatalogTab()
+            MainFragmentState.EmptyState
+          }
+          else -> {
+            state
+          }
         }
       is AccountDetailEvent.OpenErrorPage -> {
         this.openErrorPage(event.parameters)
@@ -576,6 +583,10 @@ internal class MainFragmentListenerDelegate(
   private fun openCatalog() {
     this.navigator.popBackStack()
     this.navigator.reset(R.id.tabCatalog, false)
+  }
+
+  private fun returnToCatalogTab() {
+    this.navigator.goToTab(R.id.tabCatalog)
   }
 
   private fun openViewer(

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -284,10 +284,10 @@ internal class MainFragmentListenerDelegate(
     return when (event) {
       AccountDetailEvent.LoginSucceeded ->
         when (state) {
-            is MainFragmentState.CatalogWaitingForLogin -> {
-              this.openCatalog()
-              MainFragmentState.EmptyState
-            }
+          is MainFragmentState.CatalogWaitingForLogin -> {
+            this.openCatalog()
+            MainFragmentState.EmptyState
+          }
           is MainFragmentState.BookDetailsWaitingForLogin -> {
             this.returnToCatalogTab()
             MainFragmentState.EmptyState

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentState.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentState.kt
@@ -13,4 +13,11 @@ sealed class MainFragmentState {
    */
 
   object CatalogWaitingForLogin : MainFragmentState()
+
+  /**
+   * Book details required the patron to be logged in.
+   */
+
+  object BookDetailsWaitingForLogin : MainFragmentState()
+
 }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentState.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentState.kt
@@ -19,5 +19,4 @@ sealed class MainFragmentState {
    */
 
   object BookDetailsWaitingForLogin : MainFragmentState()
-
 }

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigator.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/TabbedNavigator.kt
@@ -56,6 +56,10 @@ class TabbedNavigator private constructor (private val navigator: BottomNavigato
     this.navigator.addFragment(fragment, tab)
   }
 
+  fun goToTab(@IdRes tab: Int) {
+    this.navigator.switchTab(tab)
+  }
+
   fun reset(@IdRes tab: Int, resetRootFragment: Boolean) {
     this.navigator.reset(tab, resetRootFragment)
   }


### PR DESCRIPTION
**What's this do?**
This PR adds logic to better handle the way the app behaves after an user logs in to a library after performing an action on a book details screen. There's a new event that will specify if the user is requesting a login from a book details screen so the app can intercept it and redirect the user to the catalog tab (where the book details screen is still open) after successfully logging in.

**Why are we doing this? (w/ JIRA link if applicable)**
There was a [task created on Notion](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=c5596de5b57d4027bf2984acfa70f930&p=8f17f0a85cd34af09c323397f2e993ea) saying that it could be misleading and a bad UX if the user returned to the catalog page after logging in from a book details screen without knowing if the performed action was happening or not.

**How should this be tested? / Do these changes have associated tests?**
1. Open the app and select the Lyrasis library
2. If you're logged in, then log out from the library
3. Go to catalog
4. Request book
5. Log in
6. Verify the app is returning to the book details page and not the catalog

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 