### PR TITLE
Always default to UTC for dates

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -121,12 +121,12 @@
         <c:change date="2021-11-08T00:00:00+00:00" summary="Return to book details after logging in while borrowing a book"/>
       </c:changes>
     </c:release>
-    <c:release date="2021-11-12T16:03:02+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.5">
+    <c:release date="2021-11-22T13:46:49+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.5">
       <c:changes>
-        <c:change date="2021-11-12T05:39:10+00:00" summary="Change reader toolbar color to black on white."/>
-        <c:change date="2021-11-16T16:18:33+00:00" summary="Added return option to all loaned books"/>
-        <c:change date="2021-11-16T16:03:02+00:00" summary="Fixed Palace books not being removed from 'My Books' when they're returned"/>
-        <c:change date="2021-11-16T15:38:27+00:00" summary="Updated catalog feed groups UI"/>
+        <c:change date="2021-11-12T00:00:00+00:00" summary="Change reader toolbar color to black on white."/>
+        <c:change date="2021-11-16T00:00:00+00:00" summary="Added return option to all loaned books"/>
+        <c:change date="2021-11-16T00:00:00+00:00" summary="Fixed Palace books not being removed from 'My Books' when they're returned"/>
+        <c:change date="2021-11-16T00:00:00+00:00" summary="Updated catalog feed groups UI"/>
         <c:change date="2021-11-17T00:00:00+00:00" summary="Implement dark mode">
           <c:tickets>
             <c:ticket id="SMA-220"/>
@@ -135,6 +135,7 @@
             <c:ticket id="SMA-223"/>
           </c:tickets>
         </c:change>
+        <c:change date="2021-11-22T13:46:49+00:00" summary="Ensure that dates are parsed correctly as UTC in OPDS feeds"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-json-core/src/main/java/org/nypl/simplified/json/core/JSONParserUtilities.java
+++ b/simplified-json-core/src/main/java/org/nypl/simplified/json/core/JSONParserUtilities.java
@@ -715,6 +715,7 @@ public final class JSONParserUtilities {
 
     try {
       return ISODateTimeFormat.dateTimeParser()
+        .withZoneUTC()
         .parseDateTime(JSONParserUtilities.getString(s, key));
     } catch (final IllegalArgumentException e) {
       throw new JSONParseException(

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSDateParsers.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSDateParsers.java
@@ -1,0 +1,22 @@
+package org.nypl.simplified.opds.core;
+
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+/**
+ * A supplier of date/time parsers.
+ */
+
+public final class OPDSDateParsers {
+  private OPDSDateParsers() {
+
+  }
+
+  /**
+   * @return A properly configured date/time parser.
+   */
+
+  public static DateTimeFormatter dateTimeParser() {
+    return ISODateTimeFormat.dateTimeParser().withZoneUTC();
+  }
+}

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedEntryParserTest.java
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedEntryParserTest.java
@@ -5,7 +5,6 @@ import com.io7m.jfunctional.OptionType;
 import com.io7m.jfunctional.Some;
 
 import org.joda.time.DateTime;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.nypl.simplified.opds.core.DRMLicensor;
@@ -20,6 +19,7 @@ import org.nypl.simplified.opds.core.OPDSAvailabilityLoanable;
 import org.nypl.simplified.opds.core.OPDSAvailabilityLoaned;
 import org.nypl.simplified.opds.core.OPDSAvailabilityOpenAccess;
 import org.nypl.simplified.opds.core.OPDSAvailabilityType;
+import org.nypl.simplified.opds.core.OPDSDateParsers;
 import org.nypl.simplified.opds.core.OPDSIndirectAcquisition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +79,7 @@ public final class OPDSFeedEntryParserTest {
     final OPDSAvailabilityType availability = e.getAvailability();
 
     final OptionType<DateTime> expected_start_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
     final OptionType<DateTime> expected_end_date = Option.none();
     final OptionType<URI> expected_revoke =
       Option.some(new URI("http://example.com/revoke"));
@@ -108,9 +108,9 @@ public final class OPDSFeedEntryParserTest {
     final OPDSAvailabilityType availability = e.getAvailability();
 
     final OptionType<DateTime> expected_start_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
     final OptionType<DateTime> expected_end_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2010-01-01T00:00:00Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2010-01-01T00:00:00Z"));
     final OptionType<URI> expected_revoke =
       Option.some(new URI("http://example.com/revoke"));
     final OPDSAvailabilityLoaned expected = OPDSAvailabilityLoaned.get(
@@ -160,7 +160,7 @@ public final class OPDSFeedEntryParserTest {
     final OPDSAvailabilityType availability = e.getAvailability();
 
     final OptionType<DateTime> expected_start_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
     final OptionType<Integer> queue_position = Option.none();
     final OptionType<DateTime> expected_end_date = Option.none();
     final OptionType<URI> expected_revoke =
@@ -190,9 +190,9 @@ public final class OPDSFeedEntryParserTest {
     final OPDSAvailabilityType availability = e.getAvailability();
 
     final OptionType<DateTime> expected_start_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
     final OptionType<DateTime> expected_end_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2010-01-01T00:00:00Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2010-01-01T00:00:00Z"));
     final OptionType<Integer> queue_position = Option.none();
     final OptionType<URI> expected_revoke =
       Option.some(new URI("http://example.com/revoke"));
@@ -221,7 +221,7 @@ public final class OPDSFeedEntryParserTest {
     final OPDSAvailabilityType availability = e.getAvailability();
 
     final OptionType<DateTime> expected_start_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
     final OptionType<Integer> queue_position = Option.some(3);
     final OptionType<DateTime> expected_end_date = Option.none();
     final OptionType<URI> expected_revoke =
@@ -251,9 +251,9 @@ public final class OPDSFeedEntryParserTest {
     final OPDSAvailabilityType availability = e.getAvailability();
 
     final OptionType<DateTime> expected_start_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2000-01-01T00:00:00Z"));
     final OptionType<DateTime> expected_end_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2010-01-01T00:00:00Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2010-01-01T00:00:00Z"));
     final OptionType<Integer> queue_position = Option.some(3);
     final OptionType<URI> expected_revoke =
       Option.some(new URI("http://example.com/revoke"));
@@ -309,7 +309,7 @@ public final class OPDSFeedEntryParserTest {
     final OPDSAvailabilityType availability = e.getAvailability();
 
     final OptionType<DateTime> expected_end_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2010-01-01T00:00:00Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2010-01-01T00:00:00Z"));
     final OptionType<URI> expected_revoke =
       Option.some(new URI("http://example.com/revoke"));
     final OPDSAvailabilityHeldReady expected =
@@ -360,7 +360,7 @@ public final class OPDSFeedEntryParserTest {
     final OPDSAvailabilityType availability = e.getAvailability();
 
     final OptionType<DateTime> expected_end_date = Option.some(
-      ISODateTimeFormat.dateTimeParser().parseDateTime("2015-08-24T00:30:24Z"));
+      OPDSDateParsers.dateTimeParser().parseDateTime("2015-08-24T00:30:24Z"));
     final OptionType<URI> expected_revoke =
       Option.some(new URI("http://example.com/revoke"));
     final OPDSAvailabilityHeldReady expected =
@@ -451,6 +451,16 @@ public final class OPDSFeedEntryParserTest {
     Assertions.assertEquals(
       Option.some("http://qa.circulation.librarysimplified.org/NYNYPL/AdobeAuth/devices"),
       licensor.getDeviceManager());
+  }
+
+  @Test
+  public void testEntryDateBug()
+    throws Exception {
+    final OPDSAcquisitionFeedEntryParserType parser = this.getParser();
+    parser.parseEntryStream(
+      URI.create("urn:test"),
+      OPDSFeedEntryParserTest.getResource("date-bug.xml")
+    );
   }
 
   private OPDSAcquisitionFeedEntryParserType getParser() {

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/date-bug.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/date-bug.xml
@@ -1,0 +1,37 @@
+<entry
+  schema:additionalType="http://schema.org/EBook"
+  xmlns:schema="http://schema.org/"
+  xmlns="http://www.w3.org/2005/Atom"
+  xmlns:bibframe="http://bibframe.org/vocab/"
+  xmlns:dcterms="http://purl.org/dc/terms/"
+  xmlns:opds="http://opds-spec.org/2010/catalog"
+  xmlns:simplified="http://librarysimplified.org/terms/">
+  <title>Anthem</title>
+  <author>
+    <name>Ayn Rand</name>
+    <link href="https://openbookshelf.dp.la/OB/works/contributor/Ayn%20Rand/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ayn Rand"/>
+  </author>
+  <summary type="html">&lt;p&gt;Anthem is a dystopian fiction novella by Ayn Rand, first published in 1938. It takes place at some unspecified future date when mankind has entered another dark age as a result of the evils of irrationality and collectivism and the weaknesses of socialistic thinking and economics. Technological advancement is now carefully planned (when it is allowed to occur at all) and the concept of individuality has been eliminated (for example, the word "I" has disappeared from the language). As is common in her work, Rand draws a clear distinction between the "socialist/communal" values of equality and brotherhood and the "productive/capitalist" values of achievement and individuality.&#13;
+    &lt;br /&gt;Many of the novella's core themes, such as the struggle between individualism and collectivism, are echoed in Rand's later books, such as The Fountainhead and Atlas Shrugged. However, the style of "Anthem" is unique among Rand's work, more narrative-centered and economical, lacking the intense didactic expressions of philosophical abstraction that occur in later works. It is probably her most accessible work.&lt;/p&gt;</summary>
+  <simplified:pwid>1bdc8999-d1c2-138f-fd54-b1544ab1e5c8</simplified:pwid>
+  <link href="https://s3.amazonaws.com/open-bookshelf-covers/FeedBooks/URI/http%3A//www.feedbooks.com/book/2837/2837.jpg" type="image/jpeg" rel="http://opds-spec.org/image"/>
+  <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/FeedBooks/URI/http%3A//www.feedbooks.com/book/2837/2837.png" type="image/png" rel="http://opds-spec.org/image/thumbnail"/>
+  <category term="Adult" scheme="http://schema.org/audience" label="Adult"/>
+  <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction"/>
+  <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction"/>
+  <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction"/>
+  <dcterms:language>en</dcterms:language>
+  <dcterms:issued>1938-05-01</dcterms:issued>
+  <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2837/report" rel="issues"/>
+  <id>http://www.feedbooks.com/book/2837</id>
+  <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2837" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate"/>
+  <bibframe:distribution bibframe:ProviderName="FeedBooks"/>
+  <published>2018-03-25T00:00:00Z</published>
+  <link href="https://openbookshelf.dp.la/OB/feed/411?entrypoint=Book" rel="collection" title="Our Picks"/>
+  <updated>2020-05-02T15:00:55Z</updated>
+  <link href="https://openbookshelf.dp.la/OB/works/9760/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+    <opds:availability status="available"/>
+  </link>
+  <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2837/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works"/>
+  <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/2837/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book"/>
+</entry>


### PR DESCRIPTION
**What's this do?**
This switches the OPDS parser to consistently default to UTC
dates/times. Dates that explicitly specify time zones will use the
correct zones.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://www.notion.so/lyrasis/Illegal-instant-due-to-time-zone-offset-transition-prevents-feed-from-displaying-42a4a9d280e841dfbbda67adf9631398

**How should this be tested? / Do these changes have associated tests?**
Check the OPDS entry in the referenced ticket.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
Yes.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried various books known to have the problem, and ran the test suite.