### PR TITLE
Complete fix for defaulting feed dates to UTC.

### DIFF
--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAtom.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAtom.java
@@ -41,7 +41,7 @@ final class OPDSAtom implements Serializable
       (PartialFunctionType<Element, DateTime, ParseException>) er -> {
         final String text = er.getTextContent();
         final String trimmed = text.trim();
-        return ISODateTimeFormat.dateTimeParser().parseDateTime(trimmed);
+        return OPDSDateParsers.dateTimeParser().parseDateTime(trimmed);
       });
   }
 
@@ -58,6 +58,6 @@ final class OPDSAtom implements Serializable
     throws OPDSParseException {
     final String e_updated_raw =
       OPDSXML.getFirstChildElementTextWithName(e, OPDSFeedConstants.ATOM_URI, "updated");
-    return ISODateTimeFormat.dateTimeParser().parseDateTime(e_updated_raw);
+    return OPDSDateParsers.dateTimeParser().parseDateTime(e_updated_raw);
   }
 }

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSXML.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSXML.java
@@ -420,11 +420,14 @@ public final class OPDSXML
     try {
       final OptionType<DateTime> end_date;
       if (e.hasAttribute(name)) {
-        return Option.some(ISODateTimeFormat.dateTimeParser().parseDateTime(e.getAttribute(name)));
+        return Option.some(
+          OPDSDateParsers.dateTimeParser()
+            .parseDateTime(e.getAttribute(name))
+        );
       }
 
       return Option.none();
-    } catch (final IllegalArgumentException x) {
+    } catch (final Exception x) {
       throw new OPDSParseException(x);
     }
   }
@@ -449,11 +452,11 @@ public final class OPDSXML
     NullCheck.notNull(e);
     NullCheck.notNull(name);
 
-    final OptionType<DateTime> end_date;
     if (e.hasAttribute(name)) {
       try {
-        return ISODateTimeFormat.dateTimeParser().parseDateTime(e.getAttribute(name));
-      } catch (final IllegalArgumentException x) {
+        return OPDSDateParsers.dateTimeParser()
+          .parseDateTime(e.getAttribute(name));
+      } catch (final Exception x) {
         throw new OPDSParseException(x);
       }
     }


### PR DESCRIPTION
**What's this do?**

This completes the fix to always default to UTC when parsing dates in a feed (#66). It adds changes from the upstream fix (https://github.com/NYPL-Simplified/Simplified-Android-Core/pull/948) that were not included in #66.

**Why are we doing this? (w/ JIRA link if applicable)**

Unit tests were failing after #66 was merged, because not all the changes from upstream were included. See #66 for the original motivation.

**How should this be tested? / Do these changes have associated tests?**

Unit tests should now pass. In the app, open some book details, and verify that the publish dates look reasonable. Also see #66. 

**Dependencies for merging? Releasing to production?**

None

**Have you updated the changelog?**

No, the changelog was updated in #66.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the Palace app.
