### PR TITLE
Upgrade readium and android-r2 to enable dark mode.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -121,7 +121,7 @@
         <c:change date="2021-11-08T00:00:00+00:00" summary="Return to book details after logging in while borrowing a book"/>
       </c:changes>
     </c:release>
-    <c:release date="2021-11-30T23:04:39+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.5">
+    <c:release date="2021-12-03T15:22:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.5">
       <c:changes>
         <c:change date="2021-11-12T00:00:00+00:00" summary="Change reader toolbar color to black on white."/>
         <c:change date="2021-11-16T00:00:00+00:00" summary="Added return option to all loaned books"/>
@@ -137,7 +137,8 @@
         </c:change>
         <c:change date="2021-11-22T00:00:00+00:00" summary="Ensure that dates are parsed correctly as UTC in OPDS feeds"/>
         <c:change date="2021-11-20T00:00:00+00:00" summary="Enabled dark mode in audiobook player"/>
-        <c:change date="2021-11-30T23:04:39+00:00" summary="Added 3-step tutorial to be shown when launching the app for the first time"/>
+        <c:change date="2021-11-30T00:00:00+00:00" summary="Added 3-step tutorial to be shown when launching the app for the first time"/>
+        <c:change date="2021-12-03T15:22:06+00:00" summary="Enabled dark mode in epub reader"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
@@ -52,8 +52,6 @@ import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.reader.bookmarks.api.ReaderBookmarkServiceType
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
 import org.readium.r2.shared.publication.asset.FileAsset
-import org.readium.r2.streamer.Streamer
-import org.readium.r2.streamer.parser.epub.EpubParser
 import org.slf4j.LoggerFactory
 import java.util.ServiceLoader
 import java.util.concurrent.ExecutionException
@@ -240,14 +238,6 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
         provider.create(this)
       }
 
-    val streamer =
-      Streamer(
-        context = this,
-        parsers = listOf(EpubParser()),
-        contentProtections = contentProtections,
-        ignoreDefaultParsers = true
-      )
-
     /*
      * Load the most recently configured theme from the profile's preferences.
      */
@@ -276,7 +266,7 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
       }
 
     return SR2ReaderParameters(
-      streamer = streamer,
+      contentProtections = contentProtections,
       bookFile = bookFile,
       bookId = this.parameters.entry.feedEntry.id,
       theme = initialTheme,


### PR DESCRIPTION
**What's this do?**

This updates the android-platform submodule so that the app is using updated versions of readium and android-r2. The reader activity is updated to work with readium API changes.

**Why are we doing this? (w/ JIRA link if applicable)**

This (finally) finishes up enabling dark mode in the reader. Notion: https://www.notion.so/lyrasis/Add-support-for-dark-theme-06d7c1ac8abd438fb6c1817f0885102d

**How should this be tested? / Do these changes have associated tests?**

Read some epubs with dark theme enabled. In the reader, the toolbar, TOC/bookmarks screen, and settings dialog should all have light text on dark background. (The book color scheme still needs to be selected manually via settings.)

**Dependencies for merging? Releasing to production?**

None

**Have you updated the changelog?**

Yes

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee read some books.