### PR TITLE
Fix back button on error details.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -121,7 +121,7 @@
         <c:change date="2021-11-08T00:00:00+00:00" summary="Return to book details after logging in while borrowing a book"/>
       </c:changes>
     </c:release>
-    <c:release date="2021-12-06T18:31:33+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.5">
+    <c:release date="2021-12-07T19:48:14+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.5">
       <c:changes>
         <c:change date="2021-11-12T00:00:00+00:00" summary="Change reader toolbar color to black on white."/>
         <c:change date="2021-11-16T00:00:00+00:00" summary="Added return option to all loaned books"/>
@@ -139,8 +139,9 @@
         <c:change date="2021-11-20T00:00:00+00:00" summary="Enabled dark mode in audiobook player"/>
         <c:change date="2021-11-30T00:00:00+00:00" summary="Added 3-step tutorial to be shown when launching the app for the first time"/>
         <c:change date="2021-12-03T00:00:00+00:00" summary="Enabled dark mode in epub reader"/>
-        <c:change date="2021-12-05T11:34:17+00:00" summary="Added page indicator and swipe-to-close feature to tutorial"/>
-        <c:change date="2021-12-06T18:31:33+00:00" summary="Fixed documentation failing to display"/>
+        <c:change date="2021-12-05T00:00:00+00:00" summary="Added page indicator and swipe-to-close feature to tutorial"/>
+        <c:change date="2021-12-06T00:00:00+00:00" summary="Fixed documentation failing to display"/>
+        <c:change date="2021-12-07T19:48:14+00:00" summary="Fixed back button not working on Error Details screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentDefaultViewModelFactory.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentDefaultViewModelFactory.kt
@@ -11,6 +11,7 @@ import org.nypl.simplified.ui.accounts.saml20.AccountSAML20Event
 import org.nypl.simplified.ui.catalog.CatalogBookDetailEvent
 import org.nypl.simplified.ui.catalog.CatalogFeedEvent
 import org.nypl.simplified.ui.catalog.saml20.CatalogSAML20Event
+import org.nypl.simplified.ui.errorpage.ErrorPageEvent
 import org.nypl.simplified.ui.profiles.ProfileTabEvent
 import org.nypl.simplified.ui.settings.SettingsDebugEvent
 import org.nypl.simplified.ui.settings.SettingsDocumentViewerEvent
@@ -30,6 +31,7 @@ class MainFragmentDefaultViewModelFactory(fallbackFactory: ViewModelProvider.Fac
     repository.registerListener(AccountListRegistryEvent::class, MainFragmentListenedEvent::AccountListRegistryEvent)
     repository.registerListener(AccountListEvent::class, MainFragmentListenedEvent::AccountListEvent)
     repository.registerListener(AccountPickerEvent::class, MainFragmentListenedEvent::AccountPickerEvent)
+    repository.registerListener(ErrorPageEvent::class, MainFragmentListenedEvent::ErrorPageEvent)
     repository.registerListener(SettingsMainEvent::class, MainFragmentListenedEvent::SettingsMainEvent)
     repository.registerListener(SettingsDebugEvent::class, MainFragmentListenedEvent::SettingsDebugEvent)
     repository.registerListener(SettingsDocumentViewerEvent::class, MainFragmentListenedEvent::SettingsDocumentViewerEvent)

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenedEvent.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenedEvent.kt
@@ -34,6 +34,10 @@ sealed class MainFragmentListenedEvent {
     val event: org.nypl.simplified.ui.accounts.AccountPickerEvent
   ) : MainFragmentListenedEvent()
 
+  data class ErrorPageEvent(
+    val event: org.nypl.simplified.ui.errorpage.ErrorPageEvent
+  ) : MainFragmentListenedEvent()
+
   data class SettingsMainEvent(
     val event: org.nypl.simplified.ui.settings.SettingsMainEvent
   ) : MainFragmentListenedEvent()

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -35,6 +35,7 @@ import org.nypl.simplified.ui.catalog.CatalogBookDetailFragment
 import org.nypl.simplified.ui.catalog.CatalogBookDetailFragmentParameters
 import org.nypl.simplified.ui.catalog.CatalogFeedFragment
 import org.nypl.simplified.ui.catalog.saml20.CatalogSAML20Event
+import org.nypl.simplified.ui.errorpage.ErrorPageEvent
 import org.nypl.simplified.ui.errorpage.ErrorPageFragment
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.nypl.simplified.ui.navigation.tabs.R
@@ -148,6 +149,8 @@ internal class MainFragmentListenerDelegate(
         this.handleAccountSAML20Event(event.event, state)
       is MainFragmentListenedEvent.AccountPickerEvent ->
         this.handleAccountPickerEvent(event.event, state)
+      is MainFragmentListenedEvent.ErrorPageEvent ->
+        this.handleErrorPageEvent(event.event, state)
       is MainFragmentListenedEvent.ProfileTabEvent ->
         this.handleProfileTabEvent(event.event, state)
     }
@@ -342,6 +345,18 @@ internal class MainFragmentListenerDelegate(
       }
       AccountPickerEvent.AddAccount -> {
         this.openSettingsAccountRegistry()
+        state
+      }
+    }
+  }
+
+  private fun handleErrorPageEvent(
+    event: ErrorPageEvent,
+    state: MainFragmentState
+  ): MainFragmentState {
+    return when (event) {
+      ErrorPageEvent.GoUpwards -> {
+        this.goUpwards()
         state
       }
     }

--- a/simplified-ui-errorpage/build.gradle
+++ b/simplified-ui-errorpage/build.gradle
@@ -4,6 +4,8 @@ dependencies {
   api project(":simplified-taskrecorder-api")
 
   implementation project(":simplified-android-ktx")
+  implementation project(':simplified-ui-listeners-api')
+  implementation project(':simplified-ui-neutrality')
 
   implementation libs.androidx.app.compat
   implementation libs.androidx.constraint.layout

--- a/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageEvent.kt
+++ b/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageEvent.kt
@@ -1,0 +1,9 @@
+package org.nypl.simplified.ui.errorpage
+
+sealed class ErrorPageEvent {
+  /**
+   * The patron is tired of looking at the error page.
+   */
+
+  object GoUpwards : ErrorPageEvent()
+}

--- a/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageFragment.kt
+++ b/simplified-ui-errorpage/src/main/java/org/nypl/simplified/ui/errorpage/ErrorPageFragment.kt
@@ -13,7 +13,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import org.nypl.simplified.android.ktx.supportActionBar
+import org.nypl.simplified.listeners.api.FragmentListenerType
+import org.nypl.simplified.listeners.api.fragmentListeners
 import org.nypl.simplified.reports.Reports
+import org.nypl.simplified.ui.neutrality.NeutralToolbar
 import org.slf4j.LoggerFactory
 
 /**
@@ -50,6 +53,9 @@ class ErrorPageFragment : Fragment(R.layout.error_page) {
   private lateinit var errorStepsList: RecyclerView
   private lateinit var parameters: ErrorPageParameters
   private lateinit var sendButton: Button
+  private lateinit var toolbar: NeutralToolbar
+
+  private val listener: FragmentListenerType<ErrorPageEvent> by fragmentListeners()
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
@@ -60,6 +66,8 @@ class ErrorPageFragment : Fragment(R.layout.error_page) {
       view.findViewById(R.id.errorSteps)
     this.sendButton =
       view.findViewById(R.id.errorSendButton)
+    this.toolbar =
+      view.rootView.findViewWithTag(NeutralToolbar.neutralToolbarName)
 
     this.parameters =
       this.arguments!!.getSerializable(PARAMETERS_ID)
@@ -112,9 +120,14 @@ class ErrorPageFragment : Fragment(R.layout.error_page) {
   }
 
   private fun configureToolbar() {
-    this.supportActionBar?.apply {
-      title = getString(R.string.errorDetailsTitle)
-      subtitle = null
+    val actionBar = this.supportActionBar ?: return
+
+    actionBar.show()
+    actionBar.setDisplayHomeAsUpEnabled(true)
+    actionBar.setHomeActionContentDescription(null)
+    actionBar.setTitle(getString(R.string.errorDetailsTitle))
+    this.toolbar.setLogoOnClickListener {
+      this.listener.post(ErrorPageEvent.GoUpwards)
     }
   }
 }


### PR DESCRIPTION
**What's this do?**

This makes the back button in the toolbar on the error details screen work properly. This is a continuation of the toolbar adjustments from #34, #37, and #39. Hopefully the last!

**Why are we doing this? (w/ JIRA link if applicable)**

Previously, tapping the back button on the error details screen would open the switch library menu, instead of returning to the previous screen. This made it hard for users to exit from the error details screen.

Notion: https://www.notion.so/lyrasis/Back-button-doesn-t-work-on-Error-Details-50d509d048dc4ca9a816db1735dbbe94

**How should this be tested? / Do these changes have associated tests?**

Do something that causes an error. As of this writing, attempting to "The Secret Language of Sisters" from LYRASIS Reads will do it. Tap the Details button under the error message to open the error details screen. On the error details screen, tap the back button in the toolbar. The app should return to the previous screen. 

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

Yes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested the back button.
