### PR TITLE
Disabled landscape mode

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -133,8 +133,10 @@
         <c:change date="2021-12-07T00:00:00+00:00" summary="Fixed back button not working on Error Details screen"/>
       </c:changes>
     </c:release>
-    <c:release date="2021-12-08T23:58:58+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
-      <c:changes/>
+    <c:release date="2021-12-15T10:58:03+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
+      <c:changes>
+        <c:change date="2021-12-15T10:58:03+00:00" summary="Disabled landscape mode"/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/simplified-app-openebooks/src/main/AndroidManifest.xml
+++ b/simplified-app-openebooks/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
             android:contentDescription="@string/appName"
             android:exported="true"
             android:label="@string/appName"
+            android:screenOrientation="portrait"
             android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -70,6 +71,7 @@
         <activity
             android:name="org.nypl.simplified.viewer.pdf.PdfReaderActivity"
             android:contentDescription="@string/appName"
+            android:screenOrientation="portrait"
             android:exported="false"
             android:label="@string/appName" />
 
@@ -85,6 +87,7 @@
             android:name="org.nypl.simplified.cardcreator.CardCreatorActivity"
             android:contentDescription="@string/appName"
             android:exported="false"
+            android:screenOrientation="portrait"
             android:label="@string/appName" />
 
     </application>

--- a/simplified-app-palace/src/main/AndroidManifest.xml
+++ b/simplified-app-palace/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
       android:name="org.nypl.simplified.main.MainActivity"
       android:contentDescription="@string/app_name"
       android:launchMode="singleTop"
+      android:screenOrientation="portrait"
       android:exported="true"
       android:label="@string/app_name">
     <intent-filter>
@@ -66,6 +67,7 @@
       android:name="org.nypl.simplified.viewer.pdf.PdfReaderActivity"
       android:contentDescription="@string/app_name"
       android:exported="false"
+      android:screenOrientation="portrait"
       android:label="@string/app_name" />
 
     <activity
@@ -80,6 +82,7 @@
       android:name="org.nypl.simplified.cardcreator.CardCreatorActivity"
       android:contentDescription="@string/app_name"
       android:exported="false"
+      android:screenOrientation="portrait"
       android:label="@string/app_name" />
 
   </application>

--- a/simplified-app-simplye/src/main/AndroidManifest.xml
+++ b/simplified-app-simplye/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
       android:contentDescription="@string/appName"
       android:launchMode="singleTop"
       android:exported="true"
+      android:screenOrientation="portrait"
       android:label="@string/appName">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
@@ -66,6 +67,7 @@
       android:name="org.nypl.simplified.viewer.pdf.PdfReaderActivity"
       android:contentDescription="@string/appName"
       android:exported="false"
+      android:screenOrientation="portrait"
       android:label="@string/appName" />
 
     <activity
@@ -77,10 +79,11 @@
       android:theme="@style/SimplyE_ActionBar" />
 
     <activity
-        android:name="org.nypl.simplified.cardcreator.CardCreatorActivity"
-        android:contentDescription="@string/appName"
-        android:exported="false"
-        android:label="@string/appName" />
+      android:name="org.nypl.simplified.cardcreator.CardCreatorActivity"
+      android:contentDescription="@string/appName"
+      android:exported="false"
+      android:screenOrientation="portrait"
+      android:label="@string/appName" />
 
   </application>
 

--- a/simplified-app-vanilla/src/main/AndroidManifest.xml
+++ b/simplified-app-vanilla/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <activity
       android:name="org.nypl.simplified.main.MainActivity"
       android:exported="true"
+      android:screenOrientation="portrait"
       android:launchMode="singleTop">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
@@ -67,7 +68,8 @@
 
     <activity
       android:name="org.nypl.simplified.viewer.pdf.PdfReaderActivity"
-      android:exported="false" />
+      android:exported="false"
+      android:screenOrientation="portrait" />
 
     <activity
       android:name="org.nypl.simplified.viewer.audiobook.AudioBookPlayerActivity"
@@ -78,6 +80,7 @@
     <activity
       android:name="org.nypl.simplified.cardcreator.CardCreatorActivity"
       android:exported="false"
+      android:screenOrientation="portrait"
       android:windowSoftInputMode="adjustResize" />
   </application>
 </manifest>


### PR DESCRIPTION
**What's this do?**
This PR sets the screen orientation as "Portrait" for every activity to disable the landscape mode.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [task request](https://www.notion.so/lyrasis/Disable-landscape-mode-c4564cd3379e43b6be0ff0460fd5bcd6) to disable the landscape mode in order to fix some issues and to be aligned with the iOS app.

**How should this be tested? / Do these changes have associated tests?**
Open the app (make sure your device has the screen rotation enabled in the status bar options)
Go to every screen, rotate the device and verify the app is not rotating and the layout remains as it was

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 