### PR TITLE
Added list name to top of screen

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -133,8 +133,10 @@
         <c:change date="2021-12-07T00:00:00+00:00" summary="Fixed back button not working on Error Details screen"/>
       </c:changes>
     </c:release>
-    <c:release date="2021-12-08T23:58:58+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
-      <c:changes/>
+    <c:release date="2021-12-15T16:22:32+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
+      <c:changes>
+        <c:change date="2021-12-15T16:22:32+00:00" summary="Added books list name to top of screen"/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -963,12 +963,7 @@ class CatalogFeedViewModel(
   }
 
   fun title(): String {
-    return when (val arguments = this.feedArguments) {
-      is CatalogFeedArgumentsLocalBooks ->
-        arguments.title
-      is CatalogFeedArgumentsRemote ->
-        this.resources.getString(R.string.feedTitleCatalog)
-    }
+    return this.feedArguments.title
   }
 
   private fun openLoginDialogIfNecessary(accountID: AccountID) {


### PR DESCRIPTION
**What's this do?**
This PR changes the way we're handling the returning of the title on the catalog feed, i.e., instead of considering the type of feed (local or remote), we now just return the title of the received feed arguments, which will be "Catalog" for the generic Catalog" or the name of a clicked collection.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Display-name-of-list-at-top-of-screen-on-Android-9ee236f3ab8c48e9953c4f2dfb8ecd99) to add this in order to be similar to the iOS app and to give the user a clearer idea of where's navigating.

**How should this be tested? / Do these changes have associated tests?**
Open the app
In the catalog tab, verify the [title is 'Catalog'](https://user-images.githubusercontent.com/79104027/146226744-7e00718b-bfb1-4ca5-a7cb-8de1cb885aa2.png)
Open, for example, the "DPLA Titles" collection
Verify the title [ is now 'DPLA Titles'](https://user-images.githubusercontent.com/79104027/146226868-9839d594-5237-4730-829d-a5c4e6611d6e.png)


**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 