### PR TITLE
Sync bookmarks when opening epub reader

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -133,13 +133,14 @@
         <c:change date="2021-12-07T00:00:00+00:00" summary="Fixed back button not working on Error Details screen"/>
       </c:changes>
     </c:release>
-    <c:release date="2021-12-27T13:26:21+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
+    <c:release date="2022-01-05T22:57:10+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2021-12-15T00:00:00+00:00" summary="Disabled landscape mode"/>
         <c:change date="2021-12-15T00:00:00+00:00" summary="Added books list name to top of screen"/>
         <c:change date="2021-12-20T00:00:00+00:00" summary="Turn on sync bookmarks by default"/>
-        <c:change date="2021-12-27T13:26:21+00:00" summary="Added 'more' label to catalog list titles"/>
+        <c:change date="2021-12-27T00:00:00+00:00" summary="Added 'more' label to catalog list titles"/>
+        <c:change date="2022-01-05T22:57:10+00:00" summary="Fixed reading position from other devices not remembered when opening a book."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkServiceUsableType.kt
+++ b/simplified-reader-bookmarks-api/src/main/java/org/nypl/simplified/reader/bookmarks/api/ReaderBookmarkServiceUsableType.kt
@@ -37,6 +37,21 @@ interface ReaderBookmarkServiceUsableType {
   ): FluentFuture<ReaderBookmarkSyncEnableResult>
 
   /**
+   * Sync the bookmarks for the given account.
+   */
+  fun bookmarkSyncAccount(
+    accountID: AccountID
+  ): FluentFuture<Unit>
+
+  /**
+   * Sync the bookmarks for the given account, and load bookmarks for the given book.
+   */
+  fun bookmarkSyncAndLoad(
+    accountID: AccountID,
+    book: BookID
+  ): FluentFuture<ReaderBookmarks>
+
+  /**
    * The user wants their current bookmarks.
    */
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/reader/bookmarks/NullReaderBookmarkService.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/reader/bookmarks/NullReaderBookmarkService.kt
@@ -23,6 +23,21 @@ class NullReaderBookmarkService(
   override val bookmarkEvents: Observable<ReaderBookmarkEvent>
     get() = this.events
 
+  override fun bookmarkSyncAccount(accountID: AccountID): FluentFuture<Unit> {
+    return FluentFuture.from(Futures.immediateFuture(Unit))
+  }
+
+  override fun bookmarkSyncAndLoad(accountID: AccountID, book: BookID): FluentFuture<ReaderBookmarks> {
+    return FluentFuture.from(
+      Futures.immediateFuture(
+        ReaderBookmarks(
+          lastRead = null,
+          bookmarks = listOf()
+        )
+      )
+    )
+  }
+
   override fun bookmarkSyncStatus(accountID: AccountID): ReaderBookmarkSyncEnableStatus {
     return ReaderBookmarkSyncEnableStatus.Changing(accountID)
   }

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Bookmarks.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Bookmarks.kt
@@ -31,8 +31,8 @@ object Reader2Bookmarks {
   ): ReaderBookmarks {
     return try {
       bookmarkService
-        .bookmarkLoad(accountID, bookID)
-        .get(10L, TimeUnit.SECONDS)
+        .bookmarkSyncAndLoad(accountID, bookID)
+        .get(15L, TimeUnit.SECONDS)
     } catch (e: Exception) {
       this.logger.error("could not load bookmarks: ", e)
       ReaderBookmarks(null, emptyList())


### PR DESCRIPTION
**What's this do?**

This syncs bookmarks (and the current reading position, which is a special bookmark) from the server when a book is opened in the readium epub viewer, prior to displaying the book and navigating to the current position. Previously, bookmarks were synced when the app was started, when changing libraries, and on an hourly schedule, but not when a book was opened.

**Why are we doing this? (w/ JIRA link if applicable)**

The reading position within a book should be retained between devices. Previously, if a user read a book on device 1, then opened the book on device 2, the reading position would not be the same as on device 1, unless the user waited up to an hour for the next sync, or restarted the app, or changed to a different library and back. This forces the bookmarks to sync when a book is opened, to ensure that the current reading position is correct.

Notion: https://www.notion.so/lyrasis/Palace-does-not-remember-place-in-book-between-devices-on-Android-be7b4d5f3351465ca1f90ff480c6ad16

**How should this be tested? / Do these changes have associated tests?**

- On two devices, start the Palace app and log in to the same library.
- On device 1, open a book. Make a few bookmarks on random pages, and turn to another random page.
- On device 2, open the same book.

Verify that on device 2, the book is opened to the same chapter and page number that is open on device 1. (If the devices have different screen sizes, the page number may be slightly different, but should be close). Verify that the bookmarks from device 1 all appear on device 2.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

Yes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested on the Palace app.
