### PR TITLE
Changed "Get" to "Download" label in buttons

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -133,14 +133,15 @@
         <c:change date="2021-12-07T00:00:00+00:00" summary="Fixed back button not working on Error Details screen"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-05T22:57:10+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
+    <c:release date="2022-01-07T22:14:49+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2021-12-15T00:00:00+00:00" summary="Disabled landscape mode"/>
         <c:change date="2021-12-15T00:00:00+00:00" summary="Added books list name to top of screen"/>
         <c:change date="2021-12-20T00:00:00+00:00" summary="Turn on sync bookmarks by default"/>
         <c:change date="2021-12-27T00:00:00+00:00" summary="Added 'more' label to catalog list titles"/>
-        <c:change date="2022-01-05T22:57:10+00:00" summary="Fixed reading position from other devices not remembered when opening a book."/>
+        <c:change date="2022-01-05T00:00:00+00:00" summary="Fixed reading position from other devices not remembered when opening a book."/>
+        <c:change date="2022-01-07T22:14:49+00:00" summary="Changed the button label for the checked out books"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
@@ -91,7 +91,7 @@ class CatalogButtons(
     loanDuration: String,
     onClick: () -> Unit
   ): LinearLayout {
-    return createButtonWithDuration(loanDuration, R.string.catalogGet, onClick)
+    return createButtonWithDuration(loanDuration, R.string.catalogDownload, onClick)
   }
 
   @UiThread
@@ -203,8 +203,8 @@ class CatalogButtons(
   ): Button {
     return this.createButton(
       context = this.context,
-      text = R.string.catalogGet,
-      description = R.string.catalogAccessibilityBookBorrow,
+      text = R.string.catalogDownload,
+      description = R.string.catalogAccessibilityBookDownload,
       heightMatchParent = heightMatchParent,
       onClick = onClick
     )


### PR DESCRIPTION
**What's this do?**
This PR changes the text to display in some buttons. Instead of displaying "Get" for checked out books, it now displays "Download"

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=c5596de5b57d4027bf2984acfa70f930&p=b65bef98ec5d4fe289aeff6dfb5d64b5) to implement this in order to make it similar to the iOS version

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Go to "My Books" tab
Verify [it now shows the 'Download' text](https://user-images.githubusercontent.com/79104027/148614201-77cec063-b08d-4eaf-a5e3-3457748f0fd3.png) for the checked out books

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 