### PR TITLE
Don't show EULA screen on startup.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -133,7 +133,7 @@
         <c:change date="2021-12-07T00:00:00+00:00" summary="Fixed back button not working on Error Details screen"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-11T23:14:47+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
+    <c:release date="2022-01-11T23:16:46+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2021-12-15T00:00:00+00:00" summary="Disabled landscape mode"/>
@@ -142,7 +142,8 @@
         <c:change date="2021-12-27T00:00:00+00:00" summary="Added 'more' label to catalog list titles"/>
         <c:change date="2022-01-05T00:00:00+00:00" summary="Fixed reading position from other devices not remembered when opening a book."/>
         <c:change date="2022-01-07T00:00:00+00:00" summary="Changed the button label for the checked out books"/>
-        <c:change date="2022-01-11T23:14:47+00:00" summary="Fixed &quot;Error code: 51000&quot; error when playing certain audiobooks."/>
+        <c:change date="2022-01-11T00:00:00+00:00" summary="Fixed &quot;Error code: 51000&quot; error when playing certain audiobooks."/>
+        <c:change date="2022-01-11T23:16:46+00:00" summary="Removed EULA screen from initial startup."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
@@ -5,8 +5,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentResultListener
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
-import org.librarysimplified.documents.DocumentStoreType
-import org.librarysimplified.services.api.Services
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.listeners.api.fragmentListeners
 import org.slf4j.LoggerFactory
@@ -29,36 +27,12 @@ class SplashFragment : Fragment(R.layout.splash_fragment), FragmentResultListene
   override fun onFragmentResult(requestKey: String, result: Bundle) {
     when (childFragmentManager.fragments.last()) {
       is BootFragment -> onBootCompleted()
-      is EulaFragment -> onEulaFinished()
       is MigrationProgressFragment -> onMigrationCompleted()
       is MigrationReportFragment -> onMigrationReportFinished()
     }
   }
 
   private fun onBootCompleted() {
-    val eula =
-      Services.serviceDirectory()
-        .requireService(DocumentStoreType::class.java)
-        .eula
-
-    if (eula != null && !eula.hasAgreed) {
-      showEula()
-    } else {
-      onEulaFinished()
-    }
-  }
-
-  private fun onEulaFinished() {
-    val eula =
-      Services.serviceDirectory()
-        .requireService(DocumentStoreType::class.java)
-        .eula
-
-    if (eula != null && !eula.hasAgreed) {
-      this.logger.error("eula declined: terminating")
-      requireActivity().finish()
-    }
-
     val migrationViewModel =
       ViewModelProvider(this)
         .get(MigrationViewModel::class.java)


### PR DESCRIPTION
**What's this do?**

This removes the EULA screen from the initial startup of the app.

**Why are we doing this? (w/ JIRA link if applicable)**

This makes the Android app more similar to the iOS app, and makes the app more friendly to first-time users.

Notion: https://www.notion.so/lyrasis/Remove-end-user-agreement-from-the-first-screen-seen-before-tutorial-on-the-Android-app-ff33413b1076486cbdbad254abd4bc42

**How should this be tested? / Do these changes have associated tests?**

Uninstall the app, if you have it installed. Install the app, and run it. The app should immediately show the tutorial, without first showing the EULA.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

Yes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the Palace app.
