### PR TITLE
Added 'isOpenAccess' flag to Loaned.NotDownloaded book status

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -133,7 +133,7 @@
         <c:change date="2021-12-07T00:00:00+00:00" summary="Fixed back button not working on Error Details screen"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-07T22:14:49+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
+    <c:release date="2022-01-12T11:19:53+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2021-12-15T00:00:00+00:00" summary="Disabled landscape mode"/>
@@ -141,7 +141,8 @@
         <c:change date="2021-12-20T00:00:00+00:00" summary="Turn on sync bookmarks by default"/>
         <c:change date="2021-12-27T00:00:00+00:00" summary="Added 'more' label to catalog list titles"/>
         <c:change date="2022-01-05T00:00:00+00:00" summary="Fixed reading position from other devices not remembered when opening a book."/>
-        <c:change date="2022-01-07T22:14:49+00:00" summary="Changed the button label for the checked out books"/>
+        <c:change date="2022-01-07T00:00:00+00:00" summary="Changed the button label for the checked out books"/>
+        <c:change date="2022-01-12T11:19:53+00:00" summary="Added isOpenAccess flag to Loaned.NotDownloaded book status"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLoanCreate.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLoanCreate.kt
@@ -131,7 +131,8 @@ class BorrowLoanCreate private constructor() : BorrowSubtaskType {
           LoanedNotDownloaded(
             id = context.bookCurrent.id,
             loanExpiryDate = null,
-            returnable = false
+            returnable = false,
+            isOpenAccess = false
           )
         )
         return
@@ -217,7 +218,8 @@ class BorrowLoanCreate private constructor() : BorrowSubtaskType {
             LoanedNotDownloaded(
               id = context.bookCurrent.id,
               loanExpiryDate = a.endDateOrNull,
-              returnable = a.revoke.isSome
+              returnable = a.revoke.isSome,
+              isOpenAccess = false
             )
           )
         }
@@ -241,7 +243,8 @@ class BorrowLoanCreate private constructor() : BorrowSubtaskType {
             LoanedNotDownloaded(
               id = context.bookCurrent.id,
               loanExpiryDate = a.endDateOrNull,
-              returnable = a.revoke.isSome
+              returnable = a.revoke.isSome,
+              isOpenAccess = true
             )
           )
         }

--- a/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookStatus.kt
+++ b/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookStatus.kt
@@ -231,7 +231,8 @@ sealed class BookStatus {
     data class LoanedNotDownloaded(
       override val id: BookID,
       override val loanExpiryDate: DateTime?,
-      override val returnable: Boolean
+      override val returnable: Boolean,
+      val isOpenAccess: Boolean
     ) : Loaned() {
 
       override val priority: BookStatusPriorityOrdering
@@ -414,7 +415,8 @@ sealed class BookStatus {
         Loaned.LoanedNotDownloaded(
           id = book.id,
           loanExpiryDate = this.someOrNull(a.endDate),
-          returnable = a.revoke.isSome
+          returnable = a.revoke.isSome,
+          isOpenAccess = true
         )
       }
     }
@@ -441,7 +443,8 @@ sealed class BookStatus {
         Loaned.LoanedNotDownloaded(
           id = book.id,
           loanExpiryDate = this.someOrNull(a.endDate),
-          returnable = returnable
+          returnable = returnable,
+          isOpenAccess = false
         )
       }
     }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLoanCreateTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLoanCreateTest.kt
@@ -48,6 +48,7 @@ import org.nypl.simplified.books.formats.api.StandardFormatNames.genericEPUBFile
 import org.nypl.simplified.books.formats.api.StandardFormatNames.opdsAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSAcquisitionPathElement
+import org.nypl.simplified.opds.core.OPDSAvailabilityLoanable
 import org.nypl.simplified.profiles.api.ProfileReadableType
 import org.nypl.simplified.taskrecorder.api.TaskRecorder
 import org.nypl.simplified.taskrecorder.api.TaskRecorderType

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLoanCreateTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLoanCreateTest.kt
@@ -48,8 +48,6 @@ import org.nypl.simplified.books.formats.api.StandardFormatNames.genericEPUBFile
 import org.nypl.simplified.books.formats.api.StandardFormatNames.opdsAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSAcquisitionPathElement
-import org.nypl.simplified.opds.core.OPDSAvailabilityLoanable
-import org.nypl.simplified.opds.core.OPDSAvailabilityOpenAccess
 import org.nypl.simplified.profiles.api.ProfileReadableType
 import org.nypl.simplified.taskrecorder.api.TaskRecorder
 import org.nypl.simplified.taskrecorder.api.TaskRecorderType
@@ -159,8 +157,7 @@ class BorrowLoanCreateTest {
         account = this.accountId,
         cover = null,
         thumbnail = null,
-        entry = OPDSAcquisitionFeedEntry.newBuilder("x", "Title", DateTime.now(), OPDSAvailabilityOpenAccess.get(
-          Option.none<URI>())).build(),
+        entry = OPDSAcquisitionFeedEntry.newBuilder("x", "Title", DateTime.now(), OPDSAvailabilityLoanable.get()).build(),
         formats = listOf()
       )
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -545,11 +545,19 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     when (bookStatus) {
       is BookStatus.Loaned.LoanedNotDownloaded ->
         this.buttons.addView(
-          this.buttonCreator.createDownloadButton(
-            onClick = {
-              this.viewModel.borrowMaybeAuthenticated()
-            }
-          )
+          if (bookStatus.isOpenAccess) {
+            this.buttonCreator.createGetButton(
+              onClick = {
+                this.viewModel.borrowMaybeAuthenticated()
+              }
+            )
+          } else {
+            this.buttonCreator.createDownloadButton(
+              onClick = {
+                this.viewModel.borrowMaybeAuthenticated()
+              }
+            )
+          }
         )
 
       is BookStatus.Loaned.LoanedDownloaded ->

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -293,17 +293,28 @@ class CatalogPagedViewHolder(
     val loanDuration = getLoanDuration(book)
 
     this.idleButtons.addView(
-      if (loanDuration.isNotEmpty()) {
-        this.buttonCreator.createDownloadButtonWithLoanDuration(loanDuration) {
-          this.listener.borrowMaybeAuthenticated(book)
-        }
-      } else {
-        this.buttonCreator.createDownloadButton(
-          onClick = {
+      when {
+        loanDuration.isNotEmpty() -> {
+          this.buttonCreator.createDownloadButtonWithLoanDuration(loanDuration) {
             this.listener.borrowMaybeAuthenticated(book)
-          },
-          heightMatchParent = true
-        )
+          }
+        }
+        bookStatus.isOpenAccess -> {
+          this.buttonCreator.createGetButton(
+            onClick = {
+              this.listener.borrowMaybeAuthenticated(book)
+            },
+            heightMatchParent = true
+          )
+        }
+        else -> {
+          this.buttonCreator.createDownloadButton(
+            onClick = {
+              this.listener.borrowMaybeAuthenticated(book)
+            },
+            heightMatchParent = true
+          )
+        }
       }
     )
 

--- a/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
+++ b/simplified-ui-splash/src/main/java/org/nypl/simplified/ui/splash/SplashFragment.kt
@@ -5,8 +5,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentResultListener
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
-import org.librarysimplified.documents.DocumentStoreType
-import org.librarysimplified.services.api.Services
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.listeners.api.fragmentListeners
 import org.slf4j.LoggerFactory
@@ -29,36 +27,12 @@ class SplashFragment : Fragment(R.layout.splash_fragment), FragmentResultListene
   override fun onFragmentResult(requestKey: String, result: Bundle) {
     when (childFragmentManager.fragments.last()) {
       is BootFragment -> onBootCompleted()
-      is EulaFragment -> onEulaFinished()
       is MigrationProgressFragment -> onMigrationCompleted()
       is MigrationReportFragment -> onMigrationReportFinished()
     }
   }
 
   private fun onBootCompleted() {
-    val eula =
-      Services.serviceDirectory()
-        .requireService(DocumentStoreType::class.java)
-        .eula
-
-    if (eula != null && !eula.hasAgreed) {
-      showEula()
-    } else {
-      onEulaFinished()
-    }
-  }
-
-  private fun onEulaFinished() {
-    val eula =
-      Services.serviceDirectory()
-        .requireService(DocumentStoreType::class.java)
-        .eula
-
-    if (eula != null && !eula.hasAgreed) {
-      this.logger.error("eula declined: terminating")
-      requireActivity().finish()
-    }
-
     val migrationViewModel =
       ViewModelProvider(this)
         .get(MigrationViewModel::class.java)


### PR DESCRIPTION
**What's this do?**
This PR adds a flag (isOpenAccess) to the Loaned.NotDownloaded book status to distinguish the possible action between open access books and books from libraries that require authentication.

**Why are we doing this? (w/ JIRA link if applicable)**
This change is being made so the user's experience can be clearer in terms of actions to perform over a book. Right now the app was either showing "Get" or "Download" for the books, and this way we can show "Get" when the user doesn't have downloaded the book and it is open access and we show "Download" when the user doesn't have downloaded the book and it isn't open access.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Go to the "Palace Bookshelf" library
Open any book and [verify the button says "Get"](https://user-images.githubusercontent.com/79104027/149134247-352298e8-2ca3-44e2-a15a-9c4a592a0417.png)
Go back and switch to the "Lyrasis Reads" library (or any other that requires authentication)
Open any book, [verify the button says "Get](https://user-images.githubusercontent.com/79104027/149135439-4a257bad-8b5f-4008-b267-b21dd1a3f089.png) and press it
Wait until the book is successfully downloaded
Logout from the library, go to the device settings, open the Palace app settings and clear data
Open the Palace app
Log in to the "Lyrasis Reads" library
Go to "My Books" and [verify the previously selected book's action says "Download"](https://user-images.githubusercontent.com/79104027/149135573-09bb3684-e228-4e83-9765-d5a2efa3453a.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 