### PR TITLE
Fixed book title request infinite loading

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -133,7 +133,7 @@
         <c:change date="2021-12-07T00:00:00+00:00" summary="Fixed back button not working on Error Details screen"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-11T23:16:46+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
+    <c:release date="2022-01-13T15:59:25+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2021-12-15T00:00:00+00:00" summary="Disabled landscape mode"/>
@@ -143,7 +143,9 @@
         <c:change date="2022-01-05T00:00:00+00:00" summary="Fixed reading position from other devices not remembered when opening a book."/>
         <c:change date="2022-01-07T00:00:00+00:00" summary="Changed the button label for the checked out books"/>
         <c:change date="2022-01-11T00:00:00+00:00" summary="Fixed &quot;Error code: 51000&quot; error when playing certain audiobooks."/>
-        <c:change date="2022-01-11T23:16:46+00:00" summary="Removed EULA screen from initial startup."/>
+        <c:change date="2022-01-11T00:00:00+00:00" summary="Removed EULA screen from initial startup."/>
+        <c:change date="2022-01-13T00:00:00+00:00" summary="Fixed book title request infinite loading if the user didn't authenticate"/>
+        <c:change date="2022-01-13T15:59:25+00:00" summary="Fixed user not returning to book title or feed after pressing back on the auth screen after requesting a book"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -178,7 +178,7 @@ internal class MainFragmentListenerDelegate(
   ): MainFragmentState {
     return when (event) {
       is CatalogFeedEvent.LoginRequired -> {
-        this.openSettingsAccount(event.account, showPleaseLogInTitle = true)
+        this.openSettingsAccount(event.account, comingFromBookLoanRequest = true)
         MainFragmentState.CatalogWaitingForLogin
       }
       is CatalogFeedEvent.OpenErrorPage -> {
@@ -210,7 +210,7 @@ internal class MainFragmentListenerDelegate(
   ): MainFragmentState {
     return when (event) {
       is CatalogBookDetailEvent.LoginRequired -> {
-        this.openSettingsAccount(event.account, showPleaseLogInTitle = true)
+        this.openSettingsAccount(event.account, comingFromBookLoanRequest = true)
         MainFragmentState.BookDetailsWaitingForLogin
       }
       is CatalogBookDetailEvent.OpenErrorPage -> {
@@ -262,7 +262,7 @@ internal class MainFragmentListenerDelegate(
   ): MainFragmentState {
     return when (event) {
       is AccountListEvent.AccountSelected -> {
-        this.openSettingsAccount(event.account, showPleaseLogInTitle = false)
+        this.openSettingsAccount(event.account, comingFromBookLoanRequest = false)
         state
       }
       AccountListEvent.AddAccount -> {
@@ -528,16 +528,20 @@ internal class MainFragmentListenerDelegate(
     this.navigator.popBackStack()
   }
 
-  private fun openSettingsAccount(account: AccountID, showPleaseLogInTitle: Boolean) {
+  private fun openSettingsAccount(account: AccountID, comingFromBookLoanRequest: Boolean) {
     this.navigator.addFragment(
       fragment = AccountDetailFragment.create(
         AccountFragmentParameters(
           accountId = account,
           closeOnLoginSuccess = false,
-          showPleaseLogInTitle = showPleaseLogInTitle
+          showPleaseLogInTitle = comingFromBookLoanRequest
         )
       ),
-      tab = R.id.tabSettings
+      tab = if (comingFromBookLoanRequest) {
+        R.id.tabCatalog
+      } else {
+        R.id.tabSettings
+      }
     )
   }
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBorrowViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBorrowViewModel.kt
@@ -122,13 +122,9 @@ class CatalogBorrowViewModel(
   fun tryBorrowMaybeAuthenticated(
     book: Book
   ) {
-    this.bookRegistry.updateIfStatusIsMoreImportant(
-      BookWithStatus(
-        book, BookStatus.RequestingLoan(book.id, "")
-      )
-    )
 
     if (!this.isLoginRequired(book.account)) {
+      this.onRequestLoanStarted(book)
       return this.tryBorrowAuthenticated(book)
     }
 
@@ -137,6 +133,7 @@ class CatalogBorrowViewModel(
       bookID = book.id,
       runOnSuccess = {
         if (!this.isLoginRequired(book.account)) {
+          this.onRequestLoanStarted(book)
           this.tryBorrowAuthenticated(book)
         } else {
           this.onBorrowAttemptCancelled(book)
@@ -145,6 +142,15 @@ class CatalogBorrowViewModel(
       runOnCancel = {
         this.onBorrowAttemptCancelled(book)
       }
+    )
+  }
+
+  private fun onRequestLoanStarted(book: Book) {
+    this.logger.debug("request loan started")
+    this.bookRegistry.updateIfStatusIsMoreImportant(
+      BookWithStatus(
+        book, BookStatus.RequestingLoan(book.id, "")
+      )
     )
   }
 
@@ -198,13 +204,9 @@ class CatalogBorrowViewModel(
   fun tryReserveMaybeAuthenticated(
     book: Book
   ) {
-    this.bookRegistry.updateIfStatusIsMoreImportant(
-      BookWithStatus(
-        book, BookStatus.RequestingLoan(book.id, "")
-      )
-    )
 
     if (!this.isLoginRequired(book.account)) {
+      this.onRequestLoanStarted(book)
       return this.tryReserveAuthenticated(book)
     }
 
@@ -213,6 +215,7 @@ class CatalogBorrowViewModel(
       bookID = book.id,
       runOnSuccess = {
         if (!this.isLoginRequired(book.account)) {
+          this.onRequestLoanStarted(book)
           this.tryReserveAuthenticated(book)
         } else {
           this.onReserveAttemptCancelled(book)


### PR DESCRIPTION
**What's this do?**
This PR changes the tab where the user is coming from when entering the authentication screen for a library after trying to get a book on loan. This way, the user will stay in the settings tab if he log on to a library from there and will be redirected to the feed/book details screen after returning (logged in or not) from the auth screen (if the book required it). This PR also fixes the infinite loading bug that was happening if the user returned from the authentication screen to the book details page without logging in.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report indicating these two issues](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=c5596de5b57d4027bf2984acfa70f930&p=c72840a1fe73413f9f17f3a98f5a6e15) (infinite loading and not returning to feed/book details screen) and solving them will make the user experience less confusing and will also make it possible for the user to retry an operation over a book even if he didn't log in to the library.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "Lyrasis Reads" library
Logout from the library if you're logged in
Open any book from the catalog
Click on "Get"
In the auth screen, go back and [confirm you're in the book details page with the "Get" button visible and enabled](https://user-images.githubusercontent.com/79104027/149379026-48235681-3ad5-48ae-8598-b3a4caf1d257.png)
Click on "Get" again
In the auth screen, insert your credentials and wait
Return to the book page and confirm [the download has started](https://user-images.githubusercontent.com/79104027/149379084-e71b29d9-0994-434d-b695-94b51d32221d.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 