### PR TITLE
Added Palace Overdrive audiobooks integration module

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -133,7 +133,7 @@
         <c:change date="2021-12-07T00:00:00+00:00" summary="Fixed back button not working on Error Details screen"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-13T15:59:25+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
+    <c:release date="2022-01-17T18:43:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2021-12-15T00:00:00+00:00" summary="Disabled landscape mode"/>
@@ -145,7 +145,8 @@
         <c:change date="2022-01-11T00:00:00+00:00" summary="Fixed &quot;Error code: 51000&quot; error when playing certain audiobooks."/>
         <c:change date="2022-01-11T00:00:00+00:00" summary="Removed EULA screen from initial startup."/>
         <c:change date="2022-01-13T00:00:00+00:00" summary="Fixed book title request infinite loading if the user didn't authenticate"/>
-        <c:change date="2022-01-13T15:59:25+00:00" summary="Fixed user not returning to book title or feed after pressing back on the auth screen after requesting a book"/>
+        <c:change date="2022-01-13T00:00:00+00:00" summary="Fixed user not returning to book title or feed after pressing back on the auth screen after requesting a book"/>
+        <c:change date="2022-01-17T18:43:38+00:00" summary="Add Palace Overdrive audiobooks module"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-palace/build.gradle
+++ b/simplified-app-palace/build.gradle
@@ -9,7 +9,7 @@ def requiredFiles = [:]
 requiredFiles["ReaderClientCert.sig"] =
   "b064e68b96e258e42fe1ca66ae3fc4863dd802c46585462220907ed291e1217d"
 requiredFiles["secrets.conf"] =
-  "d7fcc3c93c0baa881b83683654d27796a3f816e0d77629f4c114493e6a53a743"
+  "756e525becd6f266e8e063abdb8bd03dfca352f0551b33756e21ecb826dfd01b"
 
 android {
   defaultConfig {
@@ -46,6 +46,7 @@ dependencies {
   implementation libs.nypl.readium
   implementation libs.palace.drm.adobe
   implementation libs.palace.findaway
+  implementation libs.palace.overdrive
   implementation libs.r2.lcp
   implementation libs.r2.opds
   implementation libs.r2.shared


### PR DESCRIPTION
**What's this do?**
This PR imports the Palace module to integrate Overdrive audiobooks. This also updates the expected sha-256 value for the secrets.conf file.

**Why are we doing this? (w/ JIRA link if applicable)**
The audiobooks from Overdrive weren't being correctly downloaded and parsed, as reported [here](https://www.notion.so/lyrasis/Implement-support-for-OverDrive-Audiobooks-in-Android-3b9545183e2342e1a45f89e4a453e010). When opening an Overdrive audiobook, we would get [a downloading error](https://user-images.githubusercontent.com/79104027/149822730-3c778d71-8c42-4d00-bb3f-a2152fec55d3.png)
that was caused by [an incorrect manifest parsing](https://user-images.githubusercontent.com/79104027/149822787-2cf5ed9c-5612-413e-83e6-dd2ac0149c6f.png). This way, it's now possible to listen to Overdrive audiobooks.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Go to settings and enable "Debug Options" by tapping 7 times in the commit version text
Enable "Show non-production libraries" option inside "Testing Features"
Go to the libraries page and add the "Overdrive Integration Test Library" library
Log in to the library
Go to catalog and open any audiobook
Press "Get" and confirm [it's being correctly downloaded](https://user-images.githubusercontent.com/79104027/149823102-cb0ccadb-11fa-47b0-8dff-9c416d904063.png)
Press "Listen" and confirm [it's being correctly played](https://user-images.githubusercontent.com/79104027/149823126-3414d219-dc10-40e5-b1e8-56929df47560.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 