### PR TITLE
Updated borrow label on open access books detail page

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -133,7 +133,7 @@
         <c:change date="2021-12-07T00:00:00+00:00" summary="Fixed back button not working on Error Details screen"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-17T18:43:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
+    <c:release date="2022-01-19T12:00:22+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2021-12-15T00:00:00+00:00" summary="Disabled landscape mode"/>
@@ -148,7 +148,8 @@
         <c:change date="2022-01-13T00:00:00+00:00" summary="Fixed book title request infinite loading if the user didn't authenticate"/>
         <c:change date="2022-01-13T00:00:00+00:00" summary="Fixed user not returning to book title or feed after pressing back on the auth screen after requesting a book"/>
         <c:change date="2022-01-14T00:00:00+00:00" summary="Added backward and forward actions to lock screen notification controls"/>
-        <c:change date="2022-01-17T18:43:38+00:00" summary="Add Palace Overdrive audiobooks module"/>
+        <c:change date="2022-01-17T00:00:00+00:00" summary="Add Palace Overdrive audiobooks module"/>
+        <c:change date="2022-01-19T12:00:22+00:00" summary="Updated borrow label on open access books detail page"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookAvailabilityStrings.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookAvailabilityStrings.kt
@@ -38,7 +38,11 @@ object CatalogBookAvailabilityStrings {
       is BookStatus.Loanable ->
         onLoanable(resources)
       is BookStatus.Loaned.LoanedNotDownloaded ->
-        onLoaned(resources, Option.of(status.loanExpiryDate))
+        if (status.isOpenAccess) {
+          onLoanable(resources)
+        } else {
+          onLoaned(resources, Option.of(status.loanExpiryDate))
+        }
       is BookStatus.Loaned.LoanedDownloaded ->
         onLoaned(resources, Option.of(status.loanExpiryDate))
       is BookStatus.RequestingLoan ->


### PR DESCRIPTION
**What's this do?**
This PR changes the borrow label information inside an open access book details page by considerating the book's open access status.

**Why are we doing this? (w/ JIRA link if applicable)**
There's [a request](https://www.notion.so/lyrasis/Change-banner-text-for-open-access-titles-that-have-not-been-checked-out-886f0b5d538d4e3db61b0d9a3f1485e3) to make it as the iOS app currently has it and also for the user to not be confused by what the label says, because an open access book would say the book's currently loaned to the user even if the available action is "Get", which implies that it's not loaned to him

**How should this be tested? / Do these changes have associated tests?**
Open Palace app
Select "Palace bookshelf" library
Open any book
Verify [the available action says "Get" and the label says "This book is available for loan"](https://user-images.githubusercontent.com/79104027/150154048-383b27bf-ed16-4744-a9e5-609d2ab0f4c8.png)
Press "Get"
Confirm the [label changed to "You have this book on loan"](https://user-images.githubusercontent.com/79104027/150154140-032f7844-e2a6-4649-b93c-25e59077da88.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 