### PR TITLE
Fixed crash when opening the TOC page on audiobooks

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -133,7 +133,7 @@
         <c:change date="2021-12-07T00:00:00+00:00" summary="Fixed back button not working on Error Details screen"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-01-19T12:00:22+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
+    <c:release date="2022-01-20T14:44:02+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.6">
       <c:changes>
         <c:change date="2021-12-14T00:00:00+00:00" summary="Added audiobook player commands to lock screen"/>
         <c:change date="2021-12-15T00:00:00+00:00" summary="Disabled landscape mode"/>
@@ -149,7 +149,8 @@
         <c:change date="2022-01-13T00:00:00+00:00" summary="Fixed user not returning to book title or feed after pressing back on the auth screen after requesting a book"/>
         <c:change date="2022-01-14T00:00:00+00:00" summary="Added backward and forward actions to lock screen notification controls"/>
         <c:change date="2022-01-17T00:00:00+00:00" summary="Add Palace Overdrive audiobooks module"/>
-        <c:change date="2022-01-19T12:00:22+00:00" summary="Updated borrow label on open access books detail page"/>
+        <c:change date="2022-01-19T00:00:00+00:00" summary="Updated borrow label on open access books detail page"/>
+        <c:change date="2022-01-20T14:44:02+00:00" summary="Fixed crash when opening the TOC page on audiobooks"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -663,7 +663,8 @@ class AudioBookPlayerActivity :
 
       this.supportFragmentManager
         .beginTransaction()
-        .replace(R.id.audio_book_player_fragment_holder, fragment, "PLAYER_TOC")
+        .hide(this.playerFragment)
+        .add(R.id.audio_book_player_fragment_holder, fragment, "PLAYER_TOC")
         .addToBackStack(null)
         .commit()
     }


### PR DESCRIPTION
**What's this do?**
This PR changes the way the _AudiobookPlayerActivity_ handles the switch from the _PlayerFragment_ to the _TOCFragment_. Instead of replacing the first one, the activity hides it which will prevent it from being destroyed and to destroy the PlayerService. In this way, the behavior remains the same and the app doesn't crash when opening the TOC screen.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [crash report](https://www.notion.so/lyrasis/Android-Tapping-in-ToC-for-audiobook-causes-app-to-crash-297b9396a30544ccafcd17174f3eba2f) saying that this was happening in some audiobooks, but the error could be most likely happening on every audiobook. By fixing this, the app doesn't crash anymore when the user opens the TOC screen.

**How should this be tested? / Do these changes have associated tests?**
In order to reproduce the exact steps of the crash report:
Open the Palace app
Go to settings and press 7 times the commit version to enable the debug options
Open the debug options and enable the "Show Non-Production libraries" option.
Go to the libraries screen and choose `Overdrive Integration Test Library`
Checkout the audiobook  *Inferno* by Dan Brown
Start listening to that audiobook
Open the table of contents (ToC)
Confirm the app doesn't crash
Select any chapter of the ToC
Confirm the app doesn't crash

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 