### PR TITLE
Removed sync bookmarks option from libraries that don't require authentication

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -151,10 +151,11 @@
         <c:change date="2022-01-21T00:00:00+00:00" summary="Removed the &quot;Show&quot; filter from My Books. This wasn't useful."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-02-03T15:19:49+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
+    <c:release date="2022-02-03T19:19:14+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
       <c:changes>
         <c:change date="2022-01-28T00:00:00+00:00" summary="Fixed the audiobook playback rate getting reset back to 1x after pausing."/>
-        <c:change date="2022-02-03T15:19:49+00:00" summary="Fixed a crash that could happen when exiting an audiobook while it's playing."/>
+        <c:change date="2022-02-03T00:00:00+00:00" summary="Fixed a crash that could happen when exiting an audiobook while it's playing."/>
+        <c:change date="2022-02-03T19:19:14+00:00" summary="Removed sync bookmarks option from libraries that don't require authentication"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountAuthenticationViews.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountAuthenticationViews.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import org.nypl.simplified.accounts.api.AccountPassword
 import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription
 import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription.Anonymous
@@ -59,6 +60,13 @@ class AccountAuthenticationViews(
       this.coppa
     )
 
+  private val dividers =
+    listOf<View>(
+      this.viewGroup.findViewById(R.id.authTopDivider),
+      this.viewGroup.findViewById(R.id.authSpace),
+      this.viewGroup.findViewById(R.id.authBottomDivider)
+    )
+
   /**
    * Lock all of the views in the collection.
    *
@@ -107,6 +115,7 @@ class AccountAuthenticationViews(
    */
 
   fun showFor(description: AccountProviderAuthenticationDescription) {
+    this.dividers.forEach { it.isVisible = description !is Anonymous }
     this.viewGroups.forEach { it.viewGroup.visibility = GONE }
 
     return when (description) {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -4,8 +4,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
-import android.view.View.INVISIBLE
-import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
@@ -212,7 +210,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       this.reportIssueGroup.findViewById(R.id.accountReportIssueEmail)
 
     if (this.parameters.showPleaseLogInTitle) {
-      this.loginTitle.visibility = VISIBLE
+      this.loginTitle.visibility = View.VISIBLE
     } else {
       this.loginTitle.visibility = View.GONE
     }
@@ -254,12 +252,12 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     val account = this.viewModel.account
     return when (status) {
       is ReaderBookmarkSyncEnableStatus.Changing -> {
-        this.bookmarkSyncProgress.visibility = VISIBLE
+        this.bookmarkSyncProgress.visibility = View.VISIBLE
         this.bookmarkSyncCheck.isEnabled = false
       }
 
       is ReaderBookmarkSyncEnableStatus.Idle -> {
-        this.bookmarkSyncProgress.visibility = INVISIBLE
+        this.bookmarkSyncProgress.visibility = View.INVISIBLE
 
         when (status.status) {
           SYNC_ENABLE_NOT_SUPPORTED -> {
@@ -436,7 +434,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     if (email != null) {
       val address = email.removePrefix("mailto:")
 
-      this.reportIssueGroup.visibility = VISIBLE
+      this.reportIssueGroup.visibility = View.VISIBLE
       this.reportIssueEmail.text = address
       this.reportIssueGroup.setOnClickListener {
         val emailIntent =
@@ -476,7 +474,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       view = buttonImage,
       onSuccess = {
         container.background = null
-        buttonImage.visibility = VISIBLE
+        buttonImage.visibility = View.VISIBLE
         buttonText.visibility = View.GONE
       }
     )
@@ -592,6 +590,12 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     this.accountSubtitle.text =
       this.viewModel.account.provider.subtitle
 
+    this.bookmarkSync.visibility = if (this.viewModel.account.requiresCredentials) {
+      View.VISIBLE
+    } else {
+      View.GONE
+    }
+
     /*
      * Only show a EULA if there's actually a EULA.
      */
@@ -656,7 +660,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     this.accountCustomOPDSField.text = catalogURIOverride?.toString() ?: ""
     this.accountCustomOPDS.visibility =
       if (catalogURIOverride != null) {
-        VISIBLE
+        View.VISIBLE
       } else {
         View.GONE
       }
@@ -681,8 +685,8 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       }
 
       is AccountLoggingIn -> {
-        this.loginProgress.visibility = VISIBLE
-        this.loginProgressBar.visibility = VISIBLE
+        this.loginProgress.visibility = View.VISIBLE
+        this.loginProgressBar.visibility = View.VISIBLE
         this.loginProgressText.text = loginState.status
         this.loginButtonErrorDetails.visibility = View.GONE
         this.loginFormLock()
@@ -700,8 +704,8 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       }
 
       is AccountLoggingInWaitingForExternalAuthentication -> {
-        this.loginProgress.visibility = VISIBLE
-        this.loginProgressBar.visibility = VISIBLE
+        this.loginProgress.visibility = View.VISIBLE
+        this.loginProgressBar.visibility = View.VISIBLE
         this.loginProgressText.text = loginState.status
         this.loginButtonErrorDetails.visibility = View.GONE
         this.loginFormLock()
@@ -718,7 +722,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       }
 
       is AccountLoginFailed -> {
-        this.loginProgress.visibility = VISIBLE
+        this.loginProgress.visibility = View.VISIBLE
         this.loginProgressBar.visibility = View.GONE
         this.loginProgressText.text = loginState.taskResult.steps.last().resolution.message
         this.loginFormUnlock()
@@ -729,7 +733,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
             this.tryLogin()
           }
         )
-        this.loginButtonErrorDetails.visibility = VISIBLE
+        this.loginButtonErrorDetails.visibility = View.VISIBLE
         this.loginButtonErrorDetails.setOnClickListener {
           this.viewModel.openErrorPage(loginState.taskResult.steps)
         }
@@ -774,9 +778,9 @@ class AccountDetailFragment : Fragment(R.layout.account) {
           }
         }
 
-        this.loginProgress.visibility = VISIBLE
+        this.loginProgress.visibility = View.VISIBLE
         this.loginButtonErrorDetails.visibility = View.GONE
-        this.loginProgressBar.visibility = VISIBLE
+        this.loginProgressBar.visibility = View.VISIBLE
         this.loginProgressText.text = loginState.status
         this.loginFormLock()
         this.setLoginButtonStatus(AsLogoutButtonDisabled)
@@ -795,7 +799,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
           }
         }
 
-        this.loginProgress.visibility = VISIBLE
+        this.loginProgress.visibility = View.VISIBLE
         this.loginProgressBar.visibility = View.GONE
         this.loginProgressText.text = loginState.taskResult.steps.last().resolution.message
         this.cancelImageButtonLoading()
@@ -807,7 +811,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
           }
         )
 
-        this.loginButtonErrorDetails.visibility = VISIBLE
+        this.loginButtonErrorDetails.visibility = View.VISIBLE
         this.loginButtonErrorDetails.setOnClickListener {
           this.viewModel.openErrorPage(loginState.taskResult.steps)
         }
@@ -893,7 +897,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
   ) {
     if (uri != null) {
       view.setImageDrawable(null)
-      view.visibility = VISIBLE
+      view.visibility = View.VISIBLE
       this.imageLoader.loader.load(uri.toString())
         .fit()
         .tag(this.imageButtonLoadingTag)
@@ -954,7 +958,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
 
   private fun authenticationAlternativesShow() {
     if (this.viewModel.account.provider.authenticationAlternatives.isNotEmpty()) {
-      this.authenticationAlternatives.visibility = VISIBLE
+      this.authenticationAlternatives.visibility = View.VISIBLE
     }
   }
 
@@ -982,7 +986,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
    */
   private fun hideCardCreatorForNonNYPL() {
     if (this.viewModel.account.provider.cardCreatorURI != null) {
-      this.settingsCardCreator.visibility = VISIBLE
+      this.settingsCardCreator.visibility = View.VISIBLE
     }
   }
 

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -1,401 +1,387 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  xmlns:tools="http://schemas.android.com/tools">
-
-  <LinearLayout
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/accountTitleAnnounce"
-      android:layout_width="match_parent"
-      android:layout_height="64dp"
-      android:visibility="visible">
-
-      <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:gravity="center"
-        android:text="@string/accountLoginRequired"
-        android:textSize="18sp"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginBottom="1dp"
-        android:background="?attr/simplifiedColorDisabledAccessibility"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <include layout="@layout/account_cell" />
-
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="1dp"
-      android:background="?attr/simplifiedColorDisabledAccessibility" />
-
-    <Space
-      android:layout_width="match_parent"
-      android:layout_height="16dp" />
-
-    <include layout="@layout/auth" />
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?android:attr/listDivider" />
-
-    <TextView
-        android:id="@+id/accountEULA"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="16dp"
-        android:gravity="center"
-        android:linksClickable="true"
-        android:autoLink="all"
-        android:textColorLink="?attr/colorPrimary"
-        android:textColor="?attr/colorPrimary"
-        android:background="?attr/selectableItemBackground"
-        android:text="@string/accountEULAStatement" />
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/accountLoginProgress"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content">
-
-      <ProgressBar
-        android:id="@+id/accountLoginProgressBar"
-        style="?android:attr/progressBarStyleHorizontal"
-        android:layout_width="0dp"
-        android:layout_height="24dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:indeterminate="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <TextView
-        android:id="@+id/accountLoginProgressText"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:ellipsize="end"
-        android:gravity="center|center_horizontal"
-        android:maxLines="2"
-        android:text="@string/accountPlaceholder"
-        android:textAlignment="center"
-        android:textSize="14sp"
-        android:textStyle="bold"
-        android:freezesText="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/accountLoginProgressBar" />
-
-      <Button
-        android:id="@+id/accountLoginButtonErrorDetails"
-        android:layout_width="256dp"
-        android:layout_height="48dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginBottom="16dp"
-        android:enabled="true"
-        android:lines="1"
-        android:text="@string/errorDetailsTitle"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/accountLoginProgressText" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    android:layout_height="match_parent">
 
     <LinearLayout
-      android:id="@+id/accountAuthAlternatives"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      android:visibility="visible">
-
-      <TextView
-        android:id="@+id/accountAuthAlternativesTitle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="@string/accountLoginAlternatives"
-        android:textStyle="bold" />
-
-      <LinearLayout
-        android:id="@+id/accountAuthAlternativesButtons"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-        <Button
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:text="@string/accountPlaceholder" />
-      </LinearLayout>
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/accountTitleAnnounce"
+            android:layout_width="match_parent"
+            android:layout_height="64dp"
+            android:visibility="visible">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:gravity="center"
+                android:text="@string/accountLoginRequired"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginBottom="1dp"
+                android:background="?attr/simplifiedColorDisabledAccessibility"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <include layout="@layout/account_cell" />
+
+        <include layout="@layout/auth" />
+
+        <TextView
+            android:id="@+id/accountEULA"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autoLink="all"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center"
+            android:linksClickable="true"
+            android:padding="16dp"
+            android:text="@string/accountEULAStatement"
+            android:textColor="?attr/colorPrimary"
+            android:textColorLink="?attr/colorPrimary" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/accountLoginProgress"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ProgressBar
+                android:id="@+id/accountLoginProgressBar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="0dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:indeterminate="true"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/accountLoginProgressText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:ellipsize="end"
+                android:freezesText="true"
+                android:gravity="center|center_horizontal"
+                android:maxLines="2"
+                android:text="@string/accountPlaceholder"
+                android:textAlignment="center"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/accountLoginProgressBar" />
+
+            <Button
+                android:id="@+id/accountLoginButtonErrorDetails"
+                android:layout_width="256dp"
+                android:layout_height="48dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
+                android:enabled="true"
+                android:lines="1"
+                android:text="@string/errorDetailsTitle"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/accountLoginProgressText" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <LinearLayout
+            android:id="@+id/accountAuthAlternatives"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="visible">
+
+            <TextView
+                android:id="@+id/accountAuthAlternativesTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="@string/accountLoginAlternatives"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:id="@+id/accountAuthAlternativesButtons"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/accountPlaceholder" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/accountCardCreator"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone">
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:background="?attr/simplifiedColorDisabledAccessibility"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/accountCardCreatorLabel"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:enabled="false"
+                android:text="@string/accountCardCreatorLabel"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/accountCardCreatorSignUp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/accountCardCreatorSignUp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:enabled="false"
+                android:text="@string/accountCardCreatorSignUp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/accountSyncBookmarks"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:background="?attr/simplifiedColorDisabledAccessibility"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/accountSyncBookmarksLabel"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:labelFor="@id/accountSyncBookmarksCheck"
+                android:text="@string/accountSyncBookmarks"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/accountSyncProgress"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <ProgressBar
+                android:id="@+id/accountSyncProgress"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:indeterminate="true"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/accountSyncBookmarksCheck"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/accountSyncBookmarksCheck"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:enabled="false"
+                android:label="@id/accountSyncBookmarksLabel"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/accountReportIssue"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground">
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:background="?attr/simplifiedColorDisabledAccessibility"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/accountReportIssueText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:background="?android:attr/selectableItemBackground"
+                android:text="@string/accountReportIssue"
+                app:layout_constraintBottom_toTopOf="@id/accountReportIssueEmail"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/accountReportIssueEmail"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:fontFamily="monospace"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:text="someone@example.com" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <FrameLayout
+            android:id="@+id/accountPrivacyPolicy"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:visibility="visible">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_gravity="top"
+                android:background="?android:attr/listDivider" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:text="@string/accountPrivacyPolicy"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/accountLicenses"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:visibility="visible">
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_gravity="top"
+                android:background="?android:attr/listDivider" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:text="@string/accountLicenses"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </FrameLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/accountCustomOPDS"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="visible">
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:background="?attr/simplifiedColorDisabledAccessibility"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/accountCustomOPDSText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:text="@string/accountCustomOPDS"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/accountCustomOPDSField"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:enabled="false"
+                android:typeface="monospace"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/accountCustomOPDSText" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
     </LinearLayout>
-
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="16dp"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent" />
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/accountCardCreator"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:visibility="gone">
-
-      <View
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="?attr/simplifiedColorDisabledAccessibility"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <TextView
-        android:id="@+id/accountCardCreatorLabel"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:enabled="false"
-        android:text="@string/accountCardCreatorLabel"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/accountCardCreatorSignUp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <Button
-        android:id="@+id/accountCardCreatorSignUp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:enabled="false"
-        android:text="@string/accountCardCreatorSignUp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/accountSyncBookmarks"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content">
-
-      <View
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="?attr/simplifiedColorDisabledAccessibility"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <TextView
-        android:id="@+id/accountSyncBookmarksLabel"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:labelFor="@id/accountSyncBookmarksCheck"
-        android:text="@string/accountSyncBookmarks"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/accountSyncProgress"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <ProgressBar
-        android:id="@+id/accountSyncProgress"
-        style="?android:attr/progressBarStyle"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:indeterminate="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/accountSyncBookmarksCheck"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/accountSyncBookmarksCheck"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:enabled="false"
-        android:label="@id/accountSyncBookmarksLabel"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/accountReportIssue"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:background="?attr/selectableItemBackground">
-
-      <View
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="?attr/simplifiedColorDisabledAccessibility"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <TextView
-        android:id="@+id/accountReportIssueText"
-        android:background="?android:attr/selectableItemBackground"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:text="@string/accountReportIssue"
-        app:layout_constraintBottom_toTopOf="@id/accountReportIssueEmail"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <TextView
-        android:id="@+id/accountReportIssueEmail"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:fontFamily="monospace"
-        tools:text="someone@example.com"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-      <FrameLayout
-          android:id="@+id/accountPrivacyPolicy"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:background="?attr/selectableItemBackground"
-          android:visibility="visible">
-
-          <View
-              android:layout_width="match_parent"
-              android:layout_height="1dp"
-              android:background="?android:attr/listDivider"
-              android:layout_gravity="top" />
-
-          <TextView
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:padding="16dp"
-              android:text="@string/accountPrivacyPolicy"
-              app:layout_constraintEnd_toEndOf="parent"
-              app:layout_constraintStart_toStartOf="parent"
-              app:layout_constraintTop_toTopOf="parent" />
-
-      </FrameLayout>
-
-      <FrameLayout
-      android:id="@+id/accountLicenses"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:background="?attr/selectableItemBackground"
-      android:visibility="visible">
-
-          <View
-              android:layout_width="match_parent"
-              android:layout_height="1dp"
-              android:background="?android:attr/listDivider"
-              android:layout_gravity="top" />
-
-          <TextView
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:padding="16dp"
-              android:text="@string/accountLicenses"
-              app:layout_constraintEnd_toEndOf="parent"
-              app:layout_constraintStart_toStartOf="parent"
-              app:layout_constraintTop_toTopOf="parent" />
-      </FrameLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-      android:id="@+id/accountCustomOPDS"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:visibility="visible">
-
-      <View
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="?attr/simplifiedColorDisabledAccessibility"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <TextView
-        android:id="@+id/accountCustomOPDSText"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:text="@string/accountCustomOPDS"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-      <TextView
-        android:id="@+id/accountCustomOPDSField"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:enabled="false"
-        android:typeface="monospace"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/accountCustomOPDSText" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-  </LinearLayout>
 </ScrollView>

--- a/simplified-ui-accounts/src/main/res/layout/auth.xml
+++ b/simplified-ui-accounts/src/main/res/layout/auth.xml
@@ -1,14 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:id="@+id/auth"
-  android:layout_width="match_parent"
-  android:layout_height="wrap_content">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/auth"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-  <include layout="@layout/auth_anon" />
-  <include layout="@layout/auth_basic" />
-  <include layout="@layout/auth_coppa" />
-  <include layout="@layout/auth_oauth" />
-  <include layout="@layout/auth_saml" />
+    <View
+        android:id="@+id/authTopDivider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?attr/simplifiedColorDisabledAccessibility" />
 
-</FrameLayout>
+    <Space
+        android:id="@+id/authSpace"
+        android:layout_width="match_parent"
+        android:layout_height="16dp" />
+
+    <include layout="@layout/auth_anon" />
+
+    <include layout="@layout/auth_basic" />
+
+    <include layout="@layout/auth_coppa" />
+
+    <include layout="@layout/auth_oauth" />
+
+    <include layout="@layout/auth_saml" />
+
+    <View
+        android:id="@+id/authBottomDivider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?android:attr/listDivider" />
+
+</LinearLayout>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -490,10 +490,10 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     bookStatus: BookStatus.Held,
     book: Book
   ) {
-    this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.buttons.removeAllViews()
     when (bookStatus) {
-      is BookStatus.Held.HeldInQueue ->
+      is BookStatus.Held.HeldInQueue -> {
+        this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
         if (bookStatus.isRevocable) {
           this.buttons.addView(
             this.buttonCreator.createRevokeHoldButton(
@@ -508,6 +508,9 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
           )
         }
 
+        this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
+      }
+
       is BookStatus.Held.HeldReady -> {
         if (bookStatus.isRevocable) {
           this.buttons.addView(
@@ -517,7 +520,11 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
               }
             )
           )
+          this.buttons.addView(this.buttonCreator.createButtonSpace())
+        } else {
+          this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
         }
+
         this.buttons.addView(
           this.buttonCreator.createGetButton(
             onClick = {
@@ -525,9 +532,13 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
             }
           )
         )
+
+        // if the book is not revocable, we need to add a dummy button on the right
+        if (!bookStatus.isRevocable) {
+          this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
+        }
       }
     }
-    this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
     this.checkButtonViewCount()
 
     this.statusInProgress.visibility = View.INVISIBLE


### PR DESCRIPTION
**What's this do?**
This PR adds logic to check if a library requires credentials in order to show or hide the sync bookmarks option. It also rearranges a bit the UI so, when the library doesn't require authentication, it doesn't look like [this](https://user-images.githubusercontent.com/79104027/152415534-d76fba2c-4855-45c9-b909-29400bf6deff.png). Finally, this PR also fixes the button action position in the book details page when it's reserved and can be removed, so it looks like [this](https://user-images.githubusercontent.com/79104027/152415745-a23d47a1-9625-488e-815b-ed24109d3d13.png).

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket to remove the sync bookmark option](https://www.notion.so/lyrasis/Remove-Sync-Bookmarks-setting-for-Palace-Bookshelf-on-Android-12490cdf78da4eb9b25b18ec0c5b178c) for the libraries that don't require authentication because the user will never be able to log in to that library and to get his bookmarks synced in differente devices. The UI related fixes were made to improve the app and to make the user's experience better.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select the "Palace Bookshelf" library
Open settings
Verify [the 'Sync Bookmarks' option is not there](https://user-images.githubusercontent.com/79104027/152416304-3063e754-bd01-43c1-98e9-d4d96caad788.png)
Go back and select "Lyrasis Reads" library
Open settings
Verify [the 'Sync Bookmarks' option is there](https://user-images.githubusercontent.com/79104027/152416340-b6f9079f-5f0a-4bb8-a566-26434b61664e.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 