### PR TITLE
Remove returned books from My Books

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -151,11 +151,12 @@
         <c:change date="2022-01-21T00:00:00+00:00" summary="Removed the &quot;Show&quot; filter from My Books. This wasn't useful."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-02-03T19:19:14+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
+    <c:release date="2022-02-04T05:49:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
       <c:changes>
         <c:change date="2022-01-28T00:00:00+00:00" summary="Fixed the audiobook playback rate getting reset back to 1x after pausing."/>
         <c:change date="2022-02-03T00:00:00+00:00" summary="Fixed a crash that could happen when exiting an audiobook while it's playing."/>
-        <c:change date="2022-02-03T19:19:14+00:00" summary="Removed sync bookmarks option from libraries that don't require authentication"/>
+        <c:change date="2022-02-03T00:00:00+00:00" summary="Removed sync bookmarks option from libraries that don't require authentication"/>
+        <c:change date="2022-02-04T05:49:43+00:00" summary="Fixed books remaining in My Books after they've been returned."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookRevokeTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookRevokeTask.kt
@@ -84,6 +84,7 @@ class BookRevokeTask(
     this.revokeFormatHandle(account)
     this.revokeNotifyServer(account)
     this.revokeNotifyServerDeleteBook()
+    this.bookRegistry.clearFor(this.bookID)
     return this.taskRecorder.finishSuccess(Unit)
   }
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskAdobeDRMTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskAdobeDRMTest.kt
@@ -50,7 +50,6 @@ import org.nypl.simplified.books.book_database.api.BookDatabaseType
 import org.nypl.simplified.books.book_database.api.BookFormats
 import org.nypl.simplified.books.book_registry.BookRegistry
 import org.nypl.simplified.books.book_registry.BookRegistryType
-import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.bundled.api.BundledContentResolverType
 import org.nypl.simplified.books.controller.BookRevokeTask
 import org.nypl.simplified.books.formats.api.BookFormatSupportType
@@ -322,8 +321,7 @@ class BookRevokeTaskAdobeDRMTest {
     TaskDumps.dump(logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Loaned.LoanedNotDownloaded
+    Assertions.assertNull(this.bookRegistry.bookOrNull(bookId))
 
     Mockito.verify(bookDatabaseEntry, Times(1)).delete()
   }
@@ -439,8 +437,7 @@ class BookRevokeTaskAdobeDRMTest {
     TaskDumps.dump(logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Loaned.LoanedNotDownloaded
+    Assertions.assertNull(this.bookRegistry.bookOrNull(bookId))
 
     Mockito.verify(bookDatabaseEntry, Times(1)).delete()
   }
@@ -600,8 +597,7 @@ class BookRevokeTaskAdobeDRMTest {
     TaskDumps.dump(logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Loaned.LoanedNotDownloaded
+    Assertions.assertNull(this.bookRegistry.bookOrNull(bookId))
 
     Mockito.verify(bookDatabaseEntry, Times(1)).delete()
     Mockito.verify(drmHandle, Times(1)).setAdobeRightsInformation(null)

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskTest.kt
@@ -17,6 +17,7 @@ import org.joda.time.Duration
 import org.joda.time.Instant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -276,8 +277,7 @@ class BookRevokeTaskTest {
     TaskDumps.dump(this.logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Loaned.LoanedNotDownloaded
+    assertNull(this.bookRegistry.bookOrNull(bookId))
 
     assertTrue(bookDatabaseEntry.deleted)
     assertEquals(0, this.server.requestCount)
@@ -683,8 +683,7 @@ class BookRevokeTaskTest {
     TaskDumps.dump(this.logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Loaned.LoanedNotDownloaded
+    assertNull(this.bookRegistry.bookOrNull(bookId))
 
     Mockito.verify(bookDatabaseEntry, Times(1)).delete()
 
@@ -816,8 +815,7 @@ class BookRevokeTaskTest {
     TaskDumps.dump(this.logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Loanable
+    assertNull(this.bookRegistry.bookOrNull(bookId))
 
     assertTrue(bookDatabaseEntry.deleted)
     assertEquals(1, this.server.requestCount)
@@ -1050,8 +1048,7 @@ class BookRevokeTaskTest {
     TaskDumps.dump(this.logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Holdable
+    assertNull(this.bookRegistry.bookOrNull(bookId))
 
     assertTrue(bookDatabaseEntry.deleted)
     assertEquals(1, this.server.requestCount)
@@ -1177,8 +1174,7 @@ class BookRevokeTaskTest {
     TaskDumps.dump(this.logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Holdable
+    assertNull(this.bookRegistry.bookOrNull(bookId))
 
     assertTrue(bookDatabaseEntry.deleted)
     assertEquals(0, this.server.requestCount)
@@ -1312,8 +1308,7 @@ class BookRevokeTaskTest {
     TaskDumps.dump(this.logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Loaned.LoanedNotDownloaded
+    assertNull(this.bookRegistry.bookOrNull(bookId))
 
     assertTrue(bookDatabaseEntry.deleted)
     assertEquals(1, this.server.requestCount)
@@ -1415,8 +1410,7 @@ class BookRevokeTaskTest {
     TaskDumps.dump(this.logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus is BookStatus.Loanable
+    assertNull(this.bookRegistry.bookOrNull(bookId))
 
     assertTrue(bookDatabaseEntry.deleted)
     assertEquals(0, this.server.requestCount)
@@ -1546,8 +1540,7 @@ class BookRevokeTaskTest {
     TaskDumps.dump(this.logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Loaned.LoanedNotDownloaded
+    assertNull(this.bookRegistry.bookOrNull(bookId))
 
     assertTrue(bookDatabaseEntry.deleted)
     assertEquals(1, this.server.requestCount)
@@ -2473,8 +2466,7 @@ class BookRevokeTaskTest {
     TaskDumps.dump(this.logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Loaned.LoanedNotDownloaded
+    assertNull(this.bookRegistry.bookOrNull(bookId))
 
     Mockito.verify(bookDatabaseEntry, Times(1)).delete()
 
@@ -2601,8 +2593,7 @@ class BookRevokeTaskTest {
     TaskDumps.dump(this.logger, result)
     result as TaskResult.Success
 
-    val newStatus = this.bookRegistry.bookOrException(bookId).status
-    newStatus as BookStatus.Loaned.LoanedNotDownloaded
+    assertNull(this.bookRegistry.bookOrNull(bookId))
 
     assertTrue(bookDatabaseEntry.deleted)
     assertEquals(1, this.server.requestCount)


### PR DESCRIPTION
**What's this do?**

This removes books from the registry after they have been revoked (returned) and deleted from the database. It's basically the same fix as #62, added to another code path.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes some books not being removed from My Books after they're returned. Notion: https://www.notion.so/lyrasis/Android-shows-already-returned-books-in-bookshelf-after-refresh-6b2f0d6e8afc4144af6b2dd48311034a

**How should this be tested? / Do these changes have associated tests?**

- In San Diego County Library, borrow a book, e.g. "The Woodlanders" by Thomas Hardy
- Open My Books, and confirm that the book appears
- Return the book
 
Verify that the book disappears from My Books.

Unit tests were updated.

**Dependencies for merging? Releasing to production?**

None

**Have you updated the changelog?**

Yes

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested the Palace app.

