### PR TITLE
Fixed related books error

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -151,13 +151,14 @@
         <c:change date="2022-01-21T00:00:00+00:00" summary="Removed the &quot;Show&quot; filter from My Books. This wasn't useful."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-02-08T03:20:11+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
+    <c:release date="2022-02-08T11:14:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
       <c:changes>
         <c:change date="2022-01-28T00:00:00+00:00" summary="Fixed the audiobook playback rate getting reset back to 1x after pausing."/>
         <c:change date="2022-02-03T00:00:00+00:00" summary="Fixed a crash that could happen when exiting an audiobook while it's playing."/>
         <c:change date="2022-02-03T00:00:00+00:00" summary="Removed sync bookmarks option from libraries that don't require authentication"/>
         <c:change date="2022-02-04T00:00:00+00:00" summary="Fixed books remaining in My Books after they've been returned."/>
-        <c:change date="2022-02-08T03:20:11+00:00" summary="Fixed reader toolbar not changing color to match the selected color scheme."/>
+        <c:change date="2022-02-08T00:00:00+00:00" summary="Fixed reader toolbar not changing color to match the selected color scheme."/>
+        <c:change date="2022-02-08T11:14:45+00:00" summary="Fixed related books error"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
@@ -209,7 +209,7 @@ class CatalogBookDetailViewModel(
     return when (val arguments = this.parameters.feedArguments) {
       is CatalogFeedArguments.CatalogFeedArgumentsRemote ->
         CatalogFeedArguments.CatalogFeedArgumentsRemote(
-          feedURI = arguments.feedURI.resolve(uri).normalize(),
+          feedURI = arguments.feedURI.resolve(uri),
           isSearchResults = false,
           ownership = CatalogFeedOwnership.OwnedByAccount(accountID),
           title = title
@@ -217,7 +217,7 @@ class CatalogBookDetailViewModel(
 
       is CatalogFeedArguments.CatalogFeedArgumentsLocalBooks -> {
         CatalogFeedArguments.CatalogFeedArgumentsRemote(
-          feedURI = uri.normalize(),
+          feedURI = uri,
           isSearchResults = false,
           ownership = CatalogFeedOwnership.OwnedByAccount(accountID),
           title = title


### PR DESCRIPTION
**What's this do?**
This PR fixes an URI parsing that was making it unparseable by the app, leading to an error message when trying to open some book related books.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://www.notion.so/lyrasis/Error-appears-when-you-try-to-open-related-books-6b840acfd4354598b75fb38dd647e51b) indicating that the books from the Palace Bookshelf are not allowing to open their related books feed.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select "Palace Bookshelf" library
Open any ebook
Scroll down and click on "Related books..."
Verify the feed [is being correctly opened](https://user-images.githubusercontent.com/79104027/152983229-07382453-de59-445d-bd5d-6a5bf2d4fea1.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 