### PR TITLE
Upgrade to production LCP library.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,42 @@ ext {
       throw new GradleException(text);
     }
   }
+
+  //
+  // Load secrets stored in secrets.conf.
+  //
+
+  assetPath = project.findProperty('org.thepalaceproject.app.assets.palace')
+  secrets = new Properties()
+
+  if (nyplDrmEnabled) {
+    file("$assetPath/secrets.conf").withInputStream {
+      secrets.load(it)
+    }
+  }
+
+  //
+  // Get the LCP production license key from secrets, or default to the test key.
+  //
+
+  lcpLicenseKey = secrets.getProperty('lcp.prod.license.key', 'test')
+}
+
+//
+// If we're not using the production LCP module, the only version available is 1.0.0, so
+// substitute out the version that was requested.
+//
+
+if (lcpLicenseKey == 'test') {
+  allprojects {
+    configurations.all {
+      resolutionStrategy {
+        dependencySubstitution {
+          substitute module('readium:liblcp') using module('readium:liblcp:1.0.0') because 'no LCP production license key was found, and the LCP test repository only contains version 1.0.0'
+        }
+      }
+    }
+  }
 }
 
 subprojects { project ->
@@ -186,7 +222,7 @@ subprojects { project ->
       name = "LCP"
       url = uri('https://liblcp.dita.digital')
       patternLayout {
-        artifact ("/[organisation]/[module]/android/aar/test/[revision].aar")
+        artifact ("/[organisation]/[module]/android/aar/$lcpLicenseKey/[revision].[ext]")
       }
       metadataSources {
         artifact()

--- a/simplified-app-palace/build.gradle
+++ b/simplified-app-palace/build.gradle
@@ -9,7 +9,7 @@ def requiredFiles = [:]
 requiredFiles["ReaderClientCert.sig"] =
   "b064e68b96e258e42fe1ca66ae3fc4863dd802c46585462220907ed291e1217d"
 requiredFiles["secrets.conf"] =
-  "35dbb18c0e97a6f0e3d9745c2f2ebff1a915202daa8905f650a742071a751f27"
+  "a824d3474ae695ccef4bac3ca92961d9b1eaf62a5db706cdea177a8cf6e27ea2"
 
 android {
   defaultConfig {


### PR DESCRIPTION
**What's this do?**

This makes changes needed to use the production Readium LCP library:
- Our license key for the production library is stored in the secrets.conf file in mobile-certificates. The values in secrets.conf weren't previously available in build.gradle. This makes it so they are. (We've previously only made GitHub repo secrets available in build.gradle, but that doesn't seem to be the right place for this value, because it will be the same whether you're building locally or on CI). 
- The location of the LCP artifact is changed to the production location (which includes the license key) instead of the test location.
- The android-platform subproject is updated to change the version of the LCP library to 2.0.0 instead of 1.0.0. The 2.0.0 version appears to be the only one in production, and the 1.0.0 version appears to be the only one in test.

**Why are we doing this? (w/ JIRA link if applicable)**

This is required to read LCP-secured books from Palace Marketplace, which use the `http://readium.org/lcp/profile-1.0` profile, only supported by the production library.

Notion: 
- https://www.notion.so/lyrasis/Test-LCP-for-ebooks-on-Android-3e48460a2f6243f1bd50fe89c66cc159#285b1e1822b14d23a0dda478d89378a4
- https://www.notion.so/lyrasis/Add-LCP-to-Android-app-286cfc2b5fa543dd8159321413dcc319#1df3bafaa71843a3993acfaa2bc55136

**How should this be tested? / Do these changes have associated tests?**

In LYRASIS Reads, borrow and open a Palace Marketplace book from the DPLA Titles lane, e.g. "Another Kind of Eden".

The app may crash or show an error, but the error should _not_ be:
```
There was an error opening the book: (java.io.IOException): Failed to unlock EPUB.
```

I'm looking into the crash, but since LCP books can't be read without this PR, it's not really making things any worse.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

No, this isn't (yet) a user-visible change. When LCP books are working, I'll update the changelog in that PR.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran it to verify that the production library is now used (although LCP books still don't work yet).
