### PR TITLE
Removed audiobook cover image resizing

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -159,7 +159,7 @@
         <c:change date="2022-02-04T00:00:00+00:00" summary="Fixed books remaining in My Books after they've been returned."/>
         <c:change date="2022-02-08T00:00:00+00:00" summary="Fixed reader toolbar not changing color to match the selected color scheme."/>
         <c:change date="2022-02-08T00:00:00+00:00" summary="Fixed related books error"/>
-        <c:change date="2022-02-15T16:30:25+00:00" summary="Removed audiobook cover image resizing"/>
+        <c:change date="2022-02-15T16:30:25+00:00" summary="Removed audiobook cover image resizing dimensions"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -151,14 +151,15 @@
         <c:change date="2022-01-21T00:00:00+00:00" summary="Removed the &quot;Show&quot; filter from My Books. This wasn't useful."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-02-08T11:14:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
+    <c:release date="2022-02-15T16:30:25+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
       <c:changes>
         <c:change date="2022-01-28T00:00:00+00:00" summary="Fixed the audiobook playback rate getting reset back to 1x after pausing."/>
         <c:change date="2022-02-03T00:00:00+00:00" summary="Fixed a crash that could happen when exiting an audiobook while it's playing."/>
         <c:change date="2022-02-03T00:00:00+00:00" summary="Removed sync bookmarks option from libraries that don't require authentication"/>
         <c:change date="2022-02-04T00:00:00+00:00" summary="Fixed books remaining in My Books after they've been returned."/>
         <c:change date="2022-02-08T00:00:00+00:00" summary="Fixed reader toolbar not changing color to match the selected color scheme."/>
-        <c:change date="2022-02-08T11:14:45+00:00" summary="Fixed related books error"/>
+        <c:change date="2022-02-08T00:00:00+00:00" summary="Fixed related books error"/>
+        <c:change date="2022-02-15T16:30:25+00:00" summary="Removed audiobook cover image resizing"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
@@ -52,8 +52,6 @@ class BookCoverProvider private constructor(
   private fun doLoad(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
-    width: Int,
-    height: Int,
     tag: String,
     uriSpecified: URI?
   ): FluentFuture<Unit> {
@@ -106,7 +104,6 @@ class BookCoverProvider private constructor(
             .tag(tag)
             .error(R.drawable.cover_error)
             .placeholder(R.drawable.cover_loading)
-            .resize(width, height)
             .transform(badgePainter)
             .into(imageView, callbackFinal)
         }
@@ -116,7 +113,6 @@ class BookCoverProvider private constructor(
         .tag(tag)
         .error(R.drawable.cover_error)
         .placeholder(R.drawable.cover_loading)
-        .resize(width, height)
         .transform(badgePainter)
         .into(imageView, fallbackToGeneration)
     } else {
@@ -126,7 +122,6 @@ class BookCoverProvider private constructor(
         .tag(tag)
         .error(R.drawable.cover_error)
         .placeholder(R.drawable.cover_loading)
-        .resize(width, height)
         .transform(badgePainter)
         .into(imageView, callbackFinal)
     }
@@ -197,14 +192,10 @@ class BookCoverProvider private constructor(
   override fun loadThumbnailInto(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
-    width: Int,
-    height: Int
   ): FluentFuture<Unit> {
     return doLoad(
       entry = entry,
       imageView = imageView,
-      width = width,
-      height = height,
       tag = thumbnailTag,
       uriSpecified = thumbnailURIOf(entry)
     )
@@ -213,14 +204,10 @@ class BookCoverProvider private constructor(
   override fun loadCoverInto(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
-    width: Int,
-    height: Int
   ): FluentFuture<Unit> {
     return doLoad(
       entry = entry,
       imageView = imageView,
-      width = width,
-      height = height,
       tag = coverTag,
       uriSpecified = coverURIOf(entry)
     )

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
@@ -52,6 +52,8 @@ class BookCoverProvider private constructor(
   private fun doLoad(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
+    width: Int,
+    height: Int,
     tag: String,
     uriSpecified: URI?
   ): FluentFuture<Unit> {
@@ -100,29 +102,45 @@ class BookCoverProvider private constructor(
             e
           )
 
-          this@BookCoverProvider.picasso.load(uriGenerated.toString())
+          val requestCreator = this@BookCoverProvider.picasso.load(uriGenerated.toString())
             .tag(tag)
             .error(R.drawable.cover_error)
             .placeholder(R.drawable.cover_loading)
+
+          if (width > 0 || height > 0) {
+            requestCreator.resize(width, height)
+          }
+
+          requestCreator
             .transform(badgePainter)
             .into(imageView, callbackFinal)
         }
       }
 
-      this.picasso.load(uriSpecified.toString())
+      val requestCreator = this.picasso.load(uriSpecified.toString())
         .tag(tag)
         .error(R.drawable.cover_error)
         .placeholder(R.drawable.cover_loading)
-        .transform(badgePainter)
+
+      if (width > 0 || height > 0) {
+        requestCreator.resize(width, height)
+      }
+
+      requestCreator.transform(badgePainter)
         .into(imageView, fallbackToGeneration)
     } else {
       this.logger.debug("{}: {}: loading generated uri {}", tag, entry.bookID, uriGenerated)
 
-      this.picasso.load(uriGenerated.toString())
+      val requestCreator = this.picasso.load(uriGenerated.toString())
         .tag(tag)
         .error(R.drawable.cover_error)
         .placeholder(R.drawable.cover_loading)
-        .transform(badgePainter)
+
+      if (width > 0 || height > 0) {
+        requestCreator.resize(width, height)
+      }
+
+      requestCreator.transform(badgePainter)
         .into(imageView, callbackFinal)
     }
 
@@ -168,7 +186,11 @@ class BookCoverProvider private constructor(
     val bitmap: Bitmap = if (drawable.intrinsicWidth <= 0 || drawable.intrinsicHeight <= 0) {
       Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
     } else {
-      Bitmap.createBitmap(drawable.intrinsicWidth, drawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
+      Bitmap.createBitmap(
+        drawable.intrinsicWidth,
+        drawable.intrinsicHeight,
+        Bitmap.Config.ARGB_8888
+      )
     }
 
     val canvas = Canvas(bitmap)
@@ -192,10 +214,14 @@ class BookCoverProvider private constructor(
   override fun loadThumbnailInto(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
+    width: Int,
+    height: Int
   ): FluentFuture<Unit> {
     return doLoad(
       entry = entry,
       imageView = imageView,
+      width = width,
+      height = height,
       tag = thumbnailTag,
       uriSpecified = thumbnailURIOf(entry)
     )
@@ -204,10 +230,14 @@ class BookCoverProvider private constructor(
   override fun loadCoverInto(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
+    width: Int,
+    height: Int
   ): FluentFuture<Unit> {
     return doLoad(
       entry = entry,
       imageView = imageView,
+      width = width,
+      height = height,
       tag = coverTag,
       uriSpecified = coverURIOf(entry)
     )

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProviderType.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProviderType.kt
@@ -32,15 +32,11 @@ interface BookCoverProviderType {
    *
    * @param entry The feed entry
    * @param imageView The image view
-   * @param width Use 0 as desired dimension to resize keeping aspect ratio.
-   * @param height Use 0 as desired dimension to resize keeping aspect ratio.
    */
 
   fun loadThumbnailInto(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
-    width: Int,
-    height: Int
   ): FluentFuture<Unit>
 
   /**
@@ -51,15 +47,11 @@ interface BookCoverProviderType {
    *
    * @param entry The feed entry
    * @param imageView The image view
-   * @param width Use 0 as desired dimension to resize keeping aspect ratio.
-   * @param height Use 0 as desired dimension to resize keeping aspect ratio.
    */
 
   fun loadCoverInto(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
-    width: Int,
-    height: Int
   ): FluentFuture<Unit>
 
   /**

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProviderType.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProviderType.kt
@@ -32,11 +32,15 @@ interface BookCoverProviderType {
    *
    * @param entry The feed entry
    * @param imageView The image view
+   * @param width Use 0 as desired dimension to resize keeping aspect ratio.
+   * @param height Use 0 as desired dimension to resize keeping aspect ratio.
    */
 
   fun loadThumbnailInto(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
+    width: Int,
+    height: Int
   ): FluentFuture<Unit>
 
   /**
@@ -47,11 +51,15 @@ interface BookCoverProviderType {
    *
    * @param entry The feed entry
    * @param imageView The image view
+   * @param width Use 0 as desired dimension to resize keeping aspect ratio.
+   * @param height Use 0 as desired dimension to resize keeping aspect ratio.
    */
 
   fun loadCoverInto(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
+    width: Int,
+    height: Int
   ): FluentFuture<Unit>
 
   /**

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -718,9 +718,7 @@ class AudioBookPlayerActivity :
 
     this.covers.loadCoverInto(
       FeedEntry.FeedEntryOPDS(this.parameters.accountID, this.parameters.opdsEntry),
-      view,
-      this.screenSize.dpToPixels(300).toInt(),
-      this.screenSize.dpToPixels(400).toInt()
+      view
     )
   }
 

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -709,16 +709,11 @@ class AudioBookPlayerActivity :
   }
 
   override fun onPlayerWantsCoverImage(view: ImageView) {
-    /*
-     * Use the cover provider to load a cover image into the image view. The width and height
-     * are essentially hints; the target image view almost certainly won't have a usable size
-     * before this method is called, so we pass in a width/height hint that should give something
-     * reasonably close to the expected 3:4 cover image size ratio.
-     */
-
     this.covers.loadCoverInto(
-      FeedEntry.FeedEntryOPDS(this.parameters.accountID, this.parameters.opdsEntry),
-      view
+      entry = FeedEntry.FeedEntryOPDS(this.parameters.accountID, this.parameters.opdsEntry),
+      imageView = view,
+      width = 0,
+      height = 0
     )
   }
 


### PR DESCRIPTION
**What's this do?**
This PR removes the hardcoded dimensions for the audiobook cover loading and adds a verification to prevent both width and height being zero or less

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=22cd92c0cc5c46409134c9f380e6e718&p=20cfdbb862d340b6a95c4efe714fa6d4) saying the images are appearing stretched in some audiobooks and this PR will make them be equally displayed regardless of the selected audiobook

**How should this be tested? / Do these changes have associated tests?**
Open the app
Go to settings and tap 7 times the commit version to enable debug options
Inside debug options, enable "Show non-production libraries" option
Go back and add the library "Palace Marketplace Integration Library"
Search and open the audiobook "Lives of the pirates"
Verify the [image is perfectly sized](https://user-images.githubusercontent.com/79104027/154138104-fdd03087-3e3d-4588-8230-9923dd6f3f4c.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 