### PR TITLE
Added toolbar with back button to pdf reader

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -151,7 +151,7 @@
         <c:change date="2022-01-21T00:00:00+00:00" summary="Removed the &quot;Show&quot; filter from My Books. This wasn't useful."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-02-15T23:16:55+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
+    <c:release date="2022-02-18T14:52:16+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
       <c:changes>
         <c:change date="2022-01-28T00:00:00+00:00" summary="Fixed the audiobook playback rate getting reset back to 1x after pausing."/>
         <c:change date="2022-02-03T00:00:00+00:00" summary="Fixed a crash that could happen when exiting an audiobook while it's playing."/>
@@ -159,8 +159,9 @@
         <c:change date="2022-02-04T00:00:00+00:00" summary="Fixed books remaining in My Books after they've been returned."/>
         <c:change date="2022-02-08T00:00:00+00:00" summary="Fixed reader toolbar not changing color to match the selected color scheme."/>
         <c:change date="2022-02-08T00:00:00+00:00" summary="Fixed related books error"/>
-        <c:change date="2022-02-15T16:30:25+00:00" summary="Removed audiobook cover image resizing dimensions"/>
-        <c:change date="2022-02-15T23:16:55+00:00" summary="Updated text on debug options"/>
+        <c:change date="2022-02-15T00:00:00+00:00" summary="Removed audiobook cover image resizing dimensions"/>
+        <c:change date="2022-02-15T00:00:00+00:00" summary="Updated text on debug options"/>
+        <c:change date="2022-02-18T14:52:16+00:00" summary="Added toolbar with back button to pdf reader"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfReaderActivity.kt
@@ -3,7 +3,9 @@ package org.nypl.simplified.viewer.pdf
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import edu.umn.minitex.pdf.android.api.PdfFragmentListenerType
 import edu.umn.minitex.pdf.android.api.TableOfContentsFragmentListenerType
 import edu.umn.minitex.pdf.android.api.TableOfContentsItem
@@ -84,6 +86,12 @@ class PdfReaderActivity :
     this.account = currentProfile.account(accountId)
     this.books = account.bookDatabase
 
+    val toolbar = this.findViewById(R.id.pdf_toolbar) as Toolbar
+    this.setSupportActionBar(toolbar)
+    this.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    this.supportActionBar?.setDisplayShowHomeEnabled(true)
+    this.supportActionBar?.title = ""
+
     try {
       this.entry = books.entry(id)
       this.handle = entry.findFormatHandle(BookDatabaseEntryFormatHandlePDF::class.java)!!
@@ -104,6 +112,13 @@ class PdfReaderActivity :
       this.tableOfContentsList =
         savedInstanceState.getParcelableArrayList(TABLE_OF_CONTENTS) ?: arrayListOf()
     }
+  }
+
+  override fun onOptionsItemSelected(item: MenuItem): Boolean {
+    if (item.itemId == android.R.id.home) {
+      onBackPressed()
+    }
+    return super.onOptionsItemSelected(item)
   }
 
   override fun onSaveInstanceState(outState: Bundle) {

--- a/simplified-viewer-pdf/src/main/res/layout/pdf_reader.xml
+++ b/simplified-viewer-pdf/src/main/res/layout/pdf_reader.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:orientation="vertical">
-
-  <FrameLayout
-    android:id="@+id/pdf_reader_fragment_holder"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/pdf_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:theme="?android:attr/actionBarTheme"
+        app:title="" />
+
+    <FrameLayout
+        android:id="@+id/pdf_reader_fragment_holder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
 </LinearLayout>


### PR DESCRIPTION
**What's this do?**
This PR adds a toolbar with a back button to the pdf reader screen

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=22cd92c0cc5c46409134c9f380e6e718&p=5d703b8bfd334b148c77a4f9db216a8c) that says the user can't go back in the pdf reader screen. If he doesn't have the physical button on his device, he needs to close and reopen the app in order to get back to the catalog.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select "Lyrasis Reads" library
Open an ebook from Biblioboard, p.e., _Steven Universe #1 (Issue 1)_ by _Rebecca Sugar
Verify [the screen has a back button](https://user-images.githubusercontent.com/79104027/154706771-cfa45424-4ce9-43da-b4d9-15b36db30052.png)
Click on the back button and verify you're back at the catalog page

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 