### PR TITLE
Added narrators information to the book detail page

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -151,7 +151,7 @@
         <c:change date="2022-01-21T00:00:00+00:00" summary="Removed the &quot;Show&quot; filter from My Books. This wasn't useful."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-02-18T14:52:16+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
+    <c:release date="2022-02-23T23:35:14+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
       <c:changes>
         <c:change date="2022-01-28T00:00:00+00:00" summary="Fixed the audiobook playback rate getting reset back to 1x after pausing."/>
         <c:change date="2022-02-03T00:00:00+00:00" summary="Fixed a crash that could happen when exiting an audiobook while it's playing."/>
@@ -161,7 +161,8 @@
         <c:change date="2022-02-08T00:00:00+00:00" summary="Fixed related books error"/>
         <c:change date="2022-02-15T00:00:00+00:00" summary="Removed audiobook cover image resizing dimensions"/>
         <c:change date="2022-02-15T00:00:00+00:00" summary="Updated text on debug options"/>
-        <c:change date="2022-02-18T14:52:16+00:00" summary="Added toolbar with back button to pdf reader"/>
+        <c:change date="2022-02-18T00:00:00+00:00" summary="Added toolbar with back button to pdf reader"/>
+        <c:change date="2022-02-23T23:35:14+00:00" summary="Added narrators information to book details page"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntry.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntry.java
@@ -39,6 +39,7 @@ public final class OPDSAcquisitionFeedEntry implements Serializable {
   private final OptionType<String> publisher;
   private final String distribution;
   private final String summary;
+  private final List<String> narrators;
   private final OptionType<URI> thumbnail;
   private final String title;
   private final DateTime updated;
@@ -61,6 +62,7 @@ public final class OPDSAcquisitionFeedEntry implements Serializable {
     final OptionType<URI> in_thumbnail,
     final DateTime in_updated,
     final String in_summary,
+    final List<String> in_narrators,
     final OptionType<DateTime> in_published,
     final OptionType<String> in_publisher,
     final String in_distribution,
@@ -82,6 +84,7 @@ public final class OPDSAcquisitionFeedEntry implements Serializable {
     this.thumbnail = NullCheck.notNull(in_thumbnail);
     this.updated = NullCheck.notNull(in_updated);
     this.summary = NullCheck.notNull(in_summary);
+    this.narrators = NullCheck.notNull(in_narrators);
     this.published = NullCheck.notNull(in_published);
     this.publisher = NullCheck.notNull(in_publisher);
     this.distribution = NullCheck.notNull(in_distribution);
@@ -229,6 +232,14 @@ public final class OPDSAcquisitionFeedEntry implements Serializable {
 
   public List<OPDSCategory> getCategories() {
     return this.categories;
+  }
+
+  /**
+   * @return The list of narrators
+   */
+
+  public List<String> getNarrators() {
+    return this.narrators;
   }
 
   /**
@@ -444,6 +455,8 @@ public final class OPDSAcquisitionFeedEntry implements Serializable {
     b.append(this.distribution);
     b.append(", summary=");
     b.append(this.summary);
+    b.append(", narrator=");
+    b.append(this.narrators);
     b.append(", thumbnail=");
     b.append(this.thumbnail);
     b.append(", title=");
@@ -476,6 +489,8 @@ public final class OPDSAcquisitionFeedEntry implements Serializable {
     private OptionType<String> publisher;
     private String distribution;
     private String summary;
+    private List<String> narrators;
+    private OptionType<String> copyright;
     private OptionType<URI> thumbnail;
     private OptionType<DRMLicensor> licensor;
 
@@ -492,6 +507,8 @@ public final class OPDSAcquisitionFeedEntry implements Serializable {
       this.updated = NullCheck.notNull(in_updated);
       this.availability = NullCheck.notNull(in_availability);
       this.summary = "";
+      this.narrators = new ArrayList<String>();
+      this.copyright = Option.none();
       this.thumbnail = Option.none();
       this.cover = Option.none();
       this.alternate = Option.none();
@@ -560,6 +577,7 @@ public final class OPDSAcquisitionFeedEntry implements Serializable {
         this.thumbnail,
         this.updated,
         this.summary,
+        this.narrators,
         this.published,
         this.publisher,
         this.distribution,
@@ -653,6 +671,12 @@ public final class OPDSAcquisitionFeedEntry implements Serializable {
       } else {
         this.summary = ((Some<String>) text).get();
       }
+      return this;
+    }
+
+    @Override
+    public OPDSAcquisitionFeedEntryBuilderType addNarrator(String name) {
+      this.narrators.add(NullCheck.notNull(name));
       return this;
     }
 

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryBuilderType.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryBuilderType.java
@@ -165,6 +165,15 @@ public interface OPDSAcquisitionFeedEntryBuilderType
     OptionType<String> text);
 
   /**
+   * Set the narrator.
+   *
+   * @param name The narrator's name
+   */
+
+  OPDSAcquisitionFeedEntryBuilderType addNarrator(
+    final String name);
+
+  /**
    * Set the thumbnail.
    *
    * @param uri The thumbnail

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryParser.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryParser.java
@@ -23,6 +23,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -73,6 +74,26 @@ public final class OPDSAcquisitionFeedEntryParser implements OPDSAcquisitionFeed
       final String name =
         OPDSXML.getFirstChildElementTextWithName(Objects.requireNonNull(ea), ATOM_URI, "name");
       eb.addAuthor(name);
+    }
+  }
+
+  private void findNarrators(
+    final Element element,
+    final OPDSAcquisitionFeedEntryBuilderType eb)
+    throws OPDSParseException {
+
+    final List<Element> e_contributors =
+      OPDSXML.getChildElementsWithName(element, ATOM_URI, "contributor");
+    for (final Element ec : e_contributors) {
+      Objects.requireNonNull(ec);
+      if (ec.hasAttribute("opf:role")) {
+        String role = ec.getAttribute("opf:role");
+        if (role.toLowerCase(Locale.ROOT).equals("nrt")) {
+          final String narratorName =
+            OPDSXML.getFirstChildElementTextWithName(Objects.requireNonNull(ec), ATOM_URI, "name");
+          eb.addNarrator(narratorName);
+        }
+      }
     }
   }
 
@@ -166,6 +187,7 @@ public final class OPDSAcquisitionFeedEntryParser implements OPDSAcquisitionFeed
     parseCategories(element, entry_builder);
 
     findAcquisitionAuthors(element, entry_builder);
+    findNarrators(element, entry_builder);
     entry_builder.setPublisherOption(findPublisher(element));
     entry_builder.setDistribution(findDistribution(element));
     entry_builder.setPublishedOption(OPDSAtom.findPublished(element));

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedEntryParserTest.java
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedEntryParserTest.java
@@ -118,6 +118,7 @@ public final class OPDSFeedEntryParserTest {
 
     Assertions.assertEquals(expected, availability);
 
+    Assertions.assertEquals(1, e.getNarrators().size());
     Assertions.assertEquals(1, e.getAcquisitions().size());
     final OPDSAcquisition acquisition = e.getAcquisitions().get(0);
     Assertions.assertTrue(

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedParserTest.java
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedParserTest.java
@@ -93,6 +93,7 @@ public final class OPDSFeedParserTest {
       final DateTime e_u = e.getUpdated();
       final List<OPDSAcquisition> e_acq = e.getAcquisitions();
       final List<String> e_authors = e.getAuthors();
+      final List<String> e_narrators = e.getNarrators();
       final OptionType<URI> e_thumb = e.getThumbnail();
       final OptionType<URI> e_cover = e.getCover();
 
@@ -107,6 +108,12 @@ public final class OPDSFeedParserTest {
         System.out.print(ea);
       }
 
+      System.out.print("narrators: ");
+      for (final String n : e_narrators) {
+        System.out.print(n);
+      }
+      System.out.println();
+
       System.out.println();
       System.out.println("id: " + e_id);
       System.out.println("title: " + e_title);
@@ -116,6 +123,7 @@ public final class OPDSFeedParserTest {
 
       Assertions.assertTrue(e.getPublisher().isSome());
       Assertions.assertTrue(e_authors.size() > 0);
+      Assertions.assertTrue(e_narrators.size() > 0);
       Assertions.assertTrue(e_acq.size() > 0);
 
       if (ids.contains(e_id)) {

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSJSONParserTest.java
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSJSONParserTest.java
@@ -48,6 +48,7 @@ public final class OPDSJSONParserTest {
       Assertions.assertEquals(e0.getCover(), e1.getCover());
       Assertions.assertEquals(e0.getGroups(), e1.getGroups());
       Assertions.assertEquals(e0.getID(), e1.getID());
+      Assertions.assertEquals(e0.getNarrators(), e1.getNarrators());
       Assertions.assertEquals(e0.getPublished(), e1.getPublished());
       Assertions.assertEquals(e0.getPublisher(), e1.getPublisher());
       Assertions.assertEquals(e0.getSummary(), e1.getSummary());

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSJSONSerializerTest.java
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSJSONSerializerTest.java
@@ -76,6 +76,7 @@ public final class OPDSJSONSerializerTest {
       Assertions.assertEquals(e0.getCover(), e1.getCover());
       Assertions.assertEquals(e0.getGroups(), e1.getGroups());
       Assertions.assertEquals(e0.getID(), e1.getID());
+      Assertions.assertEquals(e0.getNarrators(), e1.getNarrators());
       Assertions.assertEquals(e0.getPublished(), e1.getPublished());
       Assertions.assertEquals(e0.getPublisher(), e1.getPublisher());
       Assertions.assertEquals(e0.getSummary(), e1.getSummary());
@@ -117,6 +118,7 @@ public final class OPDSJSONSerializerTest {
         Assertions.assertEquals(e0.getCover(), e1.getCover());
         Assertions.assertEquals(e0.getGroups(), e1.getGroups());
         Assertions.assertEquals(e0.getID(), e1.getID());
+        Assertions.assertEquals(e0.getNarrators(), e1.getNarrators());
         Assertions.assertEquals(e0.getPublisher(), e1.getPublisher());
         Assertions.assertEquals(e0.getSummary(), e1.getSummary());
         Assertions.assertEquals(e0.getThumbnail(), e1.getThumbnail());

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/loans.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/loans.xml
@@ -3,6 +3,7 @@
   xmlns:app="http://www.w3.org/2007/app"
   xmlns:dcterms="http://purl.org/dc/terms/"
   xmlns:opds="http://opds-spec.org/2010/catalog"
+  xmlns:opf="http://www.idpf.org/2007/opf"
   xmlns:schema="http://schema.org/"
   xmlns="http://www.w3.org/2005/Atom">
 
@@ -60,6 +61,12 @@
     <author>
       <name>George Savile, 1st Marquess of Halifax</name>
     </author>
+    <contributor opf:role="nrt">
+      <name>Alan Cumming</name>
+    </contributor>
+    <contributor opf:role="nrt">
+      <name>Tim Curry</name>
+    </contributor>
     <summary type="html"></summary>
     <updated>2015-03-24T17:23:50Z</updated>
     <simplified:pwid>bd87c50d-b1ab-e78e-8c81-84ed5a1d8b3a</simplified:pwid>

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/compatibility-20180921-test-new-1.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/compatibility-20180921-test-new-1.json
@@ -47,6 +47,9 @@
   "cover": "https://d3pqhns20516vc.cloudfront.net/3M/beunz9/cover.jpg",
   "groups": [],
   "id": "urn:librarysimplified.org/terms/id/Bibliotheca%20ID/beunz9",
+  "narrators": [
+    "Simon Vance"
+  ],
   "published": "2014-04-01T01:00:00Z",
   "publisher": "Little, Brown and Company",
   "distribution": "Bibliotheca",

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/compatibility-20180921-test-old.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/compatibility-20180921-test-old.json
@@ -45,6 +45,9 @@
   "cover": "https://d3pqhns20516vc.cloudfront.net/3M/beunz9/cover.jpg",
   "groups": [],
   "id": "urn:librarysimplified.org/terms/id/Bibliotheca%20ID/beunz9",
+  "narrators": [
+    "Simon Vance"
+  ],
   "published": "2014-04-01T01:00:00Z",
   "publisher": "Little, Brown and Company",
   "distribution": "Bibliotheca",

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/entry-availability-loaned-timed.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/entry-availability-loaned-timed.xml
@@ -1,5 +1,6 @@
 <entry
   xmlns:opds="http://opds-spec.org/2010/catalog"
+  xmlns:opf="http://www.idpf.org/2007/opf"
   xmlns:schema="http://schema.org/"
   xmlns="http://www.w3.org/2005/Atom"
   schema:additionalType="http://schema.org/Book">
@@ -8,6 +9,9 @@
   <author>
     <name>Author</name>
   </author>
+  <contributor opf:role="nrt">
+    <name>Alan Cumming</name>
+  </contributor>
   <summary type="html"></summary>
   <updated>2015-08-17T20:37:53Z</updated>
   <published>2014-08-29T10:46:42Z</published>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -333,6 +333,14 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       this.metadata.addView(row)
     }
 
+    val narrators = entry.narrators.filterNot { it.isBlank() }
+    if (narrators.isNotEmpty()) {
+      val (row, rowKey, rowVal) = this.tableRowOf()
+      rowKey.text = this.getString(R.string.catalogMetaNarrators)
+      rowVal.text = narrators.joinToString(", ")
+      this.metadata.addView(row)
+    }
+
     this.run {
       val (row, rowKey, rowVal) = this.tableRowOf()
       rowKey.text = this.getString(R.string.catalogMetaUpdatedDate)

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -57,6 +57,7 @@
   <string name="catalogInformation">Information</string>
   <string name="catalogListen">Listen</string>
   <string name="catalogMetaCategories">Categories</string>
+  <string name="catalogMetaNarrators">Narrators</string>
   <string name="catalogMetaDistributor">Distributor</string>
   <string name="catalogMetaPublicationDate">Published</string>
   <string name="catalogMetaPublisher">Publisher</string>


### PR DESCRIPTION
**What's this do?**
This PR adds the list of narrators (if available) to the information block inside the audiobook details page. This PR also updates the tests in order to include some verifications to the new added field.

**Why are we doing this? (w/ JIRA link if applicable)**
There's [a feature request](https://www.notion.so/lyrasis/Display-narrator-information-for-audiobooks-Android-f17209776f284c1e87424a5334b83e36) stating that this information is available but isn't currently being displayed and the idea was to add it to the audiobook details page to make it more complete and to provide even more information to the user.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select the "Palace Marketplace Integration Library"
Choose any audiobook in the _Audible Test_ collection
Scroll down to the information block
Verify there's [a narrators list](https://user-images.githubusercontent.com/79104027/155429343-5f84f8fd-fedc-4916-9662-3f22ffa00839.png) (it may not be displayed on some books that don't contain that information)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 