### PR TITLE
Fix book details information being cut off

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -151,7 +151,7 @@
         <c:change date="2022-01-21T00:00:00+00:00" summary="Removed the &quot;Show&quot; filter from My Books. This wasn't useful."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-02-24T15:14:34+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
+    <c:release date="2022-02-25T14:42:35+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
       <c:changes>
         <c:change date="2022-01-28T00:00:00+00:00" summary="Fixed the audiobook playback rate getting reset back to 1x after pausing."/>
         <c:change date="2022-02-03T00:00:00+00:00" summary="Fixed a crash that could happen when exiting an audiobook while it's playing."/>
@@ -162,8 +162,9 @@
         <c:change date="2022-02-15T00:00:00+00:00" summary="Removed audiobook cover image resizing dimensions"/>
         <c:change date="2022-02-15T00:00:00+00:00" summary="Updated text on debug options"/>
         <c:change date="2022-02-18T00:00:00+00:00" summary="Added toolbar with back button to pdf reader"/>
-        <c:change date="2022-02-23T23:35:14+00:00" summary="Added narrators information to book details page"/>
-        <c:change date="2022-02-24T15:14:34+00:00" summary="Fix book titles being cut off on book details screen"/>
+        <c:change date="2022-02-23T00:00:00+00:00" summary="Added narrators information to book details page"/>
+        <c:change date="2022-02-24T00:00:00+00:00" summary="Fix book titles being cut off on book details screen"/>
+        <c:change date="2022-02-25T14:42:35+00:00" summary="Fixed book details information being cut off"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
-import android.widget.TableLayout
 import android.widget.TextView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -93,7 +92,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
   private lateinit var covers: BookCoverProviderType
   private lateinit var debugStatus: TextView
   private lateinit var format: TextView
-  private lateinit var metadata: TableLayout
+  private lateinit var metadata: LinearLayout
   private lateinit var related: TextView
   private lateinit var report: TextView
   private lateinit var screenSize: ScreenSizeInformationType
@@ -303,7 +302,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
 
     val publishedOpt = entry.published
     if (publishedOpt is Some<DateTime>) {
-      val (row, rowKey, rowVal) = this.tableRowOf()
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
       rowKey.text = this.getString(R.string.catalogMetaPublicationDate)
       rowVal.text = this.dateFormatter.print(publishedOpt.get())
       this.metadata.addView(row)
@@ -311,14 +310,14 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
 
     val publisherOpt = entry.publisher
     if (publisherOpt is Some<String>) {
-      val (row, rowKey, rowVal) = this.tableRowOf()
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
       rowKey.text = this.getString(R.string.catalogMetaPublisher)
       rowVal.text = publisherOpt.get()
       this.metadata.addView(row)
     }
 
     if (entry.distribution.isNotBlank()) {
-      val (row, rowKey, rowVal) = this.tableRowOf()
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
       rowKey.text = this.getString(R.string.catalogMetaDistributor)
       rowVal.text = entry.distribution
       this.metadata.addView(row)
@@ -327,7 +326,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     val categories =
       entry.categories.filter { opdsCategory -> opdsCategory.scheme == this.genreUriScheme }
     if (categories.isNotEmpty()) {
-      val (row, rowKey, rowVal) = this.tableRowOf()
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
       rowKey.text = this.getString(R.string.catalogMetaCategories)
       rowVal.text = categories.joinToString(", ") { opdsCategory -> opdsCategory.effectiveLabel }
       this.metadata.addView(row)
@@ -335,21 +334,21 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
 
     val narrators = entry.narrators.filterNot { it.isBlank() }
     if (narrators.isNotEmpty()) {
-      val (row, rowKey, rowVal) = this.tableRowOf()
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
       rowKey.text = this.getString(R.string.catalogMetaNarrators)
       rowVal.text = narrators.joinToString(", ")
       this.metadata.addView(row)
     }
 
     this.run {
-      val (row, rowKey, rowVal) = this.tableRowOf()
+      val (row, rowKey, rowVal) = this.bookInfoViewOf()
       rowKey.text = this.getString(R.string.catalogMetaUpdatedDate)
       rowVal.text = this.dateTimeFormatter.print(entry.updated)
       this.metadata.addView(row)
     }
   }
 
-  private fun tableRowOf(): Triple<View, TextView, TextView> {
+  private fun bookInfoViewOf(): Triple<View, TextView, TextView> {
     val row = this.layoutInflater.inflate(R.layout.book_detail_metadata_item, this.metadata, false)
     val rowKey = row.findViewById<TextView>(R.id.key)
     val rowVal = row.findViewById<TextView>(R.id.value)

--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -185,16 +185,14 @@
       android:textSize="18sp"
       android:textStyle="bold" />
 
-    <TableLayout
+    <LinearLayout
       android:id="@+id/bookDetailMetadataTable"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:orientation="vertical"
       android:layout_marginStart="16dp"
       android:layout_marginEnd="16dp"
-      android:layout_marginBottom="16dp">
-
-      <include layout="@layout/book_detail_metadata_item" />
-    </TableLayout>
+      android:layout_marginBottom="16dp" />
 
     <View
       android:layout_width="match_parent"

--- a/simplified-ui-catalog/src/main/res/layout/book_detail_metadata_item.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail_metadata_item.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<TableRow xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="match_parent"
-  android:layout_height="wrap_content"
-  android:minHeight="16dp">
-
-  <TextView
-    android:id="@+id/key"
-    android:layout_width="wrap_content"
-    android:maxLines="1"
-    android:maxLength="16"
-    android:layout_height="wrap_content"
-    android:layout_marginEnd="32dp"
-    android:text="@string/catalogPlaceholder"/>
-
-  <TextView
-    android:id="@+id/value"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:text="@string/catalogPlaceholder"/>
+    android:orientation="horizontal">
 
-</TableRow>
+    <TextView
+        android:id="@+id/key"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="0.3"
+        android:text="@string/catalogPlaceholder" />
+
+    <TextView
+        android:id="@+id/value"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_weight="0.7"
+        android:text="@string/catalogPlaceholder" />
+
+</LinearLayout>


### PR DESCRIPTION
**What's this do?**
This PR replaces the _TableLayout_ container with a LinearLayout in order to make its child views display more than one line of information when it gets too large.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a comment and a [screenshot](https://user-images.githubusercontent.com/79104027/155736146-c6292691-ba52-4988-a747-3628ddd9ba48.png) in [this ticket](https://www.notion.so/lyrasis/Display-narrator-information-for-audiobooks-Android-f17209776f284c1e87424a5334b83e36) saying that in some books some of the information displayed in the details page is being cut off when it's too large. Apparently the _TableLayout_ has some bug regarding this because there's no specific limitation of the child lines but they keep getting cut off, so that's why it was replaced with a _LinearLayout_ which has a similar behavior in this case.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select any library (p.e., Palace Marketplace Integration Library)
Choose any book that may have a lot of information (p.e., Dracula [Audible Edition])
Scroll down to the _Information_ section and verify [everything's being shown](https://user-images.githubusercontent.com/79104027/155736192-b382df60-b862-4cab-aaa3-6e5833395ee1.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 