### PR TITLE
Remove Open Textbook Library from pinned libraries

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -151,7 +151,7 @@
         <c:change date="2022-01-21T00:00:00+00:00" summary="Removed the &quot;Show&quot; filter from My Books. This wasn't useful."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-02-25T14:42:35+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
+    <c:release date="2022-03-01T15:01:30+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
       <c:changes>
         <c:change date="2022-01-28T00:00:00+00:00" summary="Fixed the audiobook playback rate getting reset back to 1x after pausing."/>
         <c:change date="2022-02-03T00:00:00+00:00" summary="Fixed a crash that could happen when exiting an audiobook while it's playing."/>
@@ -164,7 +164,8 @@
         <c:change date="2022-02-18T00:00:00+00:00" summary="Added toolbar with back button to pdf reader"/>
         <c:change date="2022-02-23T00:00:00+00:00" summary="Added narrators information to book details page"/>
         <c:change date="2022-02-24T00:00:00+00:00" summary="Fix book titles being cut off on book details screen"/>
-        <c:change date="2022-02-25T14:42:35+00:00" summary="Fixed book details information being cut off"/>
+        <c:change date="2022-02-25T00:00:00+00:00" summary="Fixed book details information being cut off"/>
+        <c:change date="2022-03-01T15:01:30+00:00" summary="Remove 'Open Textbook Library' from pinned libraries"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceBuildConfigurationService.kt
+++ b/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceBuildConfigurationService.kt
@@ -18,8 +18,7 @@ class PalaceBuildConfigurationService : BuildConfigurationServiceType {
     get() = true
   override val featuredLibrariesIdsList: List<String>
     get() = listOf(
-      "urn:uuid:6b849570-070f-43b4-9dcc-7ebb4bca292e", // DPLA
-      "urn:uuid:5278562c-d642-4fda-ad7e-1613077cfb8d" // Open Textbook Library
+      "urn:uuid:6b849570-070f-43b4-9dcc-7ebb4bca292e" // Palace Bookshelf
     )
   override val showDebugBookDetailStatus: Boolean
     get() = false

--- a/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
+++ b/simplified-app-vanilla/src/main/java/org/nypl/simplified/vanilla/VanillaBuildConfigurationService.kt
@@ -18,8 +18,7 @@ class VanillaBuildConfigurationService : BuildConfigurationServiceType {
     get() = true
   override val featuredLibrariesIdsList: List<String>
     get() = listOf(
-      "urn:uuid:6b849570-070f-43b4-9dcc-7ebb4bca292e", // DPLA
-      "urn:uuid:5278562c-d642-4fda-ad7e-1613077cfb8d" // Open Textbook Library
+      "urn:uuid:6b849570-070f-43b4-9dcc-7ebb4bca292e" // Palace Bookshelf
     )
   override val showDebugBookDetailStatus: Boolean
     get() = false


### PR DESCRIPTION
**What's this do?**
This PR deletes the _Open Textbook Library_ uuid from the list of featured libraries.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [request](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=22cd92c0cc5c46409134c9f380e6e718&p=d3d17099b64544ccae8f1467bda50a8b) to make this library disappear from the pinned libraries at the top and make it visible in the list below.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Remove all the libraries from your account in order to test this "from the scratch" (you can also delete the app's storate in the device app settings)
Add a library
Verify there's just [one pinned library](https://user-images.githubusercontent.com/79104027/156194753-4b55837c-ccda-4241-8bf6-848710f3b2b7.png) and the _Open Textbook Library_ is [in the middle of the list](https://user-images.githubusercontent.com/79104027/156194809-d289bb7e-bc3e-4557-9b9c-2730ad3dd8c6.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by  @nunommts 