### PR TITLE
Decode base64-encoded LCP hashed passphrases.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -151,7 +151,7 @@
         <c:change date="2022-01-21T00:00:00+00:00" summary="Removed the &quot;Show&quot; filter from My Books. This wasn't useful."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-03-01T15:01:30+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
+    <c:release date="2022-03-04T15:24:22+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.7">
       <c:changes>
         <c:change date="2022-01-28T00:00:00+00:00" summary="Fixed the audiobook playback rate getting reset back to 1x after pausing."/>
         <c:change date="2022-02-03T00:00:00+00:00" summary="Fixed a crash that could happen when exiting an audiobook while it's playing."/>
@@ -166,6 +166,7 @@
         <c:change date="2022-02-24T00:00:00+00:00" summary="Fix book titles being cut off on book details screen"/>
         <c:change date="2022-02-25T00:00:00+00:00" summary="Fixed book details information being cut off"/>
         <c:change date="2022-03-01T15:01:30+00:00" summary="Remove 'Open Textbook Library' from pinned libraries"/>
+        <c:change date="2022-03-04T15:24:22+00:00" summary="Added handling for base64-encoded LCP hashed passphrases."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-lcp/src/main/java/org/nypl/simplified/lcp/LCPContentProtectionProvider.kt
+++ b/simplified-lcp/src/main/java/org/nypl/simplified/lcp/LCPContentProtectionProvider.kt
@@ -16,7 +16,12 @@ import org.slf4j.LoggerFactory
 class LCPContentProtectionProvider : ContentProtectionProvider {
 
   /**
-   * The passphrase that will be used to open the next book.
+   * The hashed passphrase that will be used to open the next book. The value may be set to a hex
+   * string, or to its base-64 encoding, according to the spec:
+   * https://readium.org/lcp-specs/notes/lcp-key-retrieval.html#sample-of-readium-web-publication-manifest-supporting-a-link-to-an-lcp-license-and-an-lcp_hashed_passphrase-property
+   *
+   * Note: This file uses the terms "passphrase" and "hashed passphrase" interchangeably, in all
+   * cases referring to what the LCP spec calls a "hashed passphrase" or "User Key".
    *
    * XXX: This kind of back-door access is required because we can't yet change the
    *      `org.nypl.drm.core.ContentProtectionProvider` interface.
@@ -24,9 +29,13 @@ class LCPContentProtectionProvider : ContentProtectionProvider {
 
   @Volatile
   var passphrase: String? = null
+    set(value) {
+      field = value?.let { LCPHashedPassphrase.conditionallyBase64Decode(it) }
+    }
 
   /**
-   * @return The passphrase that will be used to open the next book.
+   * @return The hashed passphrase that will be used to open the next book, as a hex string (not
+   * base-64 encoded).
    */
 
   fun passphrase(): String {

--- a/simplified-lcp/src/main/java/org/nypl/simplified/lcp/LCPHashedPassphrase.kt
+++ b/simplified-lcp/src/main/java/org/nypl/simplified/lcp/LCPHashedPassphrase.kt
@@ -1,0 +1,55 @@
+package org.nypl.simplified.lcp
+
+import android.util.Base64
+
+/**
+ * Functions for working with LCP hashed passphrases.
+ */
+
+object LCPHashedPassphrase {
+
+  /**
+   * Determine if a hashed passphrase is base-64 encoded. An unencoded hashed passphrase is a
+   * 64-character hex string, so if the value is not 64 characters long, or contains a character
+   * that is not a hexadecimal digit, it is considered to be encoded.
+   */
+
+  @JvmStatic
+  fun isBase64Encoded(hashedPassphrase: String): Boolean =
+    hashedPassphrase.length != 64 || hashedPassphrase.contains(Regex("[^0-9a-fA-F]"))
+
+  /**
+   * Base-64 encode a hashed passphrase, using the algorithm described in the LCP spec:
+   * https://readium.org/lcp-specs/notes/lcp-key-retrieval.html#sample-of-readium-web-publication-manifest-supporting-a-link-to-an-lcp-license-and-an-lcp_hashed_passphrase-property
+   */
+
+  @JvmStatic
+  fun base64Encode(hashedPassphrase: String): String {
+    val bytes = hashedPassphrase.chunked(2)
+      .map { it.toInt(16).toByte() }
+      .toByteArray()
+
+    return Base64.encodeToString(bytes, Base64.NO_WRAP)
+  }
+
+  /**
+   * Decode a base-64 encoded hashed passphrase, using the algorithm described in the LCP spec:
+   * https://readium.org/lcp-specs/notes/lcp-key-retrieval.html#sample-of-readium-web-publication-manifest-supporting-a-link-to-an-lcp-license-and-an-lcp_hashed_passphrase-property
+   */
+
+  @JvmStatic
+  fun base64Decode(encodedHashedPassphrase: String) =
+    Base64.decode(encodedHashedPassphrase, Base64.DEFAULT)
+      .joinToString(separator = "") { "%02x".format(it) }
+
+  /**
+   * Determine if a hashed passphrase is base-64 encoded, and decode it if necessary.
+   */
+
+  @JvmStatic
+  fun conditionallyBase64Decode(hashedPassphrase: String) =
+    if (isBase64Encoded(hashedPassphrase))
+      base64Decode(hashedPassphrase)
+    else
+      hashedPassphrase
+}

--- a/simplified-tests/build.gradle
+++ b/simplified-tests/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   api project(":simplified-files")
   api project(":simplified-futures")
   api project(":simplified-json-core")
+  api project(":simplified-lcp")
   api project(":simplified-metrics")
   api project(":simplified-metrics-api")
   api project(":simplified-migration-from3master")

--- a/simplified-tests/src/test/java/android/util/Base64.kt
+++ b/simplified-tests/src/test/java/android/util/Base64.kt
@@ -1,0 +1,20 @@
+package android.util
+
+import java.util.Base64
+
+/**
+ * A mock of android.util.Base64 to use in tests, when the Android API is not available.
+ */
+
+object Base64 {
+
+  @JvmStatic
+  fun encodeToString(input: ByteArray?, flags: Int): String? {
+    return Base64.getEncoder().encodeToString(input)
+  }
+
+  @JvmStatic
+  fun decode(str: String?, flags: Int): ByteArray? {
+    return Base64.getDecoder().decode(str)
+  }
+}

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/lcp/LCPContentProtectionProviderTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/lcp/LCPContentProtectionProviderTest.kt
@@ -1,0 +1,44 @@
+package org.nypl.simplified.tests.lcp
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.nypl.simplified.lcp.LCPContentProtectionProvider
+import java.lang.IllegalStateException
+
+class LCPContentProtectionProviderTest {
+
+  @Test
+  fun passphrase_returnsUnencodedValue_whenHashedPassphraseIsUnencoded() {
+    val provider = LCPContentProtectionProvider().apply {
+      passphrase = "4a3c996c8b7fc2c353e58437dfec747e9ee9e0d9711b74bc9ff6080a924cebcf"
+    }
+
+    Assertions.assertEquals(
+      "4a3c996c8b7fc2c353e58437dfec747e9ee9e0d9711b74bc9ff6080a924cebcf",
+      provider.passphrase()
+    )
+  }
+
+  @Test
+  fun passphrase_returnsUnencodedValue_whenHashedPassphraseIsEncoded() {
+    val provider = LCPContentProtectionProvider().apply {
+      passphrase = "SjyZbIt/wsNT5YQ33+x0fp7p4NlxG3S8n/YICpJM688="
+    }
+
+    Assertions.assertEquals(
+      "4a3c996c8b7fc2c353e58437dfec747e9ee9e0d9711b74bc9ff6080a924cebcf",
+      provider.passphrase()
+    )
+  }
+
+  @Test
+  fun passphrase_throws_whenHashedPassphraseIsNull() {
+    val provider = LCPContentProtectionProvider().apply {
+      passphrase = null
+    }
+
+    Assertions.assertThrows(IllegalStateException::class.java) {
+      provider.passphrase()
+    }
+  }
+}

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/lcp/LCPHashedPassphraseTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/lcp/LCPHashedPassphraseTest.kt
@@ -1,0 +1,68 @@
+package org.nypl.simplified.tests.lcp
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.nypl.simplified.lcp.LCPHashedPassphrase
+
+class LCPHashedPassphraseTest {
+
+  @Test
+  fun isBase64Encoded_isFalse_whenHashedPassphraseIsUnencoded() {
+    Assertions.assertFalse(
+      LCPHashedPassphrase.isBase64Encoded("ecf294243697a2bb915bc78577f49d6c37b8b0dc6bb4c6bd1bc425dfad8317ae")
+    )
+  }
+
+  @Test
+  fun isBase64Encoded_isTrue_whenHashedPassphraseIsEncoded() {
+    Assertions.assertTrue(
+      LCPHashedPassphrase.isBase64Encoded("SjyZbIt/wsNT5YQ33+x0fp7p4NlxG3S8n/YICpJM688=")
+    )
+  }
+
+  @Test
+  fun isBase64Encoded_isTrue_whenHashedPassphraseIsNot64Chars() {
+    Assertions.assertTrue(
+      LCPHashedPassphrase.isBase64Encoded("ecf294243697a2bb915bc78577f49d6c37b8b0dc6bb4c6bd1bc425dfad8317a")
+    )
+  }
+
+  @Test
+  fun isBase64Encoded_isTrue_whenHashedPassphraseContainsNonHexChar() {
+    Assertions.assertTrue(
+      LCPHashedPassphrase.isBase64Encoded("ecf294243697a2bb915bc78577f49d6c3/b8b0dc6bb4c6bd1bc425dfad8317ae")
+    )
+  }
+
+  @Test
+  fun base64Encode_returnsEncodedValue() {
+    Assertions.assertEquals(
+      "SjyZbIt/wsNT5YQ33+x0fp7p4NlxG3S8n/YICpJM688=",
+      LCPHashedPassphrase.base64Encode("4a3c996c8b7fc2c353e58437dfec747e9ee9e0d9711b74bc9ff6080a924cebcf")
+    )
+  }
+
+  @Test
+  fun base64Decode_returnsDecodedValue() {
+    Assertions.assertEquals(
+      "4a3c996c8b7fc2c353e58437dfec747e9ee9e0d9711b74bc9ff6080a924cebcf",
+      LCPHashedPassphrase.base64Decode("SjyZbIt/wsNT5YQ33+x0fp7p4NlxG3S8n/YICpJM688=")
+    )
+  }
+
+  @Test
+  fun conditionallyBase64Decode_returnsDecodedValue_whenHashedPassphraseIsEncoded() {
+    Assertions.assertEquals(
+      "4a3c996c8b7fc2c353e58437dfec747e9ee9e0d9711b74bc9ff6080a924cebcf",
+      LCPHashedPassphrase.conditionallyBase64Decode("SjyZbIt/wsNT5YQ33+x0fp7p4NlxG3S8n/YICpJM688=")
+    )
+  }
+
+  @Test
+  fun conditionallyBase64Decode_returnsInputValue_whenHashedPassphraseIsUnencoded() {
+    Assertions.assertEquals(
+      "4a3c996c8b7fc2c353e58437dfec747e9ee9e0d9711b74bc9ff6080a924cebcf",
+      LCPHashedPassphrase.conditionallyBase64Decode("4a3c996c8b7fc2c353e58437dfec747e9ee9e0d9711b74bc9ff6080a924cebcf")
+    )
+  }
+}


### PR DESCRIPTION
**What's this do?**

This adds support for base-64 encoded LCP hashed passphrases. For LCP encrypted books in the loans feed, the `lcp:hashed_passphrase` element contains the hashed passphrase to be used as a key to decrypt the book. Currently, the CM sets this value to a hex string (a sha-256 hash). According to the spec, this value should be base64 encoded. The app will now check if a hashed passphrase is base64 encoded, and decode it if necessary, before using it as a key for decryption.

**Why are we doing this? (w/ JIRA link if applicable)**

The LCP automatic key retrieval spec wants the hashed passphrase to be base64 encoded in transit:
https://readium.org/lcp-specs/notes/lcp-key-retrieval.html#sample-of-readium-web-publication-manifest-supporting-a-link-to-an-lcp-license-and-an-lcp_hashed_passphrase-property

Notion: https://www.notion.so/lyrasis/Decode-base64-encoded-hashed-passphrases-Android-c9cb35a8ddbe4b22869b181be398c9f2

**How should this be tested? / Do these changes have associated tests?**

LCP epubs should continue to open successfully. The CM has not been updated yet to send base64-encoded hashed passphrases. Once it has, the app should be tested again to ensure that LCP epubs (both previously downloaded and new downloads) still open successfully.

Unit tests are included.

**Dependencies for merging? Releasing to production?**

None for merging, but the CM needs to be updated to fully test this.

**Have you updated the changelog?**

Yes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this.
