### PR TITLE
Add support for borrowing LCP audiobooks.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -168,8 +168,10 @@
         <c:change date="2022-03-01T00:00:00+00:00" summary="Removed Open Textbook Library from the featured libraries."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-03-09T18:09:32+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.8">
-      <c:changes/>
+    <c:release date="2022-03-09T19:15:05+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.8">
+      <c:changes>
+        <c:change date="2022-03-09T19:15:05+00:00" summary="Added support for acquiring LCP audiobooks (playing them does not work yet)."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookFormat.kt
+++ b/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookFormat.kt
@@ -95,6 +95,14 @@ sealed class BookFormat {
     val manifest: AudioBookManifestReference?,
 
     /**
+     * The audio book file on disk, if one has been downloaded. This is used for packaged audio
+     * books, where the entire book is downloaded in one file. For unpackaged audio books, where
+     * only the manifest is downloaded, this will always be null.
+     */
+
+    val file: File?,
+
+    /**
      * The most recent playback position.
      */
 

--- a/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookFormat.kt
+++ b/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookFormat.kt
@@ -112,11 +112,11 @@ sealed class BookFormat {
   ) : BookFormat() {
 
     /*
-     * Audio books are downloaded if there's a manifest available.
+     * Audio books are downloaded if there's a manifest or audio book file available.
      */
 
     override val isDownloaded: Boolean
-      get() = this.manifest != null
+      get() = this.manifest != null || this.file != null
   }
 
   /**

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLCP.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLCP.kt
@@ -260,6 +260,12 @@ class BorrowLCP private constructor() : BorrowSubtaskType {
       throw BorrowSubtaskFailed()
     }
 
+    /*
+     * LCP is a special case in the sense that it supersedes any acquisition
+     * path elements that might follow this one. We mark this subtask as having halted
+     * early.
+     */
+
     throw BorrowSubtaskHaltedEarly()
   }
 

--- a/simplified-books-database-api/src/main/java/org/nypl/simplified/books/book_database/api/BookDatabaseEntryType.kt
+++ b/simplified-books-database-api/src/main/java/org/nypl/simplified/books/book_database/api/BookDatabaseEntryType.kt
@@ -272,6 +272,17 @@ sealed class BookDatabaseEntryFormatHandle {
     )
 
     /**
+     * Copy the given audio book file into the directory as the book data.
+     *
+     * @param file The file to be copied
+     *
+     * @throws IOException On I/O errors
+     */
+
+    @Throws(IOException::class)
+    abstract fun copyInBook(file: File)
+
+    /**
      * Save the given player position to the database.
      *
      * @throws IOException On I/O errors or lock acquisition failures

--- a/simplified-books-database-api/src/main/java/org/nypl/simplified/books/book_database/api/BookFormats.kt
+++ b/simplified-books-database-api/src/main/java/org/nypl/simplified/books/book_database/api/BookFormats.kt
@@ -36,6 +36,11 @@ object BookFormats {
       "audio/mpeg"
     )
 
+  private val LCP_AUDIO_BOOKS =
+    mimesOf(
+      "application/audiobook+lcp"
+    )
+
   private val OVERDRIVE_AUDIO_BOOKS =
     mimesOf(
       "application/vnd.overdrive.circulation.api+json;profile=audiobook"
@@ -45,6 +50,7 @@ object BookFormats {
     unionOf(
       FINDAWAY_AUDIO_BOOKS,
       GENERIC_AUDIO_BOOKS,
+      LCP_AUDIO_BOOKS,
       OVERDRIVE_AUDIO_BOOKS
     )
 

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
@@ -17,6 +17,7 @@ import org.nypl.simplified.books.api.BookDRMKind
 import org.nypl.simplified.books.api.BookFormat
 import org.nypl.simplified.books.book_database.api.BookDRMInformationHandle
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleAudioBook
+import org.nypl.simplified.files.DirectoryUtilities
 import org.nypl.simplified.files.FileUtilities
 import org.nypl.simplified.json.core.JSONParserUtilities
 import org.nypl.simplified.json.core.JSONSerializerUtilities
@@ -39,6 +40,8 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
   private val log =
     LoggerFactory.getLogger(DatabaseFormatHandleAudioBook::class.java)
 
+  private val fileBook: File =
+    File(this.parameters.directory, "audiobook.zip")
   private val fileManifest: File =
     File(this.parameters.directory, "audiobook-manifest.json")
   private val fileManifestURI: File =
@@ -90,6 +93,7 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
     synchronized(this.dataLock) {
       loadInitial(
         objectMapper = this.parameters.objectMapper,
+        fileBook = this.fileBook,
         fileManifest = this.fileManifest,
         fileManifestURI = this.fileManifestURI,
         filePosition = this.filePosition,
@@ -133,7 +137,17 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
     val newFormat = synchronized(this.dataLock) {
       FileUtilities.fileDelete(this.filePosition)
 
-      this.formatRef = this.formatRef.copy(position = null)
+      if (this.fileBook.isDirectory) {
+        DirectoryUtilities.directoryDelete(this.fileBook)
+      } else {
+        FileUtilities.fileDelete(this.fileBook)
+      }
+
+      this.formatRef = this.formatRef.copy(
+        file = null,
+        position = null
+      )
+
       this.formatRef
     }
 
@@ -240,6 +254,27 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
     this.parameters.onUpdated.invoke(newFormat)
   }
 
+  override fun copyInBook(file: File) {
+    val newFormat = synchronized(this.dataLock) {
+      if (file.isDirectory) {
+        DirectoryUtilities.directoryCopy(file, this.fileBook)
+      } else {
+        FileUtilities.fileCopy(file, this.fileBook)
+      }
+
+      this.formatRef = this.formatRef.copy(
+        file = this.fileBook,
+        manifest = BookFormat.AudioBookManifestReference(
+          manifestURI = URI("manifest.json"),
+          manifestFile = this.fileManifest
+        )
+      )
+      this.formatRef
+    }
+
+    this.parameters.onUpdated.invoke(newFormat)
+  }
+
   override fun savePlayerPosition(position: PlayerPosition) {
     val text =
       JSONSerializerUtilities.serializeToString(PlayerPositions.serializeToObjectNode(position))
@@ -270,6 +305,7 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
 
     private fun loadInitial(
       objectMapper: ObjectMapper,
+      fileBook: File,
       fileManifest: File,
       fileManifestURI: File,
       filePosition: File,
@@ -277,6 +313,7 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
       drmInfo: BookDRMInformation
     ): BookFormat.BookFormatAudioBook {
       return BookFormat.BookFormatAudioBook(
+        file = if (fileBook.exists()) fileBook else null,
         manifest = this.loadManifestIfNecessary(fileManifest, fileManifestURI),
         position = this.loadPositionIfNecessary(objectMapper, filePosition),
         contentType = contentType,

--- a/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
+++ b/simplified-books-database/src/main/java/org/nypl/simplified/books/book_database/DatabaseFormatHandleAudioBook.kt
@@ -41,7 +41,7 @@ internal class DatabaseFormatHandleAudioBook internal constructor(
     LoggerFactory.getLogger(DatabaseFormatHandleAudioBook::class.java)
 
   private val fileBook: File =
-    File(this.parameters.directory, "audiobook.zip")
+    File(this.parameters.directory, "audiobook-book.zip")
   private val fileManifest: File =
     File(this.parameters.directory, "audiobook-manifest.json")
   private val fileManifestURI: File =

--- a/simplified-books-formats-api/src/main/java/org/nypl/simplified/books/formats/api/StandardFormatNames.kt
+++ b/simplified-books-formats-api/src/main/java/org/nypl/simplified/books/formats/api/StandardFormatNames.kt
@@ -55,6 +55,9 @@ object StandardFormatNames {
   val dplaAudioBooks =
     this.mimeOf("application/audiobook+json;profile=http://www.feedbooks.com/audiobooks/access-restriction")
 
+  val lcpAudioBooks =
+    this.mimeOf("application/audiobook+lcp")
+
   /**
    * Various standard format names used for generic, unencrypted audio books.
    */

--- a/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupport.kt
+++ b/simplified-books-formats/src/main/java/org/nypl/simplified/books/formats/BookFormatSupport.kt
@@ -80,6 +80,9 @@ class BookFormatSupport private constructor(
       if (audio.supportsDPLAAudioBooks) {
         types.add(StandardFormatNames.dplaAudioBooks)
       }
+      if (this.parameters.supportsLCP) {
+        types.add(StandardFormatNames.lcpAudioBooks)
+      }
     }
   }
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLCPTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLCPTest.kt
@@ -1,0 +1,726 @@
+package org.nypl.simplified.tests.books.borrowing
+
+import android.content.Context
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.joda.time.Instant
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.librarysimplified.http.api.LSHTTPClientConfiguration
+import org.librarysimplified.http.api.LSHTTPClientType
+import org.librarysimplified.http.vanilla.LSHTTPClients
+import org.librarysimplified.services.api.ServiceDirectoryType
+import org.mockito.Mockito
+import org.nypl.simplified.accounts.api.AccountAuthenticationCredentials
+import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.accounts.api.AccountLoginState
+import org.nypl.simplified.accounts.api.AccountPassword
+import org.nypl.simplified.accounts.api.AccountProvider
+import org.nypl.simplified.accounts.api.AccountUsername
+import org.nypl.simplified.accounts.database.api.AccountType
+import org.nypl.simplified.books.api.Book
+import org.nypl.simplified.books.api.BookFormat
+import org.nypl.simplified.books.api.BookIDs
+import org.nypl.simplified.books.book_database.BookDRMInformationHandleLCP
+import org.nypl.simplified.books.book_database.api.BookDatabaseType
+import org.nypl.simplified.books.book_registry.BookRegistry
+import org.nypl.simplified.books.book_registry.BookRegistryType
+import org.nypl.simplified.books.borrowing.BorrowContextType
+import org.nypl.simplified.books.borrowing.internal.BorrowLCP
+import org.nypl.simplified.books.borrowing.subtasks.BorrowSubtaskException
+import org.nypl.simplified.books.formats.api.StandardFormatNames
+import org.nypl.simplified.books.formats.api.StandardFormatNames.genericEPUBFiles
+import org.nypl.simplified.books.formats.api.StandardFormatNames.lcpAudioBooks
+import org.nypl.simplified.books.formats.api.StandardFormatNames.lcpLicenseFiles
+import org.nypl.simplified.opds.core.OPDSAcquisition
+import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
+import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntryParser
+import org.nypl.simplified.opds.core.OPDSAcquisitionPath
+import org.nypl.simplified.opds.core.OPDSAcquisitionPathElement
+import org.nypl.simplified.opds.core.OPDSFeedParser
+import org.nypl.simplified.opds.core.OPDSFeedParserType
+import org.nypl.simplified.taskrecorder.api.TaskRecorder
+import org.nypl.simplified.taskrecorder.api.TaskRecorderType
+import org.nypl.simplified.tests.MutableServiceDirectory
+import org.nypl.simplified.tests.TestDirectories
+import org.nypl.simplified.tests.mocking.MockAccountProviders
+import org.nypl.simplified.tests.mocking.MockBookDatabase
+import org.nypl.simplified.tests.mocking.MockBookDatabaseEntry
+import org.nypl.simplified.tests.mocking.MockBookDatabaseEntryFormatHandleAudioBook
+import org.nypl.simplified.tests.mocking.MockBookDatabaseEntryFormatHandleEPUB
+import org.nypl.simplified.tests.mocking.MockBookDatabaseEntryFormatHandlePDF
+import org.nypl.simplified.tests.mocking.MockBorrowContext
+import org.nypl.simplified.tests.mocking.MockBundledContentResolver
+import org.nypl.simplified.tests.mocking.MockContentResolver
+import org.nypl.simplified.tests.mocking.MockLCPService
+import org.readium.r2.lcp.LcpService
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.net.URI
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+
+class BorrowLCPTest {
+
+  private lateinit var account: AccountType
+  private lateinit var accountId: AccountID
+  private lateinit var accountProvider: AccountProvider
+  private lateinit var bookDatabase: BookDatabaseType
+  private lateinit var bookRegistry: BookRegistryType
+  private lateinit var bundledContent: MockBundledContentResolver
+  private lateinit var contentResolver: MockContentResolver
+  private lateinit var httpClient: LSHTTPClientType
+  private lateinit var services: ServiceDirectoryType
+  private lateinit var taskRecorder: TaskRecorderType
+  private lateinit var webServer: MockWebServer
+
+  private val logger = LoggerFactory.getLogger(BorrowLCPTest::class.java)
+
+  @TempDir
+  @JvmField
+  var tempDir: File? = null
+
+  @BeforeEach
+  fun testSetup() {
+    this.webServer = MockWebServer()
+    this.webServer.start(20000)
+
+    this.taskRecorder =
+      TaskRecorder.create()
+    this.contentResolver =
+      MockContentResolver()
+    this.bundledContent =
+      MockBundledContentResolver()
+    this.bookRegistry =
+      BookRegistry.create()
+
+    this.account =
+      Mockito.mock(AccountType::class.java)
+
+    Mockito.`when`(this.account.loginState)
+      .thenReturn(
+        AccountLoginState.AccountLoggedIn(
+          AccountAuthenticationCredentials.Basic(
+            userName = AccountUsername("someone"),
+            password = AccountPassword("not a password"),
+            adobeCredentials = null,
+            authenticationDescription = "Basic",
+            annotationsURI = URI("https://www.example.com")
+          )
+        )
+      )
+
+    this.accountProvider =
+      MockAccountProviders.fakeProvider(
+        "urn:uuid:ea9480d4-5479-4ef1-b1d1-84ccbedb680f",
+        webServer.hostName,
+        webServer.port
+      )
+
+    Mockito.`when`(this.account.provider)
+      .thenReturn(this.accountProvider)
+
+    val androidContext =
+      Mockito.mock(Context::class.java)
+
+    this.httpClient =
+      LSHTTPClients()
+        .create(
+          context = androidContext,
+          configuration = LSHTTPClientConfiguration(
+            applicationName = "simplified-tests",
+            applicationVersion = "999.999.0",
+            tlsOverrides = null,
+            timeout = Pair(5L, TimeUnit.SECONDS)
+          )
+        )
+
+    this.accountId =
+      AccountID.generate()
+
+    this.bookDatabase =
+      MockBookDatabase(this.accountId)
+
+    this.services = MutableServiceDirectory().apply {
+      putService(
+        OPDSFeedParserType::class.java,
+        OPDSFeedParser.newParser(OPDSAcquisitionFeedEntryParser.newParser())
+      )
+    }
+  }
+
+  private fun createContext(
+    feedEntry: OPDSAcquisitionFeedEntry,
+    acquisitionPath: OPDSAcquisitionPath,
+    downloadedFile: File? = null
+  ): BorrowContextType {
+    val book = Book(
+      id = BookIDs.newFromOPDSEntry(feedEntry),
+      account = this.accountId,
+      cover = null,
+      thumbnail = null,
+      entry = feedEntry,
+      formats = listOf()
+    )
+
+    val tempDirPath = this.tempDir!!.toPath()
+    val bookDatabaseEntry = MockBookDatabaseEntry(book)
+
+    bookDatabaseEntry.formatHandlesField.clear()
+
+    bookDatabaseEntry.formatHandlesField.add(
+      MockBookDatabaseEntryFormatHandleEPUB(book.id).apply {
+        drmInformationHandleField = BookDRMInformationHandleLCP(
+          directory = Files.createTempDirectory(tempDirPath, "lcpDRMInfoEPUB").toFile(),
+          format = formatDefinition,
+          onUpdate = {}
+        )
+      }
+    )
+
+    bookDatabaseEntry.formatHandlesField.add(
+      MockBookDatabaseEntryFormatHandleAudioBook(book.id).apply {
+        drmInformationHandleField = BookDRMInformationHandleLCP(
+          directory = Files.createTempDirectory(tempDirPath, "lcpDRMInfoAudioBook").toFile(),
+          format = formatDefinition,
+          onUpdate = {}
+        )
+      }
+    )
+
+    bookDatabaseEntry.formatHandlesField.add(
+      MockBookDatabaseEntryFormatHandlePDF(book.id).apply {
+        drmInformationHandleField = BookDRMInformationHandleLCP(
+          directory = Files.createTempDirectory(tempDirPath, "lcpDRMInfoPDF").toFile(),
+          format = formatDefinition,
+          onUpdate = {}
+        )
+      }
+    )
+
+    val context = MockBorrowContext(
+      logger = this.logger,
+      bookRegistry = this.bookRegistry,
+      bundledContent = this.bundledContent,
+      temporaryDirectory = TestDirectories.temporaryDirectory(),
+      account = this.account,
+      clock = { Instant.now() },
+      httpClient = this.httpClient,
+      taskRecorder = this.taskRecorder,
+      isCancelled = false,
+      bookDatabaseEntry = bookDatabaseEntry,
+      bookInitial = book,
+      contentResolver = this.contentResolver,
+    )
+
+    context.opdsAcquisitionPath = acquisitionPath
+    context.currentAcquisitionPathElement = acquisitionPath.elements.first()
+    context.services = this.services
+    context.lcpService = MockLCPService(
+      publication = if (downloadedFile == null) {
+        null
+      } else {
+        Mockito.mock(LcpService.AcquiredPublication::class.java).also {
+          Mockito.`when`(it.localFile).thenReturn(downloadedFile)
+        }
+      }
+    )
+
+    return context
+  }
+
+  @AfterEach
+  fun tearDown() {
+    this.webServer.close()
+  }
+
+  @Test
+  fun epubDownload_succeeds() {
+    val feedEntry = BorrowTestFeeds.opdsLCPFeedEntryOfType(
+      webServer = this.webServer,
+      mime = "application/epub+zip",
+      id = "urn:isbn:123456789",
+      hashedPassphrase = ""
+    )
+
+    val licenseTargetPath = "/library/works/38859/fulfill/13"
+
+    val acquisitionPath = OPDSAcquisitionPath(
+      source = Mockito.mock(OPDSAcquisition::class.java),
+      elements = listOf(
+        OPDSAcquisitionPathElement(
+          mimeType = lcpLicenseFiles,
+          target = webServer.url(licenseTargetPath).toUri(),
+          properties = mapOf()
+        ),
+        OPDSAcquisitionPathElement(
+          mimeType = genericEPUBFiles,
+          target = null,
+          properties = mapOf()
+        )
+      )
+    )
+
+    // Expect a request for the loans feed to obtain the hashed passphrase for the book.
+
+    val newHashedPassphrase = "b9e3323fb715306bd89fa311b4bc988cce0042fb1d9079d13f41acc10c6ef37a"
+
+    val loansFeedResponse =
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "application/atom+xml;profile=opds-catalog;kind=acquisition")
+        .setBody(
+          """
+          <feed xmlns="http://www.w3.org/2005/Atom" xmlns:schema="http://schema.org/" xmlns:lcp="http://readium.org/lcp-specs/ns">
+            <id>https://example.com/library/loans/</id>
+            <title>Loans</title>
+            <updated>2022-03-10T00:53:24+00:00</updated>
+            <entry schema:additionalType="http://schema.org/EBook">
+              <title>Example EPUB</title>
+              <id>${feedEntry.id}</id>
+              <updated>2022-03-07T22:07:34+00:00</updated>
+              <link type="application/vnd.readium.lcp.license.v1.0+json" rel="http://opds-spec.org/acquisition">
+                <lcp:hashed_passphrase>$newHashedPassphrase</lcp:hashed_passphrase>
+              </link>
+            </entry>
+          </feed>
+          """
+        )
+
+    this.webServer.enqueue(loansFeedResponse)
+
+    // Expect a request to the acquisition URL to get the LCP license.
+
+    val licenseResponse =
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "application/vnd.readium.lcp.license.v1.0+json")
+        .setBody("{}")
+
+    this.webServer.enqueue(licenseResponse)
+
+    // Expect the LcpService to be used to download the publication. Create a mock downloaded file.
+
+    val downloadedFile = copyToTempFile("/org/nypl/simplified/tests/books/empty.epub")
+
+    // Create a mock borrow context.
+
+    val context = createContext(
+      feedEntry,
+      acquisitionPath,
+      downloadedFile
+    )
+
+    // Execute the task. It is expected to halt early.
+
+    val task = BorrowLCP.createSubtask()
+
+    Assertions.assertThrows(BorrowSubtaskException.BorrowSubtaskHaltedEarly::class.java) {
+      task.execute(context)
+    }
+
+    // The first request should have been to the loans feed for the account.
+
+    Assertions.assertEquals(2, this.webServer.requestCount)
+
+    Assertions.assertEquals(
+      this.account.provider.loansURI.toString().toHttpUrl(),
+      this.webServer.takeRequest().requestUrl
+    )
+
+    // The next request should have been to the target of the first acquisition path element.
+
+    Assertions.assertEquals(
+      this.webServer.url(licenseTargetPath),
+      this.webServer.takeRequest().requestUrl
+    )
+
+    // The downloaded file should now be in the book format.
+
+    val formatHandle = context.bookDatabaseEntry
+      .findFormatHandleForContentType(StandardFormatNames.genericEPUBFiles)!!
+
+    val format = formatHandle.format!! as BookFormat.BookFormatEPUB
+
+    Assertions.assertEquals(downloadedFile, format.file)
+
+    // The DRM info should now contain the hashed passphrase that was just retrieved.
+
+    val drmInfo = formatHandle.drmInformationHandle as BookDRMInformationHandleLCP
+
+    Assertions.assertEquals(newHashedPassphrase, drmInfo.info.hashedPassphrase)
+  }
+
+  @Test
+  fun audioBookDownload_succeeds() {
+    val feedEntry = BorrowTestFeeds.opdsLCPFeedEntryOfType(
+      webServer = this.webServer,
+      mime = "application/audiobook+lcp",
+      id = "urn:isbn:123456789",
+      hashedPassphrase = ""
+    )
+
+    val licenseTargetPath = "/library/works/23124/fulfill/13"
+
+    val acquisitionPath = OPDSAcquisitionPath(
+      source = Mockito.mock(OPDSAcquisition::class.java),
+      elements = listOf(
+        OPDSAcquisitionPathElement(
+          mimeType = lcpLicenseFiles,
+          target = webServer.url(licenseTargetPath).toUri(),
+          properties = mapOf()
+        ),
+        OPDSAcquisitionPathElement(
+          mimeType = lcpAudioBooks,
+          target = null,
+          properties = mapOf()
+        )
+      )
+    )
+
+    // Expect a request for the loans feed to obtain the hashed passphrase for the book.
+
+    val newHashedPassphrase = "b9e3323fb715306bd89fa311b4bc988cce0042fb1d9079d13f41acc10c6ef37a"
+
+    val loansFeedResponse =
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "application/atom+xml;profile=opds-catalog;kind=acquisition")
+        .setBody(
+          """
+          <feed xmlns="http://www.w3.org/2005/Atom" xmlns:schema="http://schema.org/" xmlns:lcp="http://readium.org/lcp-specs/ns">
+            <id>https://example.com/library/loans/</id>
+            <title>Loans</title>
+            <updated>2022-03-10T00:53:24+00:00</updated>
+            <entry schema:additionalType="http://bib.schema.org/Audiobook">
+              <title>Example Audio Book</title>
+              <id>${feedEntry.id}</id>
+              <updated>2022-03-07T22:07:34+00:00</updated>
+              <link type="application/vnd.readium.lcp.license.v1.0+json" rel="http://opds-spec.org/acquisition">
+                <lcp:hashed_passphrase>$newHashedPassphrase</lcp:hashed_passphrase>
+              </link>
+            </entry>
+          </feed>
+          """
+        )
+
+    this.webServer.enqueue(loansFeedResponse)
+
+    // Expect a request to the acquisition URL to get the LCP license.
+
+    val licenseResponse =
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "application/vnd.readium.lcp.license.v1.0+json")
+        .setBody("{}")
+
+    this.webServer.enqueue(licenseResponse)
+
+    // Expect the LcpService to be used to download the publication. Create a mock downloaded file.
+
+    val downloadedFile = copyToTempFile("/org/nypl/simplified/tests/books/empty.lcpa")
+
+    // Create a mock borrow context.
+
+    val context = createContext(
+      feedEntry,
+      acquisitionPath,
+      downloadedFile
+    )
+
+    // Execute the task. It is expected to halt early.
+
+    val task = BorrowLCP.createSubtask()
+
+    Assertions.assertThrows(BorrowSubtaskException.BorrowSubtaskHaltedEarly::class.java) {
+      task.execute(context)
+    }
+
+    // The first request should have been to the loans feed for the account.
+
+    Assertions.assertEquals(2, this.webServer.requestCount)
+
+    Assertions.assertEquals(
+      this.account.provider.loansURI.toString().toHttpUrl(),
+      this.webServer.takeRequest().requestUrl
+    )
+
+    // The next request should have been to the target of the first acquisition path element.
+
+    Assertions.assertEquals(
+      this.webServer.url(licenseTargetPath),
+      this.webServer.takeRequest().requestUrl
+    )
+
+    // The downloaded file should now be in the book format.
+
+    val formatHandle = context.bookDatabaseEntry
+      .findFormatHandleForContentType(StandardFormatNames.lcpAudioBooks)!!
+
+    val format = formatHandle.format!! as BookFormat.BookFormatAudioBook
+
+    Assertions.assertEquals(downloadedFile, format.file)
+
+    // The DRM info should now contain the hashed passphrase that was just retrieved.
+
+    val drmInfo = formatHandle.drmInformationHandle as BookDRMInformationHandleLCP
+
+    Assertions.assertEquals(newHashedPassphrase, drmInfo.info.hashedPassphrase)
+  }
+
+  @Test
+  fun download_fails_whenLoansFeedCanNotBeRetrieved() {
+    val feedEntry = BorrowTestFeeds.opdsLCPFeedEntryOfType(
+      webServer = this.webServer,
+      mime = "application/epub+zip",
+      id = "urn:isbn:123456789",
+      hashedPassphrase = ""
+    )
+
+    val licenseTargetPath = "/library/works/38859/fulfill/13"
+
+    val acquisitionPath = OPDSAcquisitionPath(
+      source = Mockito.mock(OPDSAcquisition::class.java),
+      elements = listOf(
+        OPDSAcquisitionPathElement(
+          mimeType = lcpLicenseFiles,
+          target = webServer.url(licenseTargetPath).toUri(),
+          properties = mapOf()
+        ),
+        OPDSAcquisitionPathElement(
+          mimeType = genericEPUBFiles,
+          target = null,
+          properties = mapOf()
+        )
+      )
+    )
+
+    val loansFeedResponse =
+      MockResponse()
+        .setResponseCode(500)
+        .setBody("nope")
+
+    this.webServer.enqueue(loansFeedResponse)
+
+    val context = createContext(
+      feedEntry,
+      acquisitionPath
+    )
+
+    // Execute the task. It is expected to halt early.
+
+    val task = BorrowLCP.createSubtask()
+
+    Assertions.assertThrows(BorrowSubtaskException.BorrowSubtaskFailed::class.java) {
+      task.execute(context)
+    }
+
+    // The first and only request should have been to the loans feed for the account.
+
+    Assertions.assertEquals(1, this.webServer.requestCount)
+
+    Assertions.assertEquals(
+      this.account.provider.loansURI.toString().toHttpUrl(),
+      this.webServer.takeRequest().requestUrl
+    )
+  }
+
+  @Test
+  fun download_fails_whenHashedPassphraseIsNotFoundInLoansFeed() {
+    val feedEntry = BorrowTestFeeds.opdsLCPFeedEntryOfType(
+      webServer = this.webServer,
+      mime = "application/epub+zip",
+      id = "urn:isbn:123456789",
+      hashedPassphrase = ""
+    )
+
+    val licenseTargetPath = "/library/works/38859/fulfill/13"
+
+    val acquisitionPath = OPDSAcquisitionPath(
+      source = Mockito.mock(OPDSAcquisition::class.java),
+      elements = listOf(
+        OPDSAcquisitionPathElement(
+          mimeType = lcpLicenseFiles,
+          target = webServer.url(licenseTargetPath).toUri(),
+          properties = mapOf()
+        ),
+        OPDSAcquisitionPathElement(
+          mimeType = genericEPUBFiles,
+          target = null,
+          properties = mapOf()
+        )
+      )
+    )
+
+    // Expect a request for the loans feed to obtain the hashed passphrase for the book.
+
+    val loansFeedResponse =
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "application/atom+xml;profile=opds-catalog;kind=acquisition")
+        .setBody(
+          """
+          <feed xmlns="http://www.w3.org/2005/Atom" xmlns:schema="http://schema.org/" xmlns:lcp="http://readium.org/lcp-specs/ns">
+            <id>https://example.com/library/loans/</id>
+            <title>Loans</title>
+            <updated>2022-03-10T00:53:24+00:00</updated>
+            <entry schema:additionalType="http://schema.org/EBook">
+              <title>Example EPUB</title>
+              <id>${feedEntry.id}</id>
+              <updated>2022-03-07T22:07:34+00:00</updated>
+              <link type="application/vnd.readium.lcp.license.v1.0+json" rel="http://opds-spec.org/acquisition">
+                <!-- oh no, there's no hashed passphrase here -->
+              </link>
+            </entry>
+          </feed>
+          """
+        )
+
+    this.webServer.enqueue(loansFeedResponse)
+
+    val context = createContext(
+      feedEntry,
+      acquisitionPath,
+    )
+
+    val task = BorrowLCP.createSubtask()
+
+    Assertions.assertThrows(BorrowSubtaskException.BorrowSubtaskFailed::class.java) {
+      task.execute(context)
+    }
+
+    // The first and only request should have been to the loans feed for the account.
+
+    Assertions.assertEquals(1, this.webServer.requestCount)
+
+    Assertions.assertEquals(
+      this.account.provider.loansURI.toString().toHttpUrl(),
+      this.webServer.takeRequest().requestUrl
+    )
+  }
+
+  @Test
+  fun download_fails_whenLicenseCanNotBeRetrieved() {
+    val feedEntry = BorrowTestFeeds.opdsLCPFeedEntryOfType(
+      webServer = this.webServer,
+      mime = "application/epub+zip",
+      id = "urn:isbn:123456789",
+      hashedPassphrase = ""
+    )
+
+    val licenseTargetPath = "/library/works/38859/fulfill/13"
+
+    val acquisitionPath = OPDSAcquisitionPath(
+      source = Mockito.mock(OPDSAcquisition::class.java),
+      elements = listOf(
+        OPDSAcquisitionPathElement(
+          mimeType = lcpLicenseFiles,
+          target = webServer.url(licenseTargetPath).toUri(),
+          properties = mapOf()
+        ),
+        OPDSAcquisitionPathElement(
+          mimeType = genericEPUBFiles,
+          target = null,
+          properties = mapOf()
+        )
+      )
+    )
+
+    // Expect a request for the loans feed to obtain the hashed passphrase for the book.
+
+    val newHashedPassphrase = "b9e3323fb715306bd89fa311b4bc988cce0042fb1d9079d13f41acc10c6ef37a"
+
+    val loansFeedResponse =
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "application/atom+xml;profile=opds-catalog;kind=acquisition")
+        .setBody(
+          """
+          <feed xmlns="http://www.w3.org/2005/Atom" xmlns:schema="http://schema.org/" xmlns:lcp="http://readium.org/lcp-specs/ns">
+            <id>https://example.com/library/loans/</id>
+            <title>Loans</title>
+            <updated>2022-03-10T00:53:24+00:00</updated>
+            <entry schema:additionalType="http://schema.org/EBook">
+              <title>Example EPUB</title>
+              <id>${feedEntry.id}</id>
+              <updated>2022-03-07T22:07:34+00:00</updated>
+              <link type="application/vnd.readium.lcp.license.v1.0+json" rel="http://opds-spec.org/acquisition">
+                <lcp:hashed_passphrase>$newHashedPassphrase</lcp:hashed_passphrase>
+              </link>
+            </entry>
+          </feed>
+          """
+        )
+
+    this.webServer.enqueue(loansFeedResponse)
+
+    // Expect a request to the acquisition URL to get the LCP license.
+
+    val licenseResponse =
+      MockResponse()
+        .setResponseCode(500)
+        .setBody("oh no")
+
+    this.webServer.enqueue(licenseResponse)
+
+    val context = createContext(
+      feedEntry,
+      acquisitionPath,
+    )
+
+    val task = BorrowLCP.createSubtask()
+
+    Assertions.assertThrows(BorrowSubtaskException.BorrowSubtaskFailed::class.java) {
+      task.execute(context)
+    }
+
+    // The first request should have been to the loans feed for the account.
+
+    Assertions.assertEquals(2, this.webServer.requestCount)
+
+    Assertions.assertEquals(
+      this.account.provider.loansURI.toString().toHttpUrl(),
+      this.webServer.takeRequest().requestUrl
+    )
+
+    // The next request should have been to the target of the first acquisition path element.
+
+    Assertions.assertEquals(
+      this.webServer.url(licenseTargetPath),
+      this.webServer.takeRequest().requestUrl
+    )
+  }
+
+  @Throws(IOException::class)
+  private fun copyToTempFile(
+    name: String
+  ): File {
+    val file = File.createTempFile(name, "", this.tempDir)
+
+    logger.debug("copyToTempFile: {} -> {}", name, file)
+
+    FileOutputStream(file).use { output ->
+      BorrowLCPTest::class.java.getResourceAsStream(name)!!.use { input ->
+        val buffer = ByteArray(4096)
+
+        while (true) {
+          val r = input.read(buffer)
+
+          if (r == -1) {
+            break
+          }
+
+          output.write(buffer, 0, r)
+        }
+
+        return file
+      }
+    }
+  }
+}

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowTestFeeds.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowTestFeeds.kt
@@ -207,6 +207,28 @@ object BorrowTestFeeds {
     return parsedEntry
   }
 
+  fun opdsLCPFeedEntryOfType(
+    webServer: MockWebServer,
+    mime: String,
+    id: String,
+    hashedPassphrase: String
+  ): OPDSAcquisitionFeedEntry {
+    val parsedEntry = this.opdsFeedEntryOf(
+      """
+      <entry xmlns="http://www.w3.org/2005/Atom" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:lcp="http://readium.org/lcp-specs/ns">
+        <title>Example</title>
+        <updated>2020-09-17T16:48:51+0000</updated>
+        <id>$id</id>
+        <link type="application/vnd.readium.lcp.license.v1.0+json" rel="http://opds-spec.org/acquisition" href="${webServer.url("/next")}">
+          <opds:indirectAcquisition type="$mime"/>
+          <lcp:hashed_passphrase>$hashedPassphrase</lcp:hashed_passphrase>
+        </link>
+      </entry>
+      """
+    )
+    return parsedEntry
+  }
+
   fun opdsFeedEntryOf(text: String): OPDSAcquisitionFeedEntry {
     return OPDSAcquisitionFeedEntryParser.newParser()
       .parseEntryStream(URI.create("urn:stdin"), text.byteInputStream())

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskTest.kt
@@ -2367,6 +2367,7 @@ class BookRevokeTaskTest {
 
     val bookFormat =
       BookFormat.BookFormatAudioBook(
+        file = null,
         manifest = null,
         position = null,
         contentType = BookFormats.audioBookGenericMimeTypes().first(),

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookDatabaseEntry.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookDatabaseEntry.kt
@@ -9,6 +9,7 @@ import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryType
 import org.nypl.simplified.books.formats.api.StandardFormatNames.genericEPUBFiles
 import org.nypl.simplified.books.formats.api.StandardFormatNames.genericPDFFiles
+import org.nypl.simplified.books.formats.api.StandardFormatNames.lcpAudioBooks
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSAcquisitionPaths
 import org.slf4j.LoggerFactory
@@ -86,6 +87,10 @@ class MockBookDatabaseEntry(private val bookInitial: Book) : BookDatabaseEntryTy
       }
       if (MIMECompatibility.isCompatibleStrictWithoutAttributes(finalType, genericPDFFiles)) {
         formats.add(MockBookDatabaseEntryFormatHandlePDF(bookId))
+        continue
+      }
+      if (MIMECompatibility.isCompatibleStrictWithoutAttributes(finalType, lcpAudioBooks)) {
+        formats.add(MockBookDatabaseEntryFormatHandleAudioBook(bookId))
         continue
       }
     }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookDatabaseEntryFormatHandleAudioBook.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookDatabaseEntryFormatHandleAudioBook.kt
@@ -46,7 +46,10 @@ class MockBookDatabaseEntryFormatHandleAudioBook(
   }
 
   override fun copyInBook(file: File) {
-    TODO("Not yet implemented")
+    this.bookData = file.readText()
+    this.bookFile = file
+    this.formatField = this.formatField.copy(file = this.bookFile)
+    check(this.formatField.isDownloaded)
   }
 
   override fun savePlayerPosition(position: PlayerPosition) {

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookDatabaseEntryFormatHandleAudioBook.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBookDatabaseEntryFormatHandleAudioBook.kt
@@ -22,6 +22,7 @@ class MockBookDatabaseEntryFormatHandleAudioBook(
     BookFormat.BookFormatAudioBook(
       drmInformation = BookDRMInformation.None,
       contentType = StandardFormatNames.genericAudioBooks.first(),
+      file = null,
       manifest = null,
       position = null
     )
@@ -42,6 +43,10 @@ class MockBookDatabaseEntryFormatHandleAudioBook(
         File("whatever")
       )
     )
+  }
+
+  override fun copyInBook(file: File) {
+    TODO("Not yet implemented")
   }
 
   override fun savePlayerPosition(position: PlayerPosition) {

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBorrowContext.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBorrowContext.kt
@@ -42,6 +42,7 @@ class MockBorrowContext(
   override var isCancelled: Boolean,
   override var bookDatabaseEntry: BookDatabaseEntryType,
   override var samlDownloadContext: SAMLDownloadContext? = null,
+  override var lcpService: LcpService? = null,
   bookInitial: Book,
 ) : BorrowContextType {
 
@@ -53,8 +54,6 @@ class MockBorrowContext(
 
   override lateinit var audioBookManifestStrategies: AudioBookManifestStrategiesType
   override lateinit var services: ServiceDirectoryType
-
-  override val lcpService: LcpService? = null
 
   override var adobeExecutorTimeout: BorrowTimeoutConfiguration =
     BorrowTimeoutConfiguration(2L, TimeUnit.SECONDS)

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockLCPService.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockLCPService.kt
@@ -7,12 +7,18 @@ import org.readium.r2.lcp.LcpService
 import org.readium.r2.shared.util.Try
 import java.io.File
 
-class MockLCPService : LcpService {
+class MockLCPService(
+  val publication: LcpService.AcquiredPublication? = null
+) : LcpService {
   override suspend fun acquirePublication(
     lcpl: ByteArray,
     onProgress: (Double) -> Unit
   ): Try<LcpService.AcquiredPublication, LcpException> {
-    return Try.failure(LcpException.LicenseProfileNotSupported)
+    return if (publication == null) {
+      Try.failure(LcpException.LicenseProfileNotSupported)
+    } else {
+      Try.success(publication)
+    }
   }
 
   override suspend fun isLcpProtected(


### PR DESCRIPTION
**What's this do?**

This adds support for borrowing and downloading LCP audiobooks (and eventually, PDFs).

- The `BorrowLCP` borrowing subtask only allowed the LCP acquisition path to result in an EPUB. It now allows the result to be an audiobook, and leaves a stub to allow supporting PDF.
- The `application/audiobook+lcp` mime type is now recognized, so that the LCP acquisition path will be followed.

**Why are we doing this? (w/ JIRA link if applicable)**

This is the first step to support borrowing and playing LCP audiobooks. Notion: https://www.notion.so/lyrasis/Get-LCP-for-audiobooks-working-in-the-Palace-Android-app-46e982c74a2949d9b6049d6212a10380#dfb4e416ff57468eac0f993a0d9e3ec9

**How should this be tested? / Do these changes have associated tests?**

I've added unit tests for BorrowLCP, including tests for downloading EPUB books and audiobooks.

Borrowing and downloading an LCP audiobook (from the DPLA Titles lane in LYRASIS Reads) should be successful. The book should take a relatively long time to download, because the LCP acquisition will contain all the audio files, not just the manifest.

Downloaded audiobooks will not play yet ("URI is not absolute" error message).

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

Yes

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee downloaded some LCP audiobooks.
