### PR TITLE
Read LCP license key from its own file instead of secrets.conf.

### DIFF
--- a/.ci-local/credentials.sh
+++ b/.ci-local/credentials.sh
@@ -46,11 +46,11 @@ cat ".ci/credentials/APK Signing/keystore.properties" >> "${HOME}/.gradle/gradle
 CREDENTIALS_PATH=$(realpath ".ci/credentials") ||
   fatal "could not resolve credentials path"
 
-SIMPLYE_CREDENTIALS="${CREDENTIALS_PATH}/Certificates/Palace/Android"
+ASSETS_PATH="${CREDENTIALS_PATH}/Certificates/Palace/Android"
 
-if [ ! -d "${SIMPLYE_CREDENTIALS}" ]
+if [ ! -d "${ASSETS_PATH}" ]
 then
-  fatal "${SIMPLYE_CREDENTIALS} does not exist, or is not a directory"
+  fatal "${ASSETS_PATH} does not exist, or is not a directory"
 fi
 
 cp "${CREDENTIALS_PATH}/PlayStore/play_store_api_key.json" "simplified-app-palace/play_store_api_key.json" ||
@@ -63,7 +63,8 @@ org.thepalaceproject.s3.depend=true
 org.thepalaceproject.aws.access_key_id=${CI_AWS_ACCESS_ID}
 org.thepalaceproject.aws.secret_access_key=${CI_AWS_SECRET_KEY}
 
-org.thepalaceproject.app.assets.palace=${SIMPLYE_CREDENTIALS}
+org.thepalaceproject.app.credentials.palace=${CREDENTIALS_PATH}
+org.thepalaceproject.app.assets.palace=${ASSETS_PATH}
 EOF
 
 #------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -186,15 +186,19 @@ build failure: When DRM is enabled, the build system will check that you have
 provided various configuration files containing secrets that the DRM systems
 require, and will refuse to build the app if you've failed to do this. The
 build system can copy in the correct secrets for you if tell it the location
-of directories containing those secrets. For example, assuming that you have
-[Palace's](simplified-app-palace) secrets in `/path/to/palace/secrets`<!--and
-[Open eBook's](simplified-app-openebooks) secrets in `/path/to/openebooks/secrets` -->,
-you can add the following properties to your `$HOME/.gradle/gradle.properties` file
-and the build system will copy in the required secrets at build time:
+of directories containing those secrets. There are two directories to configure:
+A credentials directory, containing secrets needed to build the app, and an
+assets directory, containing secrets needed by the app at runtime (which will be
+installed as assets in the app). For example, assuming that you have
+[Palace's](simplified-app-palace) credentials in '/path/to/palace/credentials',
+and assets in `/path/to/palace/assets`, you can add the following properties to
+your `$HOME/.gradle/gradle.properties` file and the build system will copy in
+the required secrets at build time:
 
 <!-- org.librarysimplified.app.assets.openebooks=/path/to/openebooks/secrets -->
 ```
-org.thepalaceproject.app.assets.palace=/path/to/palace/secrets
+org.thepalaceproject.app.credentials.palace=/path/to/palace/credentials
+org.thepalaceproject.app.assets.palace=/path/to/palace/assets
 ```
 
 #### Adobe DRM Support

--- a/build.gradle
+++ b/build.gradle
@@ -105,24 +105,17 @@ ext {
     }
   }
 
-  //
-  // Load secrets stored in secrets.conf.
-  //
+  credentialsPath =
+    project.findProperty('org.thepalaceproject.app.credentials.palace') ?: ''
+  lcpLicenseFile = "${credentialsPath}/LCP/prod_license_key.txt"
+  lcpLicenseKey = 'test'
 
-  assetPath = project.findProperty('org.thepalaceproject.app.assets.palace')
-  secrets = new Properties()
-
-  if (nyplDrmEnabled) {
-    file("$assetPath/secrets.conf").withInputStream {
-      secrets.load(it)
-    }
+  try {
+    lcpLicenseKey = new File(lcpLicenseFile).text.trim()
+  } catch (Exception ex) {
+    logger.error("Failed to read production LCP license key from {}", lcpLicenseFile)
+    logger.error("Test liblcp will be used")
   }
-
-  //
-  // Get the LCP production license key from secrets, or default to the test key.
-  //
-
-  lcpLicenseKey = secrets.getProperty('lcp.prod.license.key', 'test')
 }
 
 //


### PR DESCRIPTION
**What's this do?**

This changes how the LCP production license key is obtained by gradle. Previously, the key was in Certificates/Palace/Android/secrets.conf in mobile-certificates, but it doesn't belong there, because the secrets.conf file is meant to only contain secrets needed by the app at runtime. The LCP production license key is only used at build time, in order to download the library using maven. The key now resides in LCP/prod_license_key.txt instead, and the build reads that file.

Note that for local builds, the property `org.thepalaceproject.app.credentials.palace` now must be set in gradle.properties. The value should be the path to the mobile-certificates repo. (This is similar to the`org.thepalaceproject.app.assets.palace` property, which should already be set.)

**Why are we doing this? (w/ JIRA link if applicable)**

This cleans up the Android secrets, so we don't leak them unnecessarily.

**How should this be tested? / Do these changes have associated tests?**

Builds should continue to work, and LCP downloads should work as usual.

**Dependencies for merging? Releasing to production?**

https://github.com/ThePalaceProject/mobile-certificates/pull/19/files needs to be merged first.

**Have you updated the changelog?**

No, this is not a user-facing change.

**Has the application documentation been updated for these changes?**

The README has been updated.

**Did someone actually run this code to verify it works?**

@ray-lee ran a local build, but a CI build with DRM will have to wait until this is merged.