### PR TITLE
Fix timeout downloading large audiobooks.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -168,11 +168,12 @@
         <c:change date="2022-03-01T00:00:00+00:00" summary="Removed Open Textbook Library from the featured libraries."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-03-22T19:16:19+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.8">
+    <c:release date="2022-03-23T15:42:33+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.8">
       <c:changes>
         <c:change date="2022-03-15T00:00:00+00:00" summary="Added support for acquiring and playing LCP-protected audiobooks."/>
         <c:change date="2022-03-22T00:00:00+00:00" summary="Changed label of untitled audiobook files from &quot;Chapter&quot; to &quot;Track&quot;."/>
-        <c:change date="2022-03-22T19:16:19+00:00" summary="Eliminated the delay between downloading an LCP-protected audiobook and playing it."/>
+        <c:change date="2022-03-22T00:00:00+00:00" summary="Eliminated the delay between downloading an LCP-protected audiobook and playing it."/>
+        <c:change date="2022-03-23T15:42:33+00:00" summary="Fixed timeout error when downloading some large audiobooks."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLCP.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLCP.kt
@@ -285,6 +285,9 @@ class BorrowLCP private constructor() : BorrowSubtaskType {
           context.bookDownloadSucceeded()
         }
       }
+    } catch (e: BorrowSubtaskFailed) {
+      context.bookDownloadFailed()
+      throw e
     } catch (e: Exception) {
       context.taskRecorder.currentStepFailed(
         message = "LCP fulfillment error: ${e.message}",

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainHTTP.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainHTTP.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import org.librarysimplified.http.api.LSHTTPClientConfiguration
 import org.librarysimplified.http.api.LSHTTPClientType
 import org.librarysimplified.http.vanilla.LSHTTPClients
+import java.util.concurrent.TimeUnit
 
 object MainHTTP {
 
@@ -23,7 +24,11 @@ object MainHTTP {
     val configuration =
       LSHTTPClientConfiguration(
         applicationName = name,
-        applicationVersion = version
+        applicationVersion = version,
+        // TODO: The 5 minute timeout is for download of large LCP audiobooks (in BorrowLCP).
+        // Otherwise, the default of 1 minute would be sufficient. In the future we might want to
+        // allow per-request timeouts.
+        timeout = Pair(5L, TimeUnit.MINUTES)
       )
 
     return LSHTTPClients().create(context, configuration)


### PR DESCRIPTION
**What's this do?**

This fixes a timeout error when downloading large LCP audiobooks.
- The HTTP client timeout is increased to 5 minutes (from the default 1 minute).
- Error handling in `BorrowLCP.fulfill` is tweaked, so that a better error message appears on the Error Details screen when a download fails.

**Why are we doing this? (w/ JIRA link if applicable)**

This addresses an error found in QA for the fix to remove the delay when opening LCP audiobooks. Notion: https://www.notion.so/lyrasis/Investigate-long-delay-when-opening-LCP-encrypted-audiobooks-900b5c8d8329417089e50ae4cfc14a13

**How should this be tested? / Do these changes have associated tests?**

Borrow and download a large LCP audiobook, e.g. "Goliath" in LYRASIS Reads. The download should complete successfully, although it may take over 1 minute.

**Dependencies for merging? Releasing to production?**

None

**Have you updated the changelog?**

Yes

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee downloaded some large LCP books.
