### PR TITLE
Make OverDrive client key and secret optional.

### DIFF
--- a/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookOverdriveSecretServiceType.kt
+++ b/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/AudioBookOverdriveSecretServiceType.kt
@@ -11,11 +11,11 @@ interface AudioBookOverdriveSecretServiceType : AudioBookSecretServiceType {
    * The client key.
    */
 
-  val clientKey: String
+  val clientKey: String?
 
   /**
    * The client secret.
    */
 
-  val clientPass: String
+  val clientPass: String?
 }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainOverdriveSecretService.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainOverdriveSecretService.kt
@@ -5,7 +5,6 @@ import org.nypl.simplified.books.audio.AudioBookOverdriveSecretServiceType
 import org.slf4j.LoggerFactory
 import java.io.FileNotFoundException
 import java.io.InputStream
-import java.lang.NullPointerException
 import java.util.Properties
 
 /**
@@ -13,8 +12,8 @@ import java.util.Properties
  */
 
 class MainOverdriveSecretService private constructor(
-  override val clientKey: String,
-  override val clientPass: String
+  override val clientKey: String?,
+  override val clientPass: String?
 ) : AudioBookOverdriveSecretServiceType {
 
   companion object {
@@ -44,10 +43,8 @@ class MainOverdriveSecretService private constructor(
 
       val clientKey =
         properties.getProperty("overdrive.prod.client.key")
-          ?: throw NullPointerException("overdrive.prod.client.key is missing")
       val clientPass =
         properties.getProperty("overdrive.prod.client.secret")
-          ?: throw NullPointerException("overdrive.prod.client.secret is missing")
 
       return MainOverdriveSecretService(
         clientKey = clientKey,

--- a/simplified-tests/build.gradle
+++ b/simplified-tests/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   api project(":simplified-futures")
   api project(":simplified-json-core")
   api project(":simplified-lcp")
+  api project(":simplified-main")
   api project(":simplified-metrics")
   api project(":simplified-metrics-api")
   api project(":simplified-migration-from3master")

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/overdrive/MainOverdriveSecretServiceTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/overdrive/MainOverdriveSecretServiceTest.kt
@@ -1,0 +1,36 @@
+package org.nypl.simplified.tests.overdrive
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.nypl.simplified.main.MainOverdriveSecretService
+
+class MainOverdriveSecretServiceTest {
+
+  @Test
+  fun create_withKeyAndSecret_succeeds() {
+    val secretService = MainOverdriveSecretService.create(
+      """
+      foo.value.a = something
+      foo.value.b = another
+      overdrive.prod.client.key = hello
+      overdrive.prod.client.secret = world
+      """.trimIndent().byteInputStream()
+    )
+
+    Assertions.assertEquals("hello", secretService.clientKey)
+    Assertions.assertEquals("world", secretService.clientPass)
+  }
+
+  @Test
+  fun create_withoutKeyAndSecret_succeeds() {
+    val secretService = MainOverdriveSecretService.create(
+      """
+      foo.value.a = something
+      foo.value.b = another
+      """.trimIndent().byteInputStream()
+    )
+
+    Assertions.assertEquals(null, secretService.clientKey)
+    Assertions.assertEquals(null, secretService.clientPass)
+  }
+}


### PR DESCRIPTION
**What's this do?**

This makes the OverDrive client key and secret optional (nullable). The CM will be updated to provide the app with an OverDrive patron token to use for downloading OverDrive audio books, at which point the client key and secret won't be needed, and will be removed from the app. This ensures that the OverDrive service will continue to work when the key and secret are null.

Note: The CI build is failing because https://github.com/ThePalaceProject/android-audiobook-overdrive/pull/1 needs to be merged first.

**Why are we doing this? (w/ JIRA link if applicable)**

Removing the OverDrive client credentials from the app improves security. Notion: https://www.notion.so/lyrasis/Android-Remove-need-for-OverDrive-client-key-and-secret-fbf7cf563def446dbb501fb7bcfa3a5a?d=9435e3d7bed8485c9492e668c8eb20d8

**How should this be tested? / Do these changes have associated tests?**

Unit tests are included to verify that the key and secret are nullable.

The app should be able to download audiobooks from the OverDrive Integration Test library successfully -- now, and after the CM has been updated to provide a token, and the OD credentials are removed from the app.

**Dependencies for merging? Releasing to production?**

https://github.com/ThePalaceProject/android-audiobook-overdrive/pull/1 should be merged first.

**Have you updated the changelog?**

No, this is not a user-visible change.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested that services initialize correctly without an OverDrive key and secret. There are existing problems with the OverDrive Integration Test library, so I can't download a book, but there are no new errors.