### PR TITLE
Add support for LCP-protected PDFs.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -174,8 +174,10 @@
         <c:change date="2022-03-22T00:00:00+00:00" summary="Changed the label of untitled audiobook files from &quot;Chapter&quot; to &quot;Track&quot;."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-03-29T17:43:01+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.9">
-      <c:changes/>
+    <c:release date="2022-04-07T22:33:03+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.9">
+      <c:changes>
+        <c:change date="2022-04-07T22:33:03+00:00" summary="Added support for PDF books with LCP DRM."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLCP.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLCP.kt
@@ -363,8 +363,7 @@ class BorrowLCP private constructor() : BorrowSubtaskType {
         formatHandle.moveInBook(bookFile)
       }
       is BookDatabaseEntryFormatHandlePDF ->
-        // TODO
-        throw NotImplementedError("LCP-encrypted PDF downloads are not yet implemented")
+        formatHandle.copyInBook(bookFile)
     }
 
     context.taskRecorder.currentStepSucceeded("Saved book.")

--- a/simplified-viewer-pdf/build.gradle
+++ b/simplified-viewer-pdf/build.gradle
@@ -4,13 +4,17 @@ dependencies {
   implementation project(":simplified-books-database-api")
   implementation project(":simplified-profiles-controller-api")
   implementation project(":simplified-services-api")
+  implementation project(":simplified-ui-thread-api")
   implementation project(":simplified-viewer-spi")
 
   implementation libs.androidx.activity
   implementation libs.androidx.app.compat
+  implementation libs.kotlin.coroutines
   implementation libs.kotlin.reflect
   implementation libs.kotlin.stdlib
   implementation libs.nypl.pdf.api
   implementation libs.nypl.pdf.viewer
+  implementation libs.palace.drm.core
+  implementation libs.r2.streamer
   implementation libs.slf4j
 }

--- a/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfReaderParameters.kt
+++ b/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfReaderParameters.kt
@@ -1,6 +1,7 @@
 package org.nypl.simplified.viewer.pdf
 
 import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.books.api.BookDRMInformation
 import org.nypl.simplified.books.api.BookID
 import java.io.File
 import java.io.Serializable
@@ -17,5 +18,6 @@ data class PdfReaderParameters(
   val accountId: AccountID,
   val documentTile: String,
   val pdfFile: File,
-  val id: BookID
+  val id: BookID,
+  val drmInfo: BookDRMInformation
 ) : Serializable

--- a/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfViewerProvider.kt
+++ b/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfViewerProvider.kt
@@ -51,7 +51,8 @@ class PdfViewerProvider : ViewerProviderType {
         accountId = book.account,
         documentTile = book.entry.title,
         pdfFile = formatPDF.file!!,
-        id = book.id
+        id = book.id,
+        drmInfo = formatPDF.drmInformation
       )
     )
   }


### PR DESCRIPTION
**What's this do?**

This adds support for reading LCP-protected PDFs. These are downloaded as zip files, containing an encrypted PDF. Readium's kotlin-toolkit is used to open and decrypt the file, and pass an input stream to the reader.

**Why are we doing this? (w/ JIRA link if applicable)**

Notion: https://www.notion.so/lyrasis/Add-support-for-LCP-encrypted-PDFs-Android-c14bd90d074941759ce038c62aa4a272#26d1b8829815434ab9f5dd452af46b23

**How should this be tested? / Do these changes have associated tests?**

In LYRASIS library, borrow and open "Spin Doctors" by Nora Loreto. The book should open successfully in the PDF reader. Other titles from the PDF Test lane may work, depending on the device, but they may be too large for the PDF reader to handle.

**Dependencies for merging? Releasing to production?**

None

**Have you updated the changelog?**

Yes

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee opened an LCP PDF.