### PR TITLE
Added related books feed to book details page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 *.jks
 secrets.conf
 ReaderClientCert.sig
+LCP/prod_license_key.txt
 
 # Backup files
 *~

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -174,9 +174,10 @@
         <c:change date="2022-03-22T00:00:00+00:00" summary="Changed the label of untitled audiobook files from &quot;Chapter&quot; to &quot;Track&quot;."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-04-07T22:33:03+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.9">
+    <c:release date="2022-04-08T14:48:28+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.9">
       <c:changes>
-        <c:change date="2022-04-07T22:33:03+00:00" summary="Added support for PDF books with LCP DRM."/>
+        <c:change date="2022-04-07T00:00:00+00:00" summary="Added support for PDF books with LCP DRM."/>
+        <c:change date="2022-04-08T14:48:28+00:00" summary="Added automatic loading and displaying of related books in a book details screen "/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/UnpackagedAudioBookManifestStrategy.kt
+++ b/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/UnpackagedAudioBookManifestStrategy.kt
@@ -116,8 +116,8 @@ class UnpackagedAudioBookManifestStrategy(
             OPAParameters(
               userName = credentials.userName,
               password = OPAPassword.Password(credentials.password),
-              clientKey = secretService.clientKey,
-              clientPass = secretService.clientPass,
+              clientKey = secretService.clientKey.orEmpty(),
+              clientPass = secretService.clientPass.orEmpty(),
               targetURI = OPAManifestURI.Indirect(this.request.targetURI),
               userAgent = this.request.userAgent
             )
@@ -125,8 +125,8 @@ class UnpackagedAudioBookManifestStrategy(
             OPAParameters(
               userName = credentials.userName,
               password = OPAPassword.NotRequired,
-              clientKey = secretService.clientKey,
-              clientPass = secretService.clientPass,
+              clientKey = secretService.clientKey.orEmpty(),
+              clientPass = secretService.clientPass.orEmpty(),
               targetURI = OPAManifestURI.Indirect(this.request.targetURI),
               userAgent = this.request.userAgent
             )

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -225,6 +225,10 @@ internal class MainFragmentListenerDelegate(
         this.openFeed(event.feedArguments)
         state
       }
+      is CatalogBookDetailEvent.OpenBookDetail -> {
+        this.openBookDetail(event.feedArguments, event.opdsEntry)
+        state
+      }
       CatalogBookDetailEvent.GoUpwards -> {
         this.goUpwards()
         state

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailEvent.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailEvent.kt
@@ -3,6 +3,7 @@ package org.nypl.simplified.ui.catalog
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookFormat
+import org.nypl.simplified.feeds.api.FeedEntry
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 
 sealed class CatalogBookDetailEvent {
@@ -20,6 +21,11 @@ sealed class CatalogBookDetailEvent {
   data class OpenViewer(
     val book: Book,
     val format: BookFormat
+  ) : CatalogBookDetailEvent()
+
+  data class OpenBookDetail(
+    val feedArguments: CatalogFeedArguments,
+    val opdsEntry: FeedEntry.FeedEntryOPDS
   ) : CatalogBookDetailEvent()
 
   data class OpenFeed(

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.text.Html
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
@@ -11,6 +12,9 @@ import android.widget.TextView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SimpleItemAnimator
 import com.google.common.base.Preconditions
 import com.google.common.util.concurrent.FluentFuture
 import com.io7m.jfunctional.Some
@@ -26,11 +30,14 @@ import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.covers.BookCoverProviderType
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryOPDS
+import org.nypl.simplified.feeds.api.FeedGroup
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.listeners.api.fragmentListeners
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
+import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.ui.neutrality.NeutralToolbar
 import org.nypl.simplified.ui.screen.ScreenSizeInformationType
+import org.slf4j.LoggerFactory
 import java.net.URI
 
 /**
@@ -55,8 +62,19 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     }
   }
 
+  private val logger = LoggerFactory.getLogger(CatalogBookDetailFragment::class.java)
+
   private val services =
     Services.serviceDirectory()
+
+  private val bookCovers =
+    services.requireService(BookCoverProviderType::class.java)
+
+  private val profilesController =
+    services.requireService(ProfilesControllerType::class.java)
+
+  private val screenInformation =
+    services.requireService(ScreenSizeInformationType::class.java)
 
   private val parameters: CatalogBookDetailFragmentParameters by lazy {
     this.requireArguments()[PARAMETERS_ID] as CatalogBookDetailFragmentParameters
@@ -91,9 +109,13 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
   private lateinit var cover: ImageView
   private lateinit var covers: BookCoverProviderType
   private lateinit var debugStatus: TextView
+  private lateinit var feedWithGroupsAdapter: CatalogFeedWithGroupsAdapter
+  private lateinit var feedWithoutGroupsAdapter: CatalogPagedAdapter
   private lateinit var format: TextView
   private lateinit var metadata: LinearLayout
-  private lateinit var related: TextView
+  private lateinit var relatedBooksContainer: FrameLayout
+  private lateinit var relatedBooksList: RecyclerView
+  private lateinit var relatedBooksLoading: ViewGroup
   private lateinit var report: TextView
   private lateinit var screenSize: ScreenSizeInformationType
   private lateinit var status: ViewGroup
@@ -131,6 +153,8 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       .appendLiteral(':')
       .appendSecondOfMinute(2)
       .toFormatter()
+
+  private val feedWithGroupsData: MutableList<FeedGroup> = mutableListOf()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -170,8 +194,12 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       view.findViewById(R.id.bookDetailMetadataTable)
     this.buttons =
       view.findViewById(R.id.bookDetailButtons)
-    this.related =
-      view.findViewById(R.id.bookDetailRelated)
+    this.relatedBooksContainer =
+      view.findViewById(R.id.bookDetailRelatedBooksContainer)
+    this.relatedBooksList =
+      view.findViewById(R.id.relatedBooksList)
+    this.relatedBooksLoading =
+      view.findViewById(R.id.feedLoading)
     this.report =
       view.findViewById(R.id.bookDetailReport)
 
@@ -213,6 +241,22 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     this.covers.loadCoverInto(
       this.parameters.feedEntry, this.cover, 0, targetHeight
     )
+
+    this.relatedBooksList.setHasFixedSize(true)
+    this.relatedBooksList.setItemViewCacheSize(32)
+    this.relatedBooksList.layoutManager = LinearLayoutManager(this.context)
+    (this.relatedBooksList.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
+    this.relatedBooksList.addItemDecoration(
+      CatalogFeedWithGroupsDecorator(this.screenInformation.dpToPixels(16).toInt())
+    )
+
+    this.feedWithGroupsAdapter =
+      CatalogFeedWithGroupsAdapter(
+        groups = this.feedWithGroupsData,
+        coverLoader = this.bookCovers,
+        onFeedSelected = this.viewModel::openFeed,
+        onBookSelected = this.viewModel::openBookDetail
+      )
 
     this.configureOPDSEntry(this.parameters.feedEntry)
   }
@@ -285,12 +329,12 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     val feedRelatedOpt = feedEntry.feedEntry.related
     if (feedRelatedOpt is Some<URI>) {
       val feedRelated = feedRelatedOpt.get()
-      this.related.setOnClickListener {
-        this.viewModel.openRelatedFeed(feedRelated)
-      }
-      this.related.isEnabled = true
+
+      this.viewModel.relatedBooksFeedState.observe(this.viewLifecycleOwner, this::updateRelatedBooksUI)
+      this.relatedBooksContainer.visibility = View.VISIBLE
+      this.viewModel.loadRelatedBooks(feedRelated)
     } else {
-      this.related.isEnabled = false
+      this.relatedBooksContainer.visibility = View.GONE
     }
   }
 
@@ -388,6 +432,66 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       is BookStatus.DownloadExternalAuthenticationInProgress ->
         this.onBookStatusDownloadExternalAuthenticationInProgress()
     }
+  }
+
+  private fun updateRelatedBooksUI(feedState: CatalogFeedState?) {
+    when (feedState) {
+      is CatalogFeedState.CatalogFeedLoading -> {
+        this.onCatalogFeedLoading()
+      }
+       is CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithGroups -> {
+         this.onCatalogFeedWithGroups(feedState)
+       }
+      is CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithoutGroups -> {
+        this.onCatalogFeedWithoutGroups(feedState)
+      }
+      else -> {
+        this.relatedBooksContainer.visibility = View.GONE
+      }
+    }
+  }
+
+  private fun onCatalogFeedLoading() {
+    this.relatedBooksContainer.visibility = View.VISIBLE
+    this.relatedBooksList.visibility = View.INVISIBLE
+    this.relatedBooksLoading.visibility = View.VISIBLE
+  }
+
+  private fun onCatalogFeedWithoutGroups(
+    feedState: CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithoutGroups
+  ) {
+
+    this.relatedBooksContainer.visibility = View.VISIBLE
+    this.relatedBooksLoading.visibility = View.INVISIBLE
+    this.relatedBooksList.visibility = View.VISIBLE
+
+    this.feedWithoutGroupsAdapter =
+      CatalogPagedAdapter(
+        context = requireActivity(),
+        listener = this.viewModel,
+        buttonCreator = this.buttonCreator,
+        bookCovers = this.bookCovers,
+        profilesController = this.profilesController
+      )
+
+    this.relatedBooksList.adapter = this.feedWithoutGroupsAdapter
+    feedState.entries.observe(this) { newPagedList ->
+      this.logger.debug("received paged list ({} elements)", newPagedList.size)
+      this.feedWithoutGroupsAdapter.submitList(newPagedList)
+    }
+  }
+
+  private fun onCatalogFeedWithGroups(
+    feedState: CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithGroups
+  ) {
+    this.relatedBooksContainer.visibility = View.VISIBLE
+    this.relatedBooksLoading.visibility = View.INVISIBLE
+    this.relatedBooksList.visibility = View.VISIBLE
+
+    this.relatedBooksList.adapter = this.feedWithGroupsAdapter
+    this.feedWithGroupsData.clear()
+    this.feedWithGroupsData.addAll(feedState.feed.feedGroupsInOrder)
+    this.feedWithGroupsAdapter.notifyDataSetChanged()
   }
 
   private fun onBookStatusFailedLoan(

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -91,7 +91,6 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
   private val viewModel: CatalogBookDetailViewModel by viewModels(
     factoryProducer = {
       CatalogBookDetailViewModelFactory(
-        requireActivity().application,
         this.services,
         this.borrowViewModel,
         this.listener,
@@ -330,7 +329,10 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     if (feedRelatedOpt is Some<URI>) {
       val feedRelated = feedRelatedOpt.get()
 
-      this.viewModel.relatedBooksFeedState.observe(this.viewLifecycleOwner, this::updateRelatedBooksUI)
+      this.viewModel.relatedBooksFeedState.observe(
+        this.viewLifecycleOwner,
+        this::updateRelatedBooksUI
+      )
       this.relatedBooksContainer.visibility = View.VISIBLE
       this.viewModel.loadRelatedBooks(feedRelated)
     } else {
@@ -439,9 +441,9 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       is CatalogFeedState.CatalogFeedLoading -> {
         this.onCatalogFeedLoading()
       }
-       is CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithGroups -> {
-         this.onCatalogFeedWithGroups(feedState)
-       }
+      is CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithGroups -> {
+        this.onCatalogFeedWithGroups(feedState)
+      }
       is CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithoutGroups -> {
         this.onCatalogFeedWithoutGroups(feedState)
       }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
@@ -1,6 +1,5 @@
 package org.nypl.simplified.ui.catalog
 
-import android.content.res.Resources
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
@@ -4,17 +4,28 @@ import android.content.res.Resources
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.paging.LivePagedListBuilder
+import androidx.paging.PagedList
+import com.google.common.util.concurrent.FluentFuture
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.subjects.PublishSubject
+import org.nypl.simplified.accounts.api.AccountAuthenticatedHTTP
 import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.accounts.api.AccountProviderAuthenticationDescription
 import org.nypl.simplified.books.api.Book
 import org.nypl.simplified.books.api.BookFormat
+import org.nypl.simplified.books.api.BookID
 import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookStatusEvent
 import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
+import org.nypl.simplified.feeds.api.Feed
 import org.nypl.simplified.feeds.api.FeedEntry
+import org.nypl.simplified.feeds.api.FeedLoaderResult
+import org.nypl.simplified.feeds.api.FeedLoaderType
+import org.nypl.simplified.futures.FluentFutureExtensions.map
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.opds.core.OPDSAvailabilityHeld
 import org.nypl.simplified.opds.core.OPDSAvailabilityHeldReady
@@ -24,38 +35,73 @@ import org.nypl.simplified.opds.core.OPDSAvailabilityLoaned
 import org.nypl.simplified.opds.core.OPDSAvailabilityMatcherType
 import org.nypl.simplified.opds.core.OPDSAvailabilityOpenAccess
 import org.nypl.simplified.opds.core.OPDSAvailabilityRevoked
+import org.nypl.simplified.profiles.api.ProfilePreferences
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.slf4j.LoggerFactory
 import java.net.URI
+import java.util.*
+import javax.annotation.concurrent.GuardedBy
 
 class CatalogBookDetailViewModel(
   private val resources: Resources,
+  private val feedLoader: FeedLoaderType,
   private val profilesController: ProfilesControllerType,
   private val bookRegistry: BookRegistryType,
   private val buildConfiguration: BuildConfigurationServiceType,
   private val borrowViewModel: CatalogBorrowViewModel,
   private val parameters: CatalogBookDetailFragmentParameters,
   private val listener: FragmentListenerType<CatalogBookDetailEvent>
-) : ViewModel() {
+) : ViewModel(), CatalogPagedViewListener {
+
+  private val instanceId =
+    UUID.randomUUID()
 
   private val logger =
     LoggerFactory.getLogger(CatalogBookDetailViewModel::class.java)
+
+  @GuardedBy("loaderResults")
+  private val loaderResults =
+    PublishSubject.create<LoaderResultWithArguments>()
 
   private val subscriptions =
     CompositeDisposable(
       this.bookRegistry.bookEvents()
         .filter { event -> event.bookId == this.parameters.bookID }
         .observeOn(AndroidSchedulers.mainThread())
-        .subscribe(this::onBookStatusEvent)
+        .subscribe(this::onBookStatusEvent),
+      this.loaderResults
+        .observeOn(AndroidSchedulers.mainThread())
+        .subscribe(this::onFeedLoaderResult)
     )
+
+  private lateinit var feedArguments: CatalogFeedArguments.CatalogFeedArgumentsRemote
 
   private val bookWithStatusMutable: MutableLiveData<BookWithStatus> =
     MutableLiveData(this.createBookWithStatus())
 
   private val bookWithStatus: BookWithStatus
     get() = bookWithStatusMutable.value!!
+
+  private val relatedBooksFeedStateMutable: MutableLiveData<CatalogFeedState?> =
+    MutableLiveData(null)
+
+  val relatedBooksFeedState: LiveData<CatalogFeedState?>
+    get() = relatedBooksFeedStateMutable
+
+  private data class LoaderResultWithArguments(
+    val arguments: CatalogFeedArguments,
+    val result: FeedLoaderResult
+  )
+
+  private class BookModel(
+    val feedEntry: FeedEntry.FeedEntryOPDS,
+    val onBookChanged: MutableList<(BookWithStatus) -> Unit> = mutableListOf()
+  )
+
+  private val bookModels: MutableMap<BookID, BookModel> =
+    mutableMapOf()
 
   private fun onBookStatusEvent(event: BookStatusEvent) {
     val bookWithStatus = this.createBookWithStatus()
@@ -179,14 +225,260 @@ class CatalogBookDetailViewModel(
     }
   }
 
-  fun openRelatedFeed(feedRelated: URI) {
-    val targetFeed =
+  override fun openBookDetail(opdsEntry: FeedEntry.FeedEntryOPDS) {
+    this.listener.post(
+      CatalogBookDetailEvent.OpenBookDetail(this.feedArguments, opdsEntry)
+    )
+  }
+
+  override fun openViewer(book: Book, format: BookFormat) {
+    this.listener.post(CatalogBookDetailEvent.OpenViewer(book, format))
+  }
+
+  override fun showTaskError(book: Book, result: TaskResult.Failure<*>) {
+    // do nothing
+  }
+
+  override fun registerObserver(
+    feedEntry: FeedEntry.FeedEntryOPDS,
+    callback: (BookWithStatus) -> Unit
+  ) {
+    this.bookModels.getOrPut(feedEntry.bookID, { BookModel(feedEntry) }).onBookChanged.add(callback)
+    this.notifyBookStatus(feedEntry, callback)
+  }
+
+  override fun unregisterObserver(
+    feedEntry: FeedEntry.FeedEntryOPDS,
+    callback: (BookWithStatus) -> Unit
+  ) {
+    val model = this.bookModels[feedEntry.bookID]
+    if (model != null) {
+      model.onBookChanged.remove(callback)
+      if (model.onBookChanged.isEmpty()) {
+        this.bookModels.remove(feedEntry.bookID)
+      }
+    }
+  }
+
+  override fun dismissBorrowError(feedEntry: FeedEntry.FeedEntryOPDS) {
+    this.borrowViewModel.tryDismissBorrowError(feedEntry.accountID, feedEntry.bookID)
+  }
+
+  override fun dismissRevokeError(feedEntry: FeedEntry.FeedEntryOPDS) {
+    this.borrowViewModel.tryDismissRevokeError(feedEntry.accountID, feedEntry.bookID)
+  }
+
+  override fun delete(feedEntry: FeedEntry.FeedEntryOPDS) {
+    this.borrowViewModel.tryDelete(feedEntry.accountID, feedEntry.bookID)
+  }
+
+  override fun borrowMaybeAuthenticated(book: Book) {
+    // do nothing
+  }
+
+  override fun reserveMaybeAuthenticated(book: Book) {
+    // do nothing
+  }
+
+  override fun revokeMaybeAuthenticated(book: Book) {
+    // do nothing
+  }
+
+  fun openFeed(title: String, uri: URI) {
+    val arguments =
+      CatalogFeedArguments.CatalogFeedArgumentsRemote(
+        feedURI = this.feedArguments.feedURI.resolve(uri).normalize(),
+        isSearchResults = false,
+        ownership = this.feedArguments.ownership,
+        title = title
+      )
+
+    this.listener.post(
+      CatalogBookDetailEvent.OpenFeed(arguments)
+    )
+  }
+
+  fun loadRelatedBooks(feedRelated: URI) {
+    feedArguments =
       this.resolveFeedFromBook(
         accountID = this.bookWithStatus.book.account,
-        title = this.resources.getString(R.string.catalogRelatedBooks),
         uri = feedRelated
       )
-    this.listener.post(CatalogBookDetailEvent.OpenFeed(targetFeed))
+
+    this.logger.debug("[{}]: loading remote feed {}", this.instanceId, feedArguments.feedURI)
+
+    val profile =
+      this.profilesController.profileCurrent()
+    val account =
+      profile.account(feedArguments.ownership.accountId)
+
+    /*
+     * If the remote feed has an age gate, and we haven't given an age, then display an
+     * age gate!
+     */
+
+    if (shouldDisplayAgeGate(account.provider.authentication, profile.preferences())) {
+      this.logger.debug("[{}]: showing age gate", this.instanceId)
+      val newState = CatalogFeedState.CatalogFeedAgeGate(feedArguments)
+      this.relatedBooksFeedStateMutable.value = newState
+      return
+    }
+
+    val loginState =
+      account.loginState
+    val authentication =
+      AccountAuthenticatedHTTP.createAuthorizationIfPresent(loginState.credentials)
+
+    val future =
+      this.feedLoader.fetchURI(
+        account = account.id,
+        uri = feedArguments.feedURI,
+        auth = authentication,
+        method = "GET"
+      )
+
+    this.createNewStatus(
+      arguments = feedArguments,
+      future = future
+    )
+  }
+
+  private fun shouldDisplayAgeGate(
+    authentication: AccountProviderAuthenticationDescription,
+    preferences: ProfilePreferences
+  ): Boolean {
+    val isCoppa = authentication is AccountProviderAuthenticationDescription.COPPAAgeGate
+    return isCoppa && buildConfiguration.showAgeGateUi && preferences.dateOfBirth == null
+  }
+
+  /**
+   * Create a new feed state for the given operation. The feed is assumed to start in a "loading"
+   * state.
+   */
+
+  private fun createNewStatus(
+    arguments: CatalogFeedArguments,
+    future: FluentFuture<FeedLoaderResult>
+  ) {
+    val newState =
+      CatalogFeedState.CatalogFeedLoading(arguments)
+
+    this.relatedBooksFeedStateMutable.value = newState
+
+    /*
+     * Register a callback that updates the feed status when the future completes.
+     */
+
+    future.map { feedLoaderResult ->
+      synchronized(loaderResults) {
+        val resultWithArguments =
+          LoaderResultWithArguments(arguments, feedLoaderResult)
+        this.loaderResults.onNext(resultWithArguments)
+      }
+    }
+  }
+
+  private fun onFeedLoaderResult(resultWithArguments: LoaderResultWithArguments) {
+    this.logger.debug("[{}]: feed status updated: {}", this.instanceId,
+      resultWithArguments.arguments.javaClass)
+
+    this.relatedBooksFeedStateMutable.value =
+      this.feedLoaderResultToFeedState(resultWithArguments.arguments, resultWithArguments.result)
+  }
+
+  private fun feedLoaderResultToFeedState(
+    arguments: CatalogFeedArguments,
+    result: FeedLoaderResult
+  ): CatalogFeedState {
+    return when (result) {
+      is FeedLoaderResult.FeedLoaderSuccess ->
+        when (val feed = result.feed) {
+          is Feed.FeedWithoutGroups ->
+            this.onReceivedFeedWithoutGroups(arguments, feed)
+          is Feed.FeedWithGroups ->
+            this.onReceivedFeedWithGroups(arguments, feed)
+        }
+      is FeedLoaderResult.FeedLoaderFailure ->
+        CatalogFeedState.CatalogFeedLoadFailed(
+          arguments = arguments,
+          failure = result
+        )
+    }
+  }
+
+  private fun notifyBookStatus(
+    feedEntry: FeedEntry.FeedEntryOPDS,
+    callback: (BookWithStatus) -> Unit
+  ) {
+    val bookWithStatus =
+      this.bookRegistry.bookOrNull(feedEntry.bookID)
+        ?: this.synthesizeBookWithStatus(feedEntry)
+
+    callback(bookWithStatus)
+  }
+
+  private fun onReceivedFeedWithoutGroups(
+    arguments: CatalogFeedArguments,
+    feed: Feed.FeedWithoutGroups
+  ): CatalogFeedState.CatalogFeedLoaded {
+    if (feed.entriesInOrder.isEmpty()) {
+      return CatalogFeedState.CatalogFeedLoaded.CatalogFeedEmpty(
+        arguments = arguments,
+        search = feed.feedSearch,
+        title = feed.feedTitle
+      )
+    }
+
+    /*
+     * Construct a paged list for infinitely scrolling feeds.
+     */
+
+    val dataSourceFactory =
+      CatalogPagedDataSourceFactory(
+        feedLoader = this.feedLoader,
+        initialFeed = feed,
+        ownership = arguments.ownership,
+        profilesController = this.profilesController
+      )
+
+    val pagedListConfig =
+      PagedList.Config.Builder()
+        .setEnablePlaceholders(true)
+        .setPageSize(50)
+        .setMaxSize(250)
+        .setPrefetchDistance(25)
+        .build()
+
+    val pagedList =
+      LivePagedListBuilder(dataSourceFactory, pagedListConfig)
+        .build()
+
+    return CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithoutGroups(
+      arguments = arguments,
+      entries = pagedList,
+      facetsInOrder = feed.facetsOrder,
+      facetsByGroup = feed.facetsByGroup,
+      search = feed.feedSearch,
+      title = feed.feedTitle
+    )
+  }
+
+  private fun onReceivedFeedWithGroups(
+    arguments: CatalogFeedArguments,
+    feed: Feed.FeedWithGroups
+  ): CatalogFeedState.CatalogFeedLoaded {
+    if (feed.size == 0) {
+      return CatalogFeedState.CatalogFeedLoaded.CatalogFeedEmpty(
+        arguments = arguments,
+        search = feed.feedSearch,
+        title = feed.feedTitle
+      )
+    }
+
+    return CatalogFeedState.CatalogFeedLoaded.CatalogFeedWithGroups(
+      arguments = arguments,
+      feed = feed
+    )
   }
 
   /**
@@ -203,16 +495,15 @@ class CatalogBookDetailViewModel(
 
   private fun resolveFeedFromBook(
     accountID: AccountID,
-    title: String,
     uri: URI
-  ): CatalogFeedArguments {
+  ): CatalogFeedArguments.CatalogFeedArgumentsRemote {
     return when (val arguments = this.parameters.feedArguments) {
       is CatalogFeedArguments.CatalogFeedArgumentsRemote ->
         CatalogFeedArguments.CatalogFeedArgumentsRemote(
           feedURI = arguments.feedURI.resolve(uri),
           isSearchResults = false,
           ownership = CatalogFeedOwnership.OwnedByAccount(accountID),
-          title = title
+          title = ""
         )
 
       is CatalogFeedArguments.CatalogFeedArgumentsLocalBooks -> {
@@ -220,7 +511,7 @@ class CatalogBookDetailViewModel(
           feedURI = uri,
           isSearchResults = false,
           ownership = CatalogFeedOwnership.OwnedByAccount(accountID),
-          title = title
+          title = ""
         )
       }
     }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModelFactory.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModelFactory.kt
@@ -1,6 +1,5 @@
 package org.nypl.simplified.ui.catalog
 
-import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import org.librarysimplified.services.api.ServiceDirectoryType
@@ -12,7 +11,6 @@ import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.slf4j.LoggerFactory
 
 class CatalogBookDetailViewModelFactory(
-  private val application: Application,
   private val services: ServiceDirectoryType,
   private val borrowViewModel: CatalogBorrowViewModel,
   private val listener: FragmentListenerType<CatalogBookDetailEvent>,
@@ -37,7 +35,6 @@ class CatalogBookDetailViewModelFactory(
           services.requireService(BuildConfigurationServiceType::class.java)
 
         CatalogBookDetailViewModel(
-          this.application.resources,
           feedLoader,
           profilesController,
           bookRegistry,

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModelFactory.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModelFactory.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import org.librarysimplified.services.api.ServiceDirectoryType
 import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
+import org.nypl.simplified.feeds.api.FeedLoaderType
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.slf4j.LoggerFactory
@@ -26,6 +27,8 @@ class CatalogBookDetailViewModelFactory(
 
     return when {
       modelClass.isAssignableFrom(CatalogBookDetailViewModel::class.java) -> {
+        val feedLoader: FeedLoaderType =
+          this.services.requireService(FeedLoaderType::class.java)
         val profilesController =
           services.requireService(ProfilesControllerType::class.java)
         val bookRegistry =
@@ -35,6 +38,7 @@ class CatalogBookDetailViewModelFactory(
 
         CatalogBookDetailViewModel(
           this.application.resources,
+          feedLoader,
           profilesController,
           bookRegistry,
           configurationService,

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -584,11 +584,11 @@ class CatalogFeedViewModel(
     override val sortBy: String
       get() = this.resources.getString(R.string.feedSortBy)
     override val show: String
-      get() = "Show"
+      get() = this.resources.getString(R.string.feedShow)
     override val showAll: String
-      get() = "All"
+      get() = this.resources.getString(R.string.feedShowAll)
     override val showOnLoan: String
-      get() = "On Loan"
+      get() = this.resources.getString(R.string.feedShowOnLoan)
   }
 
   val accountProvider: AccountProviderType?

--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -200,17 +200,25 @@
       android:layout_marginBottom="16dp"
       android:background="?android:attr/listDivider" />
 
-    <TextView
-      android:id="@+id/bookDetailRelated"
+    <FrameLayout
+      android:id="@+id/bookDetailRelatedBooksContainer"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginStart="16dp"
-      android:layout_marginEnd="16dp"
-      android:layout_marginBottom="16dp"
-      android:enabled="false"
-      android:text="@string/catalogRelatedBooks"
-      android:textSize="18sp"
-      android:textStyle="bold" />
+      android:layout_marginBottom="16dp">
+
+      <include
+          layout="@layout/feed_loading"
+          tools:visibility="visible" />
+
+      <androidx.recyclerview.widget.RecyclerView
+          android:id="@+id/relatedBooksList"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:clipChildren="false"
+          android:clipToPadding="false"
+          android:overScrollMode="never" />
+
+    </FrameLayout>
 
     <View
       android:layout_width="match_parent"

--- a/simplified-ui-catalog/src/main/res/values/stringsFeed.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsFeed.xml
@@ -11,6 +11,9 @@
   <string name="feedLoadingError">An error occurred while loading the catalog.</string>
   <string name="feedNavigationNotSupported">Navigation feeds are not currently supported. Sorry!</string>
   <string name="feedRetry">@string/catalogRetry</string>
+  <string name="feedShow">Show</string>
+  <string name="feedShowAll">All</string>
+  <string name="feedShowOnLoan">On Loan</string>
   <string name="feedSortBy">Sort By</string>
   <string name="feedTitleBooks">Books</string>
   <string name="feedTitleCatalog">Catalog</string>


### PR DESCRIPTION
**What's this do?**
This PR adds the related books catalog to the book details screen. Instead of opening a new screen after clicking on "Related books...", the related books are now automatically loaded and shown in the screen.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=1990931812bd44f29b28ce3b2aaeefad&p=af962b51273e434bbc821ac3b971c1ac) saying that this behavior should be implemented in order to replicate what we have in the iOS version.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select any library
Open any book
Scroll down and verify the related books are [being shown ](https://user-images.githubusercontent.com/79104027/162463778-ec07e783-810f-4f43-94a5-3bd9eaaec6f8.png) without having to click on any button

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 