### PR TITLE
Removed red icon from audiobook cover in the audiobook player screen

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -174,9 +174,10 @@
         <c:change date="2022-03-22T00:00:00+00:00" summary="Changed the label of untitled audiobook files from &quot;Chapter&quot; to &quot;Track&quot;."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-04-07T22:33:03+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.9">
+    <c:release date="2022-04-12T13:57:52+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.9">
       <c:changes>
-        <c:change date="2022-04-07T22:33:03+00:00" summary="Added support for PDF books with LCP DRM."/>
+        <c:change date="2022-04-07T00:00:00+00:00" summary="Added support for PDF books with LCP DRM."/>
+        <c:change date="2022-04-12T13:57:52+00:00" summary="Removed red icon from audiobook cover in the audiobook player screen"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/UnpackagedAudioBookManifestStrategy.kt
+++ b/simplified-books-audio/src/main/java/org/nypl/simplified/books/audio/UnpackagedAudioBookManifestStrategy.kt
@@ -116,8 +116,8 @@ class UnpackagedAudioBookManifestStrategy(
             OPAParameters(
               userName = credentials.userName,
               password = OPAPassword.Password(credentials.password),
-              clientKey = secretService.clientKey,
-              clientPass = secretService.clientPass,
+              clientKey = secretService.clientKey.orEmpty(),
+              clientPass = secretService.clientPass.orEmpty(),
               targetURI = OPAManifestURI.Indirect(this.request.targetURI),
               userAgent = this.request.userAgent
             )
@@ -125,8 +125,8 @@ class UnpackagedAudioBookManifestStrategy(
             OPAParameters(
               userName = credentials.userName,
               password = OPAPassword.NotRequired,
-              clientKey = secretService.clientKey,
-              clientPass = secretService.clientPass,
+              clientKey = secretService.clientKey.orEmpty(),
+              clientPass = secretService.clientPass.orEmpty(),
               targetURI = OPAManifestURI.Indirect(this.request.targetURI),
               userAgent = this.request.userAgent
             )

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
@@ -52,6 +52,7 @@ class BookCoverProvider private constructor(
   private fun doLoad(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
+    hasBadge: Boolean,
     width: Int,
     height: Int,
     tag: String,
@@ -111,9 +112,11 @@ class BookCoverProvider private constructor(
             requestCreator.resize(width, height)
           }
 
-          requestCreator
-            .transform(badgePainter)
-            .into(imageView, callbackFinal)
+          if (hasBadge) {
+            requestCreator.transform(badgePainter)
+          }
+
+          requestCreator.into(imageView, callbackFinal)
         }
       }
 
@@ -126,8 +129,12 @@ class BookCoverProvider private constructor(
         requestCreator.resize(width, height)
       }
 
-      requestCreator.transform(badgePainter)
-        .into(imageView, fallbackToGeneration)
+      if (hasBadge) {
+        requestCreator.transform(badgePainter)
+      }
+
+      requestCreator.into(imageView, callbackFinal)
+
     } else {
       this.logger.debug("{}: {}: loading generated uri {}", tag, entry.bookID, uriGenerated)
 
@@ -140,8 +147,11 @@ class BookCoverProvider private constructor(
         requestCreator.resize(width, height)
       }
 
-      requestCreator.transform(badgePainter)
-        .into(imageView, callbackFinal)
+      if (hasBadge) {
+        requestCreator.transform(badgePainter)
+      }
+
+      requestCreator.into(imageView, callbackFinal)
     }
 
     return FluentFuture.from(future)
@@ -220,6 +230,7 @@ class BookCoverProvider private constructor(
     return doLoad(
       entry = entry,
       imageView = imageView,
+      hasBadge = true,
       width = width,
       height = height,
       tag = thumbnailTag,
@@ -230,12 +241,14 @@ class BookCoverProvider private constructor(
   override fun loadCoverInto(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
+    hasBadge: Boolean,
     width: Int,
     height: Int
   ): FluentFuture<Unit> {
     return doLoad(
       entry = entry,
       imageView = imageView,
+      hasBadge = hasBadge,
       width = width,
       height = height,
       tag = coverTag,

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProvider.kt
@@ -134,7 +134,6 @@ class BookCoverProvider private constructor(
       }
 
       requestCreator.into(imageView, callbackFinal)
-
     } else {
       this.logger.debug("{}: {}: loading generated uri {}", tag, entry.bookID, uriGenerated)
 

--- a/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProviderType.kt
+++ b/simplified-books-covers/src/main/java/org/nypl/simplified/books/covers/BookCoverProviderType.kt
@@ -51,6 +51,7 @@ interface BookCoverProviderType {
    *
    * @param entry The feed entry
    * @param imageView The image view
+   * @param hasBadge If the image should have the red icon at the bottom right corner
    * @param width Use 0 as desired dimension to resize keeping aspect ratio.
    * @param height Use 0 as desired dimension to resize keeping aspect ratio.
    */
@@ -58,6 +59,7 @@ interface BookCoverProviderType {
   fun loadCoverInto(
     entry: FeedEntry.FeedEntryOPDS,
     imageView: ImageView,
+    hasBadge: Boolean,
     width: Int,
     height: Int
   ): FluentFuture<Unit>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -211,7 +211,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     val targetHeight =
       this.resources.getDimensionPixelSize(R.dimen.cover_detail_height)
     this.covers.loadCoverInto(
-      this.parameters.feedEntry, this.cover, 0, targetHeight
+      this.parameters.feedEntry, this.cover, hasBadge = true, 0, targetHeight
     )
 
     this.configureOPDSEntry(this.parameters.feedEntry)

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -724,6 +724,7 @@ class AudioBookPlayerActivity :
   override fun onPlayerWantsCoverImage(view: ImageView) {
     this.covers.loadCoverInto(
       entry = FeedEntry.FeedEntryOPDS(this.parameters.accountID, this.parameters.opdsEntry),
+      hasBadge = false,
       imageView = view,
       width = 0,
       height = 0


### PR DESCRIPTION
**What's this do?**
This PR adds a boolean to set if the red icon should or should not appear at the bottom right corner of the audiobook cover image.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Remove-red-audiobook-icon-from-covers-in-audiobook-player-3050fb51495e4286a228ebc978e9307a) to make the Android app similar to the iOS version to improve the UX

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select "LYRASIS Reads" library
Verify the audiobook [is showing the red icon](https://user-images.githubusercontent.com/79104027/162989594-6e86308c-e5dc-4f87-a0bd-b6e8a02f3f85.png) in the catalog
Open any audiobook
Verify the audioobook [is showing the red icon in the catalog](https://user-images.githubusercontent.com/79104027/162989764-2e6c57f0-bc8b-4f86-94fa-0242953b2c4d.png) in the book details
Click on "Listen"
Verify the red icon [is not appearing in the audiobook cover image](https://user-images.githubusercontent.com/79104027/162989940-f354f912-4150-4902-8a60-b90e852e6b25.png) in the player screen

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 