### PR TITLE
Added missing "toc" element

### DIFF
--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/audio/AudioBookSucceedingParsers.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/audio/AudioBookSucceedingParsers.kt
@@ -20,7 +20,8 @@ object AudioBookSucceedingParsers : ManifestParsersType {
         encrypted = null
       ),
       links = listOf(),
-      extensions = listOf()
+      extensions = listOf(),
+      toc = listOf()
     )
 
   override fun parse(


### PR DESCRIPTION
**What's this do?**
This PR adds a missing _toc_ field to the PlayerManifest constructor in the AudioBookSucceedingParsers file.

**Why are we doing this? (w/ JIRA link if applicable)**
The tests were failing

**How should this be tested? / Do these changes have associated tests?**
Run the pipeline and verify it doesn't return any errors

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 
