### PR TITLE
Use updated secrets.conf without OD keys.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -184,8 +184,10 @@
         <c:change date="2022-04-21T00:00:00+00:00" summary="Improved the chapter titles displayed in the audio book player. The chapter titles from the table of contents are now used, when one is supplied in the manifest. Previously, a file name was displayed for some books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-04-27T22:43:25+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.10">
-      <c:changes/>
+    <c:release date="2022-04-28T16:46:11+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.10">
+      <c:changes>
+        <c:change date="2022-04-28T16:46:11+00:00" summary="Improved security of OverDrive audio book downloads."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/simplified-app-palace/build.gradle
+++ b/simplified-app-palace/build.gradle
@@ -9,7 +9,7 @@ def requiredFiles = [:]
 requiredFiles["ReaderClientCert.sig"] =
   "b064e68b96e258e42fe1ca66ae3fc4863dd802c46585462220907ed291e1217d"
 requiredFiles["secrets.conf"] =
-  "756e525becd6f266e8e063abdb8bd03dfca352f0551b33756e21ecb826dfd01b"
+  "9c211ae0d153c29b72baab3bfad9de6c5cecb6b39bcda8206d36a65aaca0db21"
 
 android {
   defaultConfig {


### PR DESCRIPTION
**What's this do?**

This updates the app to use a secrets.conf file that does not include the OverDrive client key and secret.

**Why are we doing this? (w/ JIRA link if applicable)**

This improves the security of OverDrive downloads. Notion: https://www.notion.so/lyrasis/Android-Remove-need-for-OverDrive-client-key-and-secret-fbf7cf563def446dbb501fb7bcfa3a5a

**How should this be tested? / Do these changes have associated tests?**

From the OverDrive Integration Test Library, borrow and download audiobooks. The audiobooks should all download and play successfully.

**Dependencies for merging? Releasing to production?**

https://github.com/ThePalaceProject/mobile-certificates/pull/20 must be merged first.

**Have you updated the changelog?**

Yes

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee played some OverDrive audiobooks.