### PR TITLE
Fixed facet labels being cropped and catalog searching button behavior

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,8 +190,11 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-04-29T17:20:09+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
-      <c:changes/>
+    <c:release date="2022-05-05T16:08:12+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+      <c:changes>
+        <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped"/>
+        <c:change date="2022-05-05T16:08:12+00:00" summary="Disabled searching button on catalog search when the input is blank"/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -28,6 +28,7 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.setPadding
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -631,6 +632,13 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
       }
     }
     dialog.show()
+
+    // disabling the positive button can only be called after the dialog is shown
+    val dialogPositiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+    dialogPositiveButton.isEnabled = false
+    searchView.doAfterTextChanged { text ->
+      dialogPositiveButton.isEnabled = !text.isNullOrBlank()
+    }
   }
 
   private fun configureFacets(
@@ -677,7 +685,7 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
 
     val buttonLayoutParams =
       LinearLayout.LayoutParams(
-        this.screenInformation.dpToPixels(96).toInt(),
+        LinearLayout.LayoutParams.WRAP_CONTENT,
         LinearLayout.LayoutParams.WRAP_CONTENT
       )
 
@@ -719,7 +727,6 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
         group.find { facet -> facet.isActive }
           ?: group.firstOrNull()
 
-      buttonLayoutParams.weight = 1.0f
       button.id = View.generateViewId()
       button.layoutParams = buttonLayoutParams
       button.text = active?.title

--- a/simplified-ui-catalog/src/main/res/layout/feed_content.xml
+++ b/simplified-ui-catalog/src/main/res/layout/feed_content.xml
@@ -56,15 +56,15 @@
         android:id="@+id/feedEmptyMessage"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_margin="16dp"
         android:gravity="center"
+        android:text="@string/feedEmpty"
         android:textAlignment="center"
         android:visibility="invisible"
-        android:layout_margin="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/feedContentLogoHeader"
-        tools:text="@string/feedEmpty"
         tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-ui-catalog/src/main/res/values/stringsFeed.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsFeed.xml
@@ -7,7 +7,7 @@
   <string name="feedCollection">Collection</string>
   <string name="feedCollectionAll">All</string>
   <string name="feedDetails">@string/catalogDetails</string>
-  <string name="feedEmpty">No results.</string>
+  <string name="feedEmpty">No results found.</string>
   <string name="feedLoadingError">An error occurred while loading the catalog.</string>
   <string name="feedNavigationNotSupported">Navigation feeds are not currently supported. Sorry!</string>
   <string name="feedRetry">@string/catalogRetry</string>


### PR DESCRIPTION
**What's this do?**
This PR changes the way the facet buttons are created by removing their weight and setting their with to wrap their content. This also adds a condition to disable the searching button in the catalog in case the searching query is blank.

**Why are we doing this? (w/ JIRA link if applicable)**
There are feature requests to [fix the bug where the facet labels are cropped](https://www.notion.so/lyrasis/Android-Sorting-of-books-The-title-of-the-button-Recently-Added-is-not-full-7cba041227a44379a848798f6bd4acb4) and also to [update the catalog searching behavior](https://www.notion.so/lyrasis/Android-Search-for-a-book-An-error-appears-when-the-search-field-is-empty-or-only-spaces-are-enter-3164edee27fb4f2389872788171b0349) to make it more similar to iOS.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select "LYRASIS Reads" library
Click on the search icon at the top right corner and verify the [search button is disabled](https://user-images.githubusercontent.com/79104027/166965553-f35ab5d1-643b-4aa8-bd56-795a0252016c.png)
Insert some spaces and verify the [search button is still disabled](https://user-images.githubusercontent.com/79104027/166965616-3f456dfd-3ca2-43c9-8fa7-67b34ea71629.png)
Type some weird text like "dsajidsjaoidjsaoidjsioajsaioa" to get no results and verify [the "No results found" label is displayed](https://user-images.githubusercontent.com/79104027/166965497-fca5b48e-ddaf-467f-9b42-40fdaa3bb0c8.png)
Go back and click on "More..." on the Biblioboard Test lane
Click on "Availability" and select "Available Now"
Click on "Sort by" and select "Recently Added"
Verify that [both facets display the entire label](https://user-images.githubusercontent.com/79104027/166965412-2d2a1089-0abc-4b5b-a7e7-b38273775da3.png) and that the view is scrollable

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 