### PR TITLE
Updated book details and catalog UI

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,10 +190,13 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-05-05T16:08:12+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-05-13T08:17:33+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
-        <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped"/>
-        <c:change date="2022-05-05T16:08:12+00:00" summary="Disabled searching button on catalog search when the input is blank"/>
+        <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
+        <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
+        <c:change date="2022-05-13T00:00:00+00:00" summary="Fixed section title overlapping back button."/>
+        <c:change date="2022-05-13T00:00:00+00:00" summary="Removed section title from book detail screen."/>
+        <c:change date="2022-05-13T08:17:33+00:00" summary="Updated displayed text when a book is available to borrow."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -281,6 +281,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     actionBar.setDisplayHomeAsUpEnabled(true)
     actionBar.setHomeActionContentDescription(null)
     actionBar.show()
+    this.toolbar.title = ""
     this.toolbar.setLogoOnClickListener {
       this.viewModel.goUpwards()
     }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -362,12 +362,9 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
   ) {
     this.openAgeGateDialog()
     this.feedContent.visibility = View.INVISIBLE
-//    this.feedEmpty.visibility = View.INVISIBLE
     this.feedError.visibility = View.INVISIBLE
     this.feedLoading.visibility = View.INVISIBLE
     this.feedNavigation.visibility = View.INVISIBLE
-//    this.feedWithGroups.visibility = View.INVISIBLE
-//    this.feedWithoutGroups.visibility = View.INVISIBLE
 
     this.configureToolbar()
   }
@@ -537,7 +534,7 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
 
   private fun configureToolbar() {
     try {
-      this.toolbar.setTitle(this.viewModel.title())
+      this.toolbar.title = this.viewModel.title()
       val actionBar = this.supportActionBar ?: return
       actionBar.show()
 

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -23,7 +23,7 @@
   <string name="catalogBookAvailabilityHeldQueue">You are at position %1$d in the queue for this book.</string>
   <string name="catalogBookAvailabilityHeldTimed">You will be able to borrow this book in %1$s.</string>
   <string name="catalogBookAvailabilityHoldable">All copies of this book are currently on loan.</string>
-  <string name="catalogBookAvailabilityLoanable">This book is available for loan.</string>
+  <string name="catalogBookAvailabilityLoanable">This book is available to borrow.</string>
   <string name="catalogBookAvailabilityLoanedIndefinite">You have this book on loan.</string>
   <string name="catalogBookAvailabilityLoanedTimed">You have this book on loan for %1$s.</string>
   <string name="catalogBookAvailabilityOpenAccess">This book is yours to keep.</string>

--- a/simplified-ui-neutrality/src/main/java/org/nypl/simplified/ui/neutrality/NeutralToolbar.kt
+++ b/simplified-ui-neutrality/src/main/java/org/nypl/simplified/ui/neutrality/NeutralToolbar.kt
@@ -3,6 +3,7 @@ package org.nypl.simplified.ui.neutrality
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.view.Gravity
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
@@ -47,16 +48,26 @@ class NeutralToolbar(
   }
 
   init {
+    val iconDimension = this.dpToPixelsIntegral(64)
+
     this.iconKind = ICON_IS_LOGO
     TextViewCompat.setTextAppearance(this.titleView, R.style.Neutral_ActionBarTitle)
-    this.addView(this.titleView, LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT))
-    this.addView(this.iconView, LayoutParams(this.dpToPixelsIntegral(64), this.dpToPixelsIntegral(64)))
+    this.titleView.apply {
+      layoutParams = MarginLayoutParams(
+        LayoutParams.MATCH_PARENT,
+        LayoutParams.MATCH_PARENT
+      ).apply {
+        marginStart = iconDimension
+      }
+      gravity = Gravity.CENTER
+    }
+    this.addView(this.titleView)
+    this.addView(this.iconView, LayoutParams(iconDimension, iconDimension))
     this.tag = neutralToolbarName
   }
 
   override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
     super.onLayout(changed, l, t, r, b)
-    this.titleView.x = ((this.width - this.titleView.width) / 2).toFloat()
 
     when (this.iconKind) {
       ICON_IS_NAVIGATION -> {


### PR DESCRIPTION
**What's this do?**
This PR fixes some small UI issues in both the catalog and book details screens. We are setting a margin to the start of the section title to prevent it from overlapping the back button and removing the title when the user enters the book details screen. Finally, this PR also updates the book availability text that is displayed to the user in a book details screen.

**Why are we doing this? (w/ JIRA link if applicable)**
There are some feature requests ([here](https://www.notion.so/lyrasis/Android-hange-the-sentence-This-book-is-available-for-loan-to-This-book-is-available-to-borrow--d7e321d50c144f77b3492428f5152bb7), [here](https://www.notion.so/lyrasis/Android-The-title-of-the-section-appears-at-the-top-of-the-book-detail-view-1698dfa5a25a4001ac27e1fce3d514c0)and [here](https://www.notion.so/lyrasis/Android-The-title-of-a-book-section-overlaps-the-back-arrow-2b867ac1124a488a9e3acc69d389ed65)) to fix these small issues to make the UI/UX more similar to the iOS app.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select "Palace Bookshelf" library
Go to the "Plague and Pandemic: History Perspective" section and click on "More..."
Verify [the title at the top is not overlapping the back button and is being fully displayed](https://user-images.githubusercontent.com/79104027/168242756-573c89a0-0b82-4fcc-9ecb-1e3949c34ccf.png)
Click on any book
Verify [the availability text is now "This book is available to borrow." and that the section title is not being displayed at the top of the screen](https://user-images.githubusercontent.com/79104027/168242821-76afc444-03ea-49f3-ba3c-95f8503c3ee4.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 