### PR TITLE
Show loading indicator while LCP passphrase is being retrieved

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,7 +190,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-05-13T15:39:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-05-17T15:03:53+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
@@ -198,7 +198,8 @@
         <c:change date="2022-05-13T00:00:00+00:00" summary="Removed section title from book detail screen."/>
         <c:change date="2022-05-13T00:00:00+00:00" summary="Updated displayed text when a book is available to borrow."/>
         <c:change date="2022-05-13T00:00:00+00:00" summary="Moved book format text to the Information block."/>
-        <c:change date="2022-05-13T15:39:45+00:00" summary="Upgraded Readium library in EPUB reader to version 2.2.0."/>
+        <c:change date="2022-05-13T00:00:00+00:00" summary="Upgraded Readium library in EPUB reader to version 2.2.0."/>
+        <c:change date="2022-05-17T15:03:53+00:00" summary="Added loading to book details when the passphrase is being retrieved."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLCP.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLCP.kt
@@ -59,8 +59,6 @@ class BorrowLCP private constructor() : BorrowSubtaskType {
     try {
       this.checkDRMSupport(context)
 
-      val passphrase = this.findPassphrase(context)
-
       context.taskRecorder.beginNewStep("Downloading LCP license…")
       context.bookDownloadIsRunning(
         "Downloading...",
@@ -68,6 +66,8 @@ class BorrowLCP private constructor() : BorrowSubtaskType {
         expectedSize = 100L,
         bytesPerSecond = 1L
       )
+
+      val passphrase = this.findPassphrase(context)
 
       val currentURI = context.currentURICheck()
       context.logDebug("downloading {}", currentURI)

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -286,8 +286,6 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
   }
 
   private fun configureOPDSEntry(feedEntry: FeedEntryOPDS) {
-    val context = this.requireContext()
-
     val opds = feedEntry.feedEntry
     this.title.text = opds.title
     this.authors.text = opds.authorsCommaSeparated


### PR DESCRIPTION
**What's this do?**
This PR forces the downloading status event to be sent before retrieving the book's passphrase when it's needed, so it can happen while a loading animation is displayed to the user instead of display the action buttons without any feedback

**Why are we doing this? (w/ JIRA link if applicable)**
There's a reported bug saying that while the book's passphrase is being retrieved, the user sees the "Download" and "Return" buttons instead of a loading animation, which is misleading and causes a bad UX

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select "LYRASIS Reads" library
Open any book from the "DPLA Titles" section
Click on "Get"
Confirm you get [two loading animations: one for the LCP passphrase retrieval and the other for the book itself](https://user-images.githubusercontent.com/79104027/168845393-6a67f75d-1714-403d-862c-6b9fd6f587a7.mp4)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 