### PR TITLE
Added 'More' button to the book details screen

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,7 +190,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-05-17T17:53:36+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-05-19T14:43:39+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
@@ -199,8 +199,9 @@
         <c:change date="2022-05-13T00:00:00+00:00" summary="Updated displayed text when a book is available to borrow."/>
         <c:change date="2022-05-13T00:00:00+00:00" summary="Moved book format text to the Information block."/>
         <c:change date="2022-05-13T00:00:00+00:00" summary="Upgraded Readium library in EPUB reader to version 2.2.0."/>
-        <c:change date="2022-05-17T15:03:53+00:00" summary="Added loading to book details when the passphrase is being retrieved."/>
-        <c:change date="2022-05-17T17:53:36+00:00" summary="Fixed error downloading BiblioBoard audio books."/>
+        <c:change date="2022-05-17T00:00:00+00:00" summary="Added loading to book details when the passphrase is being retrieved."/>
+        <c:change date="2022-05-17T00:00:00+00:00" summary="Fixed error downloading BiblioBoard audio books."/>
+        <c:change date="2022-05-19T14:43:39+00:00" summary="Added 'More' button to display the whole book's description in a book details screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -116,6 +116,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
   private lateinit var relatedBooksLoading: ViewGroup
   private lateinit var report: TextView
   private lateinit var screenSize: ScreenSizeInformationType
+  private lateinit var seeMore: TextView
   private lateinit var status: ViewGroup
   private lateinit var statusFailed: ViewGroup
   private lateinit var statusFailedText: TextView
@@ -182,6 +183,8 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       view.findViewById(R.id.bookDetailTitle)
     this.authors =
       view.findViewById(R.id.bookDetailAuthors)
+    this.seeMore =
+      view.findViewById(R.id.seeMoreText)
     this.status =
       view.findViewById(R.id.bookDetailStatus)
     this.summary =
@@ -302,6 +305,19 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
     } else {
       @Suppress("DEPRECATION")
       this.summary.text = Html.fromHtml(opds.summary)
+    }
+
+    this.summary.post {
+      this.seeMore.visibility = if (this.summary.lineCount > 6) {
+        this.summary.maxLines = 6
+        this.seeMore.setOnClickListener {
+          this.summary.maxLines = Integer.MAX_VALUE
+          this.seeMore.visibility = View.GONE
+        }
+        View.VISIBLE
+      } else {
+        View.GONE
+      }
     }
 
     this.configureMetadataTable(feedEntry.probableFormat, opds)

--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -151,6 +151,16 @@
       android:layout_marginBottom="16dp"
       android:text="@string/catalogPlaceholder" />
 
+    <TextView
+        android:id="@+id/seeMoreText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:textSize="12sp"
+        android:layout_gravity="end"
+        android:padding="8dp"
+        android:text="@string/catalogMore" />
+
     <View
       android:layout_width="match_parent"
       android:layout_height="1dp"


### PR DESCRIPTION
**What's this do?**
This PR adds logic to get the number of lines the book description is filling after being set and in case it's higher than 6, it sets the maximum of lines to 6 and displays a "More" button that will display the full description when it's clicked.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-There-is-no-More-button-in-the-book-detail-view-1632eebb651447ed97bbf8e0fd55afa4) to add this logic to make the app more similar to the iOS version

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select "Palace Bookshelf" library (it can be other library)
Open _Macbeth_ by William Shakespeare (it can be other book)
Verify the [book's description is not fully visible and there's a "More..." label below it](https://user-images.githubusercontent.com/79104027/169325603-5d0d1202-0022-491d-b8aa-c5ba844278f4.png)
Click on "More..."
Verify [the book's description is now fully visible](https://user-images.githubusercontent.com/79104027/169325680-f0edc74d-6e85-40e4-9ddc-8c27ffd53fbf.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 