### PR TITLE
Added support to urls in an account's support email field

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,7 +190,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-05-19T14:43:39+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-06-03T18:06:51+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
@@ -201,8 +201,9 @@
         <c:change date="2022-05-13T00:00:00+00:00" summary="Upgraded Readium library in EPUB reader to version 2.2.0."/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Added loading to book details when the passphrase is being retrieved."/>
         <c:change date="2022-05-17T00:00:00+00:00" summary="Fixed error downloading BiblioBoard audio books."/>
-        <c:change date="2022-05-18T15:55:42+00:00" summary="Added cancel download button to book details screen."/>
-        <c:change date="2022-05-19T14:43:39+00:00" summary="Added 'More' button to display the whole book's description in a book details screen."/>
+        <c:change date="2022-05-18T00:00:00+00:00" summary="Added cancel download button to book details screen."/>
+        <c:change date="2022-05-19T00:00:00+00:00" summary="Added 'More' button to display the whole book's description in a book details screen."/>
+        <c:change date="2022-06-03T18:06:51+00:00" summary="Added support to urls in an account's support email field"/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.URLUtil
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.ProgressBar
@@ -437,20 +438,30 @@ class AccountDetailFragment : Fragment(R.layout.account) {
       this.reportIssueGroup.visibility = View.VISIBLE
       this.reportIssueEmail.text = address
       this.reportIssueGroup.setOnClickListener {
-        val emailIntent =
+        val intent = if (email.contains("mailto:")) {
           Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", address, null))
-        val chosenIntent =
-          Intent.createChooser(emailIntent, this.resources.getString(R.string.accountReportIssue))
+        } else if (URLUtil.isValidUrl(address)) {
+          Intent(Intent.ACTION_VIEW, Uri.parse(address))
+        } else {
+          null
+        }
 
-        try {
-          this.startActivity(chosenIntent)
-        } catch (e: Exception) {
-          this.logger.error("unable to start activity: ", e)
-          val context = this.requireContext()
-          AlertDialog.Builder(context)
-            .setMessage(context.getString(R.string.accountReportFailed, address))
-            .create()
-            .show()
+        if (intent != null) {
+          val chosenIntent =
+            Intent.createChooser(intent, this.resources.getString(R.string.accountReportIssue))
+
+          try {
+            this.startActivity(chosenIntent)
+          } catch (e: Exception) {
+            this.logger.error("unable to start activity: ", e)
+            val context = this.requireContext()
+            AlertDialog.Builder(context)
+              .setMessage(context.getString(R.string.accountReportFailed, address))
+              .create()
+              .show()
+          }
+        } else {
+          this.reportIssueGroup.visibility = View.GONE
         }
       }
     } else {

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -427,21 +427,20 @@ class AccountDetailFragment : Fragment(R.layout.account) {
   }
 
   /**
-   * If there's a support email, enable an option to use it.
+   * If there's a support url, enable an option to use it.
    */
 
   private fun configureReportIssue() {
-    val email = this.viewModel.account.provider.supportEmail
-    if (email != null) {
-      val address = email.removePrefix("mailto:")
+    val supportUrl = this.viewModel.account.provider.supportEmail
 
+    if (supportUrl != null) {
       this.reportIssueGroup.visibility = View.VISIBLE
-      this.reportIssueEmail.text = address
+      this.reportIssueEmail.text = supportUrl.replace("mailto:", "")
       this.reportIssueGroup.setOnClickListener {
-        val intent = if (email.contains("mailto:")) {
-          Intent(Intent.ACTION_SENDTO, Uri.fromParts("mailto", address, null))
-        } else if (URLUtil.isValidUrl(address)) {
-          Intent(Intent.ACTION_VIEW, Uri.parse(address))
+        val intent = if (supportUrl.startsWith("mailto:")) {
+          Intent(Intent.ACTION_SENDTO, Uri.parse(supportUrl))
+        } else if (URLUtil.isValidUrl(supportUrl)) {
+          Intent(Intent.ACTION_VIEW, Uri.parse(supportUrl))
         } else {
           null
         }
@@ -456,7 +455,7 @@ class AccountDetailFragment : Fragment(R.layout.account) {
             this.logger.error("unable to start activity: ", e)
             val context = this.requireContext()
             AlertDialog.Builder(context)
-              .setMessage(context.getString(R.string.accountReportFailed, address))
+              .setMessage(context.getString(R.string.accountReportFailed, supportUrl))
               .create()
               .show()
           }

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -271,7 +271,6 @@
                 android:layout_marginTop="16dp"
                 android:layout_marginEnd="16dp"
                 android:layout_marginBottom="16dp"
-                android:background="?android:attr/selectableItemBackground"
                 android:text="@string/accountReportIssue"
                 app:layout_constraintBottom_toTopOf="@id/accountReportIssueEmail"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
   <string name="accountSAML20NoPatronInfo">Failed to retrieve patron info from the URI: %1$s</string>
   <string name="accountSearchHint">Search accounts&#8230;</string>
   <string name="accountMore">More options</string>
-  <string name="accountReportFailed">Sorry, we weren\'t able to find a usable app to deal with this address. Please send email to %1$s if you need to report an issue.</string>
+  <string name="accountReportFailed">Sorry, we weren\'t able to find a usable app to contact support. Please send email to %1$s if you need to report an issue.</string>
   <string name="accountPrivacyPolicy">Privacy Policy</string>
   <string name="accountLicenses">Content Licenses</string>
   <string name="accountEULA">End User License Agreement</string>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
   <string name="accountSAML20NoPatronInfo">Failed to retrieve patron info from the URI: %1$s</string>
   <string name="accountSearchHint">Search accounts&#8230;</string>
   <string name="accountMore">More options</string>
-  <string name="accountReportFailed">Sorry, we weren\'t able to find a usable email app. Please send email to %1$s if you need to report an issue.</string>
+  <string name="accountReportFailed">Sorry, we weren\'t able to find a usable app to deal with this address. Please send email to %1$s if you need to report an issue.</string>
   <string name="accountPrivacyPolicy">Privacy Policy</string>
   <string name="accountLicenses">Content Licenses</string>
   <string name="accountEULA">End User License Agreement</string>


### PR DESCRIPTION
**What's this do?**
This PR adds logic to properly handle an url if an account's support email comes in that format instead of a regular email. If it's an url, a browser should be opened with the given link. If it's an email address, the behavior remains as it is. This also updates the text to display in case there's no installed browser on the user's phone.

**Why are we doing this? (w/ JIRA link if applicable)**
There are some libraries that may set an url as a support email, as stated [here](https://www.notion.so/lyrasis/Android-Change-support-email-field-to-support-URLs-d2050a378112466e9c9025d9feecaad2), and the apps should adapt to that.

**How should this be tested? / Do these changes have associated tests?**
For now, as far as I know, there are no libraries with an url as a support email, so I forced them to show a real url and [recorded the behavior](https://user-images.githubusercontent.com/79104027/171922517-1ba8e5df-e36d-46a0-b7b9-cca32e40878e.mp4)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Locally tested by @nunommts 