### PR TITLE
Added 'Cancel' option to library selection dialog.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,7 +190,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-06-30T13:44:20+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-07-15T17:26:47+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
@@ -207,7 +207,8 @@
         <c:change date="2022-06-10T00:00:00+00:00" summary="Fixed error playing audio books after switching libraries."/>
         <c:change date="2022-06-15T00:00:00+00:00" summary="Fixed cropping of non-square audio book covers in the player."/>
         <c:change date="2022-06-29T00:00:00+00:00" summary="Added new PDF reader implementation that can be optionally enabled."/>
-        <c:change date="2022-06-30T13:44:20+00:00" summary="Added bookmarks to audiobooks"/>
+        <c:change date="2022-06-30T00:00:00+00:00" summary="Added bookmarks to audiobooks."/>
+        <c:change date="2022-07-15T17:26:47+00:00" summary="Added 'Cancel' option to library selection dialog."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountPickerDialogFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountPickerDialogFragment.kt
@@ -113,6 +113,10 @@ class AccountPickerDialogFragment : BottomSheetDialogFragment(), OnAccountClickL
     this.listener.post(AccountPickerEvent.AddAccount)
     dismiss()
   }
+
+  override fun onCancelClick() {
+    dismiss()
+  }
 }
 
 class AccountPickerViewHolder(
@@ -154,7 +158,7 @@ class AccountPickerViewHolder(
   }
 }
 
-class FooterViewHolder(
+class AddAccountViewHolder(
   view: View,
   private val listener: OnAccountClickListener
 ) : RecyclerView.ViewHolder(view) {
@@ -174,6 +178,24 @@ class FooterViewHolder(
   }
 }
 
+class CancelViewHolder(
+  view: View,
+  private val listener: OnAccountClickListener
+) : RecyclerView.ViewHolder(view) {
+
+  init {
+    val titleView: TextView = view.findViewById(R.id.accountTitle)
+    titleView.setText(R.string.accountCancel)
+
+    val iconView: ImageView = view.findViewById(R.id.accountIcon)
+    iconView.visibility = View.GONE
+
+    view.setOnClickListener {
+      listener.onCancelClick()
+    }
+  }
+}
+
 class AccountPickerAdapter(
   private val accounts: List<AccountType>,
   private val currentId: AccountID,
@@ -184,26 +206,33 @@ class AccountPickerAdapter(
 
   companion object {
     private const val LIST_ITEM = 1
-    private const val LIST_FOOTER = 2
+    private const val LIST_ADD_ACCOUNT = 2
+    private const val LIST_CANCEL = 3
   }
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
     val inflater = LayoutInflater.from(parent.context)
     val view = inflater.inflate(R.layout.account_picker_item, parent, false)
     return when (viewType) {
-      LIST_FOOTER -> FooterViewHolder(view, listener)
+      LIST_CANCEL -> CancelViewHolder(view, listener)
+      LIST_ADD_ACCOUNT -> AddAccountViewHolder(view, listener)
       else -> AccountPickerViewHolder(view, imageLoader, listener)
     }
   }
 
-  override fun getItemCount() = if (showAddAccount) {
-    accounts.size + 1 // Show the 'add account' footer
+  override fun getItemCount() = accounts.size + if (showAddAccount) {
+    2 // Show the 'add account' and 'cancel' options
   } else {
-    accounts.size
+    1 // Show 'cancel' option
   }
 
   override fun getItemViewType(position: Int) = when (position) {
-    accounts.size -> LIST_FOOTER
+    accounts.size + 1 -> LIST_CANCEL
+    accounts.size -> if (showAddAccount) {
+      LIST_ADD_ACCOUNT
+    } else {
+      LIST_CANCEL
+    }
     else -> LIST_ITEM
   }
 
@@ -219,5 +248,6 @@ class AccountPickerAdapter(
   interface OnAccountClickListener {
     fun onAccountClick(account: AccountType)
     fun onAddAccountClick()
+    fun onCancelClick()
   }
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountPickerDialogFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountPickerDialogFragment.kt
@@ -228,11 +228,12 @@ class AccountPickerAdapter(
 
   override fun getItemViewType(position: Int) = when (position) {
     accounts.size + 1 -> LIST_CANCEL
-    accounts.size -> if (showAddAccount) {
-      LIST_ADD_ACCOUNT
-    } else {
-      LIST_CANCEL
-    }
+    accounts.size ->
+      if (showAddAccount) {
+        LIST_ADD_ACCOUNT
+      } else {
+        LIST_CANCEL
+      }
     else -> LIST_ITEM
   }
 


### PR DESCRIPTION
**What's this do?**
This PR adds a "Cancel" option to the library selection dialog

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=7669bb698f0b4f7486211f75d6170b17&p=157fa0c2bdac427292d6e74ce240dd98) to make this change so it gets similar to the iOS version of the app

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Click on the logo on the top left corner
Verify [there's a "Cancel" option at the bottom of the dialog](https://user-images.githubusercontent.com/79104027/179277576-5ce07e5e-357a-4c36-9ccb-1bc614b19a87.png)
Click on it and verify the dialog closes

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 