### PR TITLE
Added playbackRates to profile preferences

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,7 +190,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-15T17:26:47+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-07-19T10:44:07+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
@@ -209,7 +209,8 @@
         <c:change date="2022-06-29T00:00:00+00:00" summary="Added new PDF reader implementation that can be optionally enabled."/>
         <c:change date="2022-06-30T00:00:00+00:00" summary="Added bookmarks to audiobooks."/>
         <c:change date="2022-07-12T00:00:00+00:00" summary="Added dialog with the loan limit message instead of displaying it as an error with options."/>
-        <c:change date="2022-07-15T17:26:47+00:00" summary="Added 'Cancel' option to library selection dialog."/>
+        <c:change date="2022-07-15T00:00:00+00:00" summary="Added 'Cancel' option to library selection dialog."/>
+        <c:change date="2022-07-19T10:44:07+00:00" summary="Added playbackRates to profile preferences so the user can save all audiobook's current playback rates."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
+++ b/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
@@ -1,5 +1,6 @@
 package org.nypl.simplified.profiles.api
 
+import org.librarysimplified.audiobook.api.PlayerPlaybackRate
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.reader.api.ReaderPreferences
 
@@ -32,6 +33,10 @@ data class ProfilePreferences(
   /** @return The reader-specific preferences */
 
   val readerPreferences: ReaderPreferences,
+
+  /** @return The playback rates for every audiobook */
+
+  val playbackRates: Map<String, PlayerPlaybackRate>,
 
   /** The most recently used account provider. */
 

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
@@ -499,7 +499,8 @@ object ProfilesDatabases {
               showTestingLibraries = false,
               readerPreferences = ReaderPreferences.builder().build(),
               mostRecentAccount = account.id,
-              hasSeenLibrarySelectionScreen = false
+              hasSeenLibrarySelectionScreen = false,
+              playbackRates = hashMapOf()
             ),
             attributes = ProfileAttributes(sortedMapOf())
           )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
@@ -52,7 +52,8 @@ class ProfileDescriptionJSONTest {
           showTestingLibraries = false,
           hasSeenLibrarySelectionScreen = false,
           readerPreferences = ReaderPreferences.builder().build(),
-          mostRecentAccount = AccountID.generate()
+          mostRecentAccount = AccountID.generate(),
+          playbackRates = hashMapOf()
         ),
         attributes = ProfileAttributes(
           sortedMapOf(
@@ -142,6 +143,24 @@ class ProfileDescriptionJSONTest {
     assertEquals(ReaderFontSelection.READER_FONT_OPEN_DYSLEXIC, description.preferences.readerPreferences.fontFamily())
     assertEquals(ReaderColorScheme.SCHEME_WHITE_ON_BLACK, description.preferences.readerPreferences.colorScheme())
     assertEquals("5310437f-db1a-492e-a09f-1ceaa43303dd", description.preferences.mostRecentAccount.uuid.toString())
+  }
+
+  @Test
+  fun testPlaybackRates() {
+    val mapper = ObjectMapper()
+    val mostRecentAccountFallback = AccountID.generate()
+    val description =
+      ProfileDescriptionJSON.deserializeFromText(
+        mapper,
+        this.ofResource("profile-rates.json"),
+        mostRecentAccountFallback
+      )
+
+    assertEquals(2, description.preferences.playbackRates.size)
+    assertEquals("bookid1", description.preferences.playbackRates.keys.first())
+    assertEquals("bookid2", description.preferences.playbackRates.keys.last())
+    assertEquals(1.0, description.preferences.playbackRates["bookid1"]?.speed)
+    assertEquals(1.25, description.preferences.playbackRates["bookid2"]?.speed)
   }
 
   /**

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
@@ -138,6 +138,7 @@ class ProfileDescriptionJSONTest {
       )
 
     assertEquals("", description.displayName)
+    assertEquals(0, description.preferences.playbackRates.size)
     assertEquals(1.0, description.preferences.readerPreferences.brightness())
     assertEquals(100.0, description.preferences.readerPreferences.fontScale())
     assertEquals(ReaderFontSelection.READER_FONT_OPEN_DYSLEXIC, description.preferences.readerPreferences.fontFamily())

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
@@ -34,7 +34,8 @@ class MockProfile(
         showTestingLibraries = false,
         hasSeenLibrarySelectionScreen = false,
         readerPreferences = ReaderPreferences.builder().build(),
-        mostRecentAccount = this.accounts.firstKey()
+        mostRecentAccount = this.accounts.firstKey(),
+        playbackRates = hashMapOf()
       ),
       attributes = ProfileAttributes(sortedMapOf())
     )

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-rates.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-rates.json
@@ -12,7 +12,10 @@
       "font_family" : "READER_FONT_OPEN_DYSLEXIC",
       "color_scheme" : "SCHEME_WHITE_ON_BLACK"
     },
-    "playbackRates" : "{\"bookid1\": \"NORMAL_TIME\", \"bookid2\": \"ONE_AND_A_QUARTER_TIME\"}",
+    "playbackRates" : {
+      "bookid1" : "NORMAL_TIME",
+      "bookid2" : "ONE_AND_A_QUARTER_TIME"
+    },
     "dateOfBirth" : {
       "date" : "2006-08-07",
       "isSynthesized" : true

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-rates.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-rates.json
@@ -1,0 +1,22 @@
+{
+  "@version" : 20200504,
+  "displayName" : "",
+  "preferences" : {
+    "showTestingLibraries" : true,
+    "hasSeenLibrarySelectionScreen" : true,
+    "useExperimentalR2" : true,
+    "showDebugSettings" : true,
+    "mostRecentAccount" : "5310437f-db1a-492e-a09f-1ceaa43303dd",
+    "readerPreferences" : {
+      "font_scale" : 100.0,
+      "font_family" : "READER_FONT_OPEN_DYSLEXIC",
+      "color_scheme" : "SCHEME_WHITE_ON_BLACK"
+    },
+    "playbackRates" : "{\"bookid1\": \"NORMAL_TIME\", \"bookid2\": \"ONE_AND_A_QUARTER_TIME\"}",
+    "dateOfBirth" : {
+      "date" : "2006-08-07",
+      "isSynthesized" : true
+    }
+  },
+  "attributes" : { }
+}


### PR DESCRIPTION
**What's this do?**
This PR adds a field called _playbackRates_ to the profile preferences so the user can save all of their audiobook's playback rates. When listening to an audiobook, a new entry is added to that new field with the BookID and the playback rate so it can be restored when reopening that same audiobook

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=7669bb698f0b4f7486211f75d6170b17&p=0f3ab653edd54965bc9f9280702eea47) that says the audiobook's playback rate is not saved when the user closes the book and they need to set it again when reopening the book.

**How should this be tested? / Do these changes have associated tests?**
_This can only be tested when [this PR](https://github.com/ThePalaceProject/android-audiobook/pull/33) is merged_

Open the Palace app
Open any audiobook
Change the playback rate to a different value
Close the audiobook
Reopen the audiobook and verify the rate is the you previously select

**Dependencies for merging? Releasing to production?**
This PR will only work and can only be tested after [this PR](https://github.com/ThePalaceProject/android-audiobook/pull/33) is merged. For this to be fully completed, i.e., for the audiobooks to restore the saved rates, [this PR](https://github.com/ThePalaceProject/android-drm-audioengine/pull/9) needs to be merged too.

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 