### PR TITLE
Fixed account name not being fully displayed on account details screen.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,7 +190,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-27T10:07:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-07-28T17:40:57+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
@@ -212,7 +212,8 @@
         <c:change date="2022-07-15T00:00:00+00:00" summary="Added 'Cancel' option to library selection dialog."/>
         <c:change date="2022-07-19T00:00:00+00:00" summary="Added playbackRates to profile preferences so the user can save all audiobook's current playback rates."/>
         <c:change date="2022-07-22T00:00:00+00:00" summary="Added 'Cancel' option to player settings dialogs."/>
-        <c:change date="2022-07-27T10:07:06+00:00" summary="Fixed failing builds on CI."/>
+        <c:change date="2022-07-27T00:00:00+00:00" summary="Fixed failing builds on CI."/>
+        <c:change date="2022-07-28T17:40:57+00:00" summary="Fixed account name not being fully displayed on account details screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-accounts/src/main/res/layout/account_cell.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_cell.xml
@@ -2,7 +2,8 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
-  android:layout_height="112dp">
+  android:layout_height="wrap_content"
+  android:minHeight="112dp">
 
   <ImageView
     android:id="@+id/accountCellIcon"
@@ -23,8 +24,6 @@
     android:layout_marginStart="16dp"
     android:layout_marginTop="16dp"
     android:layout_marginEnd="16dp"
-    android:ellipsize="end"
-    android:maxLines="1"
     android:text="@string/accountPlaceholder"
     android:textStyle="bold"
     app:layout_constraintEnd_toEndOf="parent"
@@ -39,8 +38,6 @@
     android:layout_marginTop="8dp"
     android:layout_marginEnd="16dp"
     android:layout_marginBottom="16dp"
-    android:ellipsize="end"
-    android:maxLines="2"
     android:text="@string/accountPlaceholder"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
**What's this do?**
This PR removes the line limit for both account title and subtitle on the account details screen.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket](https://www.notion.so/lyrasis/Android-Library-name-does-not-wrap-on-the-Account-page-in-app-f192d27905fb4cc991fd45dcab46f15f) with a bug saying that on the account details screen when an account has a large name it's not being fully displayed.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Go to Hopkinsville Christian County Public Library
Go to their account page
Verify [the account name is being fully displayed](https://user-images.githubusercontent.com/79104027/181605438-18d94b85-7527-47da-9cf2-bca9a8872212.png)

**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 