### PR TITLE
Fixed audiobook bookmarks not being saved after exiting the player.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,7 +190,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-07-29T15:13:53+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-08-03T10:15:04+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
@@ -213,8 +213,9 @@
         <c:change date="2022-07-19T00:00:00+00:00" summary="Added playbackRates to profile preferences so the user can save all audiobook's current playback rates."/>
         <c:change date="2022-07-22T00:00:00+00:00" summary="Added 'Cancel' option to player settings dialogs."/>
         <c:change date="2022-07-27T00:00:00+00:00" summary="Fixed failing builds on CI."/>
-        <c:change date="2022-07-28T17:40:57+00:00" summary="Fixed account name not being fully displayed on account details screen."/>
-        <c:change date="2022-07-29T15:13:53+00:00" summary="Added option to reset patron's password on account details screen."/>
+        <c:change date="2022-07-28T00:00:00+00:00" summary="Fixed account name not being fully displayed on account details screen."/>
+        <c:change date="2022-07-29T00:00:00+00:00" summary="Added option to reset patron's password on account details screen."/>
+        <c:change date="2022-08-03T10:15:04+00:00" summary="Fixed audiobook bookmarks not being saved after exiting the player."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-bookmarks-api/src/main/java/org/nypl/simplified/bookmarks/api/BookmarkServiceUsableType.kt
+++ b/simplified-bookmarks-api/src/main/java/org/nypl/simplified/bookmarks/api/BookmarkServiceUsableType.kt
@@ -61,10 +61,19 @@ interface BookmarkServiceUsableType {
   ): FluentFuture<Bookmarks>
 
   /**
-   * The user has created a bookmark.
+   * Create a local bookmark.
    */
 
-  fun bookmarkCreate(
+  fun bookmarkCreateLocal(
+    accountID: AccountID,
+    bookmark: Bookmark
+  ): FluentFuture<Unit>
+
+  /**
+   * Create a remote bookmark.
+   */
+
+  fun bookmarkCreateRemote(
     accountID: AccountID,
     bookmark: Bookmark
   ): FluentFuture<Unit>

--- a/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BService.kt
+++ b/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BService.kt
@@ -315,17 +315,38 @@ class BService(
     }
   }
 
-  override fun bookmarkCreate(
+  override fun bookmarkCreateLocal(
     accountID: AccountID,
     bookmark: Bookmark
   ): FluentFuture<Unit> {
     return try {
       FluentFuture.from(
         this.executor.submit(
-          BServiceOpCreateBookmark(
+          BServiceOpCreateLocalBookmark(
+            logger = this.logger,
+            bookmarkEventsOut = this.bookmarkEventsOut,
+            profile = profilesController.profileCurrent(),
+            accountID = accountID,
+            bookmark = bookmark
+          )
+        )
+      )
+    } catch (e: ProfileNoneCurrentException) {
+      this.logger.error("bookmarkCreateLocal: no profile is current: ", e)
+      FluentFuture.from(Futures.immediateFailedFuture(e))
+    }
+  }
+
+  override fun bookmarkCreateRemote(
+    accountID: AccountID,
+    bookmark: Bookmark
+  ): FluentFuture<Unit> {
+    return try {
+      FluentFuture.from(
+        this.executor.submit(
+          BServiceOpCreateRemoteBookmark(
             logger = this.logger,
             objectMapper = this.objectMapper,
-            bookmarkEventsOut = this.bookmarkEventsOut,
             httpCalls = this.httpCalls,
             profile = profilesController.profileCurrent(),
             accountID = accountID,
@@ -334,7 +355,7 @@ class BService(
         )
       )
     } catch (e: ProfileNoneCurrentException) {
-      this.logger.error("bookmarkLoad: no profile is current: ", e)
+      this.logger.error("bookmarkCreateRemote: no profile is current: ", e)
       FluentFuture.from(Futures.immediateFailedFuture(e))
     }
   }

--- a/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BServiceOpCreateLocalBookmark.kt
+++ b/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BServiceOpCreateLocalBookmark.kt
@@ -1,11 +1,8 @@
 package org.nypl.simplified.bookmarks.internal
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.reactivex.subjects.Subject
 import org.nypl.simplified.accounts.api.AccountID
-import org.nypl.simplified.bookmarks.api.BookmarkAnnotations
 import org.nypl.simplified.bookmarks.api.BookmarkEvent
-import org.nypl.simplified.bookmarks.api.BookmarkHTTPCallsType
 import org.nypl.simplified.books.api.bookmark.Bookmark
 import org.nypl.simplified.books.api.bookmark.BookmarkKind
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle
@@ -17,11 +14,9 @@ import org.slf4j.Logger
  * An operation that handles user-created bookmarks.
  */
 
-internal class BServiceOpCreateBookmark(
+internal class BServiceOpCreateLocalBookmark(
   logger: Logger,
-  private val objectMapper: ObjectMapper,
   private val bookmarkEventsOut: Subject<BookmarkEvent>,
-  private val httpCalls: BookmarkHTTPCallsType,
   private val profile: ProfileReadableType,
   private val accountID: AccountID,
   private val bookmark: Bookmark
@@ -29,44 +24,6 @@ internal class BServiceOpCreateBookmark(
 
   override fun runActual() {
     this.locallySaveBookmark()
-    this.remotelySendBookmark()
-  }
-
-  private fun remotelySendBookmark() {
-    try {
-      this.logger.debug(
-        "[{}]: remote sending bookmark {}",
-        this.profile.id.uuid,
-        this.bookmark.bookmarkId.value
-      )
-
-      val syncInfo = BSyncableAccount.ofAccount(this.profile.account(this.accountID))
-      if (syncInfo == null) {
-        this.logger.debug(
-          "[{}]: cannot remotely send bookmark {} because the account is not syncable",
-          this.profile.id.uuid,
-          this.bookmark.bookmarkId.value
-        )
-        return
-      }
-
-      val bookmarkAnnotation = when (this.bookmark) {
-        is Bookmark.ReaderBookmark ->
-          BookmarkAnnotations.fromReaderBookmark(this.objectMapper, this.bookmark)
-        is Bookmark.AudiobookBookmark ->
-          BookmarkAnnotations.fromAudiobookBookmark(this.objectMapper, this.bookmark)
-        else ->
-          throw IllegalStateException("Unsupported bookmark type: $bookmark")
-      }
-
-      this.httpCalls.bookmarkAdd(
-        annotationsURI = syncInfo.annotationsURI,
-        credentials = syncInfo.credentials,
-        bookmark = bookmarkAnnotation
-      )
-    } catch (e: Exception) {
-      this.logger.error("error sending bookmark: ", e)
-    }
   }
 
   private fun locallySaveBookmark() {

--- a/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BServiceOpCreateRemoteBookmark.kt
+++ b/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BServiceOpCreateRemoteBookmark.kt
@@ -1,0 +1,64 @@
+package org.nypl.simplified.bookmarks.internal
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.nypl.simplified.accounts.api.AccountID
+import org.nypl.simplified.bookmarks.api.BookmarkAnnotations
+import org.nypl.simplified.bookmarks.api.BookmarkHTTPCallsType
+import org.nypl.simplified.books.api.bookmark.Bookmark
+import org.nypl.simplified.profiles.api.ProfileReadableType
+import org.slf4j.Logger
+
+/**
+ * An operation that handles user-created bookmarks.
+ */
+
+internal class BServiceOpCreateRemoteBookmark(
+  logger: Logger,
+  private val objectMapper: ObjectMapper,
+  private val httpCalls: BookmarkHTTPCallsType,
+  private val profile: ProfileReadableType,
+  private val accountID: AccountID,
+  private val bookmark: Bookmark
+) : BServiceOp<Unit>(logger) {
+
+  override fun runActual() {
+    this.remotelySendBookmark()
+  }
+
+  private fun remotelySendBookmark() {
+    try {
+      this.logger.debug(
+        "[{}]: remote sending bookmark {}",
+        this.profile.id.uuid,
+        this.bookmark.bookmarkId.value
+      )
+
+      val syncInfo = BSyncableAccount.ofAccount(this.profile.account(this.accountID))
+      if (syncInfo == null) {
+        this.logger.debug(
+          "[{}]: cannot remotely send bookmark {} because the account is not syncable",
+          this.profile.id.uuid,
+          this.bookmark.bookmarkId.value
+        )
+        return
+      }
+
+      val bookmarkAnnotation = when (this.bookmark) {
+        is Bookmark.ReaderBookmark ->
+          BookmarkAnnotations.fromReaderBookmark(this.objectMapper, this.bookmark)
+        is Bookmark.AudiobookBookmark ->
+          BookmarkAnnotations.fromAudiobookBookmark(this.objectMapper, this.bookmark)
+        else ->
+          throw IllegalStateException("Unsupported bookmark type: $bookmark")
+      }
+
+      this.httpCalls.bookmarkAdd(
+        annotationsURI = syncInfo.annotationsURI,
+        credentials = syncInfo.credentials,
+        bookmark = bookmarkAnnotation
+      )
+    } catch (e: Exception) {
+      this.logger.error("error sending bookmark: ", e)
+    }
+  }
+}

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainServices.kt
@@ -402,24 +402,6 @@ internal object MainServices {
     return ProfileIdleTimer.create(execProfileTimer, profileEvents)
   }
 
-//  private fun createReaderBookmarksService(
-//    http: LSHTTPClientType,
-//    bookController: ProfilesControllerType
-//  ): ReaderBookmarkServiceType {
-//    val threadFactory: (Runnable) -> Thread = { runnable ->
-//      NamedThreadPools.namedThreadPoolFactory("reader-bookmarks", 19).newThread(runnable)
-//    }
-//
-//    return BookmarkService.createService(
-//      BookmarkServiceProviderType.Requirements(
-//        threads = threadFactory,
-//        events = PublishSubject.create(),
-//        httpCalls = BHTTPCalls(ObjectMapper(), http),
-//        profilesController = bookController
-//      )
-//    )
-//  }
-
   private fun createBookmarksService(
     http: LSHTTPClientType,
     bookController: ProfilesControllerType

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/NullBookmarkService.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/NullBookmarkService.kt
@@ -46,7 +46,11 @@ class NullBookmarkService(
     return FluentFuture.from(Futures.immediateFuture(BookmarkSyncEnableResult.SYNC_ENABLE_NOT_SUPPORTED))
   }
 
-  override fun bookmarkCreate(accountID: AccountID, bookmark: Bookmark): FluentFuture<Unit> {
+  override fun bookmarkCreateLocal(accountID: AccountID, bookmark: Bookmark): FluentFuture<Unit> {
+    return FluentFuture.from(Futures.immediateFuture(Unit))
+  }
+
+  override fun bookmarkCreateRemote(accountID: AccountID, bookmark: Bookmark): FluentFuture<Unit> {
     return FluentFuture.from(Futures.immediateFuture(Unit))
   }
 

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
@@ -336,7 +336,12 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
             source = event.bookmark
           )
 
-        this.bookmarkService.bookmarkCreate(
+        this.bookmarkService.bookmarkCreateLocal(
+          accountID = this.parameters.accountId,
+          bookmark = bookmark
+        )
+
+        this.bookmarkService.bookmarkCreateRemote(
           accountID = this.parameters.accountId,
           bookmark = bookmark
         )


### PR DESCRIPTION
**What's this do?**
This PR divides the bookmark saving concept into two different ways: local and remote. By doing that, we can exit the player screen and just save the bookmark remotely because now it'll be locally saved every second (implemented on [this PR](https://github.com/ThePalaceProject/android-audiobook/pull/38)).

**Why are we doing this? (w/ JIRA link if applicable)**
There's [a ticket with a bug](https://www.notion.so/lyrasis/Android-Last-reading-position-is-not-saved-after-reopening-the-audiobook-from-Biblioboard-or-Palac-b1ea2ca76af54449aa05b22f5d598f88) saying that some audiobooks are not storing the last position after exiting the player screen.

**How should this be tested? / Do these changes have associated tests?**
_Note: The PR can only be tested when [this PR](https://github.com/ThePalaceProject/android-audiobook/pull/38) is merged_

Open the Palace app
Select "LYRASIS Reads"
Open the "Daykeeper" audiobook
Wait for the bookmark saving animation to happen and listen to the audiobook for about two more seconds
Return to the previous screen and back to the audiobook
Verify the UI is displaying the last position you listened to

**Dependencies for merging? Releasing to production?**
This PR depends on [this PR](https://github.com/ThePalaceProject/android-audiobook/pull/38)

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts