### PR TITLE
Fix broken state after returning a book.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,7 +190,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-03T10:15:04+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-08-05T08:51:13+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
@@ -215,7 +215,8 @@
         <c:change date="2022-07-27T00:00:00+00:00" summary="Fixed failing builds on CI."/>
         <c:change date="2022-07-28T00:00:00+00:00" summary="Fixed account name not being fully displayed on account details screen."/>
         <c:change date="2022-07-29T00:00:00+00:00" summary="Added option to reset patron's password on account details screen."/>
-        <c:change date="2022-08-03T10:15:04+00:00" summary="Fixed audiobook bookmarks not being saved after exiting the player."/>
+        <c:change date="2022-08-03T00:00:00+00:00" summary="Fixed audiobook bookmarks not being saved after exiting the player."/>
+        <c:change date="2022-08-05T08:51:13+00:00" summary="Fix broken state after returning a book."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-controller-api/src/main/java/org/nypl/simplified/books/controller/api/BooksControllerType.kt
+++ b/simplified-books-controller-api/src/main/java/org/nypl/simplified/books/controller/api/BooksControllerType.kt
@@ -82,11 +82,13 @@ interface BooksControllerType {
    *
    * @param accountID The account
    * @param bookId The ID of the book
+   * @param onNewBookEntry The action to perform after receiving a new feed entry
    */
 
   fun bookRevoke(
     accountID: AccountID,
-    bookId: BookID
+    bookId: BookID,
+    onNewBookEntry: (FeedEntry.FeedEntryOPDS) -> Unit = { }
   ): FluentFuture<TaskResult<Unit>>
 
   /**

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookRevokeTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookRevokeTask.kt
@@ -25,7 +25,6 @@ import org.nypl.simplified.books.controller.api.BookRevokeExceptionDeviceNotActi
 import org.nypl.simplified.books.controller.api.BookRevokeExceptionNotRevocable
 import org.nypl.simplified.books.controller.api.BookRevokeStringResourcesType
 import org.nypl.simplified.feeds.api.Feed
-import org.nypl.simplified.feeds.api.FeedEntry
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryCorrupt
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryOPDS
 import org.nypl.simplified.feeds.api.FeedHTTPTransportException
@@ -63,7 +62,7 @@ class BookRevokeTask(
   private val bookID: BookID,
   private val bookRegistry: BookRegistryType,
   private val feedLoader: FeedLoaderType,
-  private val onNewBookEntry: (FeedEntry.FeedEntryOPDS) -> Unit,
+  private val onNewBookEntry: (FeedEntryOPDS) -> Unit = {},
   private val revokeStrings: BookRevokeStringResourcesType,
   private val revokeACSTimeoutDuration: Duration = Duration.standardMinutes(1L),
   private val revokeServerTimeoutDuration: Duration = Duration.standardMinutes(3L)

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookRevokeTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/BookRevokeTask.kt
@@ -25,6 +25,7 @@ import org.nypl.simplified.books.controller.api.BookRevokeExceptionDeviceNotActi
 import org.nypl.simplified.books.controller.api.BookRevokeExceptionNotRevocable
 import org.nypl.simplified.books.controller.api.BookRevokeStringResourcesType
 import org.nypl.simplified.feeds.api.Feed
+import org.nypl.simplified.feeds.api.FeedEntry
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryCorrupt
 import org.nypl.simplified.feeds.api.FeedEntry.FeedEntryOPDS
 import org.nypl.simplified.feeds.api.FeedHTTPTransportException
@@ -62,6 +63,7 @@ class BookRevokeTask(
   private val bookID: BookID,
   private val bookRegistry: BookRegistryType,
   private val feedLoader: FeedLoaderType,
+  private val onNewBookEntry: (FeedEntry.FeedEntryOPDS) -> Unit,
   private val revokeStrings: BookRevokeStringResourcesType,
   private val revokeACSTimeoutDuration: Duration = Duration.standardMinutes(1L),
   private val revokeServerTimeoutDuration: Duration = Duration.standardMinutes(3L)
@@ -231,6 +233,7 @@ class BookRevokeTask(
     }
 
     this.revokeNotifyServerSaveNewEntry(newEntry)
+    this.onNewBookEntry(newEntry)
   }
 
   private fun feedEntryWithAvailability(

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/Controller.kt
@@ -619,7 +619,8 @@ class Controller private constructor(
 
   override fun bookRevoke(
     accountID: AccountID,
-    bookId: BookID
+    bookId: BookID,
+    onNewBookEntry: (FeedEntry.FeedEntryOPDS) -> Unit
   ): FluentFuture<TaskResult<Unit>> {
     this.publishRequestingDelete(bookId)
     return this.submitTask(
@@ -631,6 +632,7 @@ class Controller private constructor(
         bookID = bookId,
         bookRegistry = this.bookRegistry,
         feedLoader = this.feedLoader,
+        onNewBookEntry = onNewBookEntry,
         revokeStrings = this.revokeStrings
       )
     )

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
@@ -76,6 +76,8 @@ class CatalogBookDetailViewModel(
 
   private lateinit var feedArguments: CatalogFeedArguments.CatalogFeedArgumentsRemote
 
+  private var feedEntry = parameters.feedEntry
+
   private val bookWithStatusMutable: MutableLiveData<BookWithStatus> =
     MutableLiveData(this.createBookWithStatus())
 
@@ -125,7 +127,7 @@ class CatalogBookDetailViewModel(
       account = item.accountID,
       cover = null,
       thumbnail = null,
-      entry = item.feedEntry,
+      entry = feedEntry.feedEntry,
       formats = listOf()
     )
     val status = BookStatus.fromBook(book)
@@ -570,7 +572,10 @@ class CatalogBookDetailViewModel(
   fun revokeMaybeAuthenticated() {
     this.openLoginDialogIfNecessary()
     this.borrowViewModel.tryRevokeMaybeAuthenticated(
-      this.bookWithStatus.book
+      book = this.bookWithStatus.book,
+      onNewBookEntry = { newBookEntry ->
+        feedEntry = newBookEntry
+      }
     )
   }
 

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBorrowViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBorrowViewModel.kt
@@ -17,6 +17,7 @@ import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.books.book_registry.BookStatus
 import org.nypl.simplified.books.book_registry.BookWithStatus
 import org.nypl.simplified.books.controller.api.BooksControllerType
+import org.nypl.simplified.feeds.api.FeedEntry
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
@@ -164,7 +165,8 @@ class CatalogBorrowViewModel(
    */
 
   fun tryRevokeMaybeAuthenticated(
-    book: Book
+    book: Book,
+    onNewBookEntry: (FeedEntry.FeedEntryOPDS) -> Unit = {}
   ) {
     this.bookRegistry.updateIfStatusIsMoreImportant(
       BookWithStatus(
@@ -173,7 +175,7 @@ class CatalogBorrowViewModel(
     )
 
     if (!this.isLoginRequired(book.account)) {
-      return this.tryRevokeAuthenticated(book)
+      return this.tryRevokeAuthenticated(book, onNewBookEntry)
     }
 
     this.executeAfterLogin(
@@ -181,7 +183,7 @@ class CatalogBorrowViewModel(
       bookID = book.id,
       runOnSuccess = {
         if (!this.isLoginRequired(book.account)) {
-          this.tryRevokeAuthenticated(book)
+          this.tryRevokeAuthenticated(book, onNewBookEntry)
         } else {
           this.onRevokeAttemptCancelled(book)
         }
@@ -244,12 +246,14 @@ class CatalogBorrowViewModel(
   }
 
   private fun tryRevokeAuthenticated(
-    book: Book
+    book: Book,
+    onNewBookEntry: (FeedEntry.FeedEntryOPDS) -> Unit
   ) {
     this.logger.debug("revoking: {}", book.id)
     this.booksController.bookRevoke(
       accountID = book.account,
-      bookId = book.id
+      bookId = book.id,
+      onNewBookEntry = onNewBookEntry
     )
   }
 


### PR DESCRIPTION
**What's this do?**
This PR changes the way the CatalogBookViewModel recreates a "book with a status" after returning it. Instead of using the _feedEntry_ from the initial parameters, now it uses an updated feed entry that's retrieved after returning the book.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/There-s-an-error-trying-to-get-a-book-after-returning-it-from-My-Books-tab-370a14f9163d483885d7da4d987d40a3) explaining and showing how this bug is happening and it should be fixed so the user can get the book again directly from its details screen on the"My Books" tab instead of having to go to the catalog to retrieve it again.

**How should this be tested? / Do these changes have associated tests?**
You can follow the steps described in the [ticket](https://www.notion.so/lyrasis/There-s-an-error-trying-to-get-a-book-after-returning-it-from-My-Books-tab-370a14f9163d483885d7da4d987d40a3)
In the end, the button's text must be "Get" (like in the "Catalog" tab) and the book should be successfully retrieved again

**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 