### PR TITLE
Added 'content description' text to back button and logo on toolbar.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,7 +190,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-05T08:51:13+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-08-10T14:20:57+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
@@ -216,7 +216,8 @@
         <c:change date="2022-07-28T00:00:00+00:00" summary="Fixed account name not being fully displayed on account details screen."/>
         <c:change date="2022-07-29T00:00:00+00:00" summary="Added option to reset patron's password on account details screen."/>
         <c:change date="2022-08-03T00:00:00+00:00" summary="Fixed audiobook bookmarks not being saved after exiting the player."/>
-        <c:change date="2022-08-05T08:51:13+00:00" summary="Fix broken state after returning a book."/>
+        <c:change date="2022-08-05T00:00:00+00:00" summary="Fix broken state after returning a book."/>
+        <c:change date="2022-08-10T14:20:57+00:00" summary="Added 'content description' text to back button and logo on toolbar."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-neutrality/src/main/java/org/nypl/simplified/ui/neutrality/NeutralToolbar.kt
+++ b/simplified-ui-neutrality/src/main/java/org/nypl/simplified/ui/neutrality/NeutralToolbar.kt
@@ -98,9 +98,11 @@ class NeutralToolbar(
       this.iconView.x = this.dpToPixelsReal(16).toFloat()
       this.iconView.y = (this.height / 2.0f) - (iconHeight / 2.0f)
       this.iconView.layoutParams = LayoutParams(iconWidth.toInt(), iconHeight.toInt())
+      this.iconView.contentDescription = context.getString(R.string.contentDescriptionBack)
     } else {
       this.iconKind = ICON_IS_LOGO
       this.setLogo(this.iconLogoLast)
+      this.iconView.contentDescription = context.getString(R.string.contentDescriptionLogo)
     }
   }
 

--- a/simplified-ui-neutrality/src/main/res/values/strings.xml
+++ b/simplified-ui-neutrality/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="contentDescriptionBack">Back</string>
+  <string name="contentDescriptionLogo">Logo</string>
+</resources>


### PR DESCRIPTION
**What's this do?**
This PR adds a content description to the back button / logo image on the toolbar. When setting the toolbar's imageview image, we verify if it's the back button or the app's logo and set its content description according to it

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/Android-There-is-an-unlabeled-button-on-the-book-detail-view-screen-2fbc0a5aa61545e78fede8ce86dbf4aa) saying that the back button of the toolbar doesn't display a "Text" value when selecting on the inspect mode of the BrowserStack.

**How should this be tested? / Do these changes have associated tests?**
The [BrowserStack now displays the "Back" label](https://user-images.githubusercontent.com/79104027/183928158-0a269d52-d9f8-405e-b502-2303a4f74e2d.png) on the Inspect Mode, but this can be tested by turning the TalkBack feature of the phone in the Accessibility options, open any book on the app and then click on the "Back" button.

[Description of any tests that need to be performed once merged goes here]

**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 