### PR TITLE
Added back button when search field appears

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -190,7 +190,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-05T08:51:13+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
+    <c:release date="2022-08-12T14:21:16+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.11">
       <c:changes>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Fixed catalog facet labels being cropped."/>
         <c:change date="2022-05-05T00:00:00+00:00" summary="Disabled searching button on catalog search when the input is blank."/>
@@ -216,7 +216,8 @@
         <c:change date="2022-07-28T00:00:00+00:00" summary="Fixed account name not being fully displayed on account details screen."/>
         <c:change date="2022-07-29T00:00:00+00:00" summary="Added option to reset patron's password on account details screen."/>
         <c:change date="2022-08-03T00:00:00+00:00" summary="Fixed audiobook bookmarks not being saved after exiting the player."/>
-        <c:change date="2022-08-05T08:51:13+00:00" summary="Fix broken state after returning a book."/>
+        <c:change date="2022-08-05T00:00:00+00:00" summary="Fixed broken state after returning a book."/>
+        <c:change date="2022-08-12T14:21:16+00:00" summary="Added back button when search field appears."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-main/src/main/res/layout/main_host.xml
+++ b/simplified-main/src/main/res/layout/main_host.xml
@@ -10,7 +10,7 @@
     android:id="@+id/mainToolbar"
     android:theme="?android:attr/actionBarTheme"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" />
+    android:layout_height="?attr/actionBarSize" />
 
   <FrameLayout
     android:id="@+id/mainFragmentHolder"

--- a/simplified-ui-accounts/src/main/res/menu/account_list_registry.xml
+++ b/simplified-ui-accounts/src/main/res/menu/account_list_registry.xml
@@ -7,7 +7,7 @@
     android:icon="@drawable/search"
     android:title="@string/accountMenuSearch"
     app:actionViewClass="androidx.appcompat.widget.SearchView"
-    app:showAsAction="collapseActionView|ifRoom" />
+    app:showAsAction="ifRoom" />
   <item
     android:id="@+id/accountMenuActionReload"
     android:icon="@drawable/refresh"

--- a/simplified-ui-neutrality/src/main/java/org/nypl/simplified/ui/neutrality/NeutralToolbar.kt
+++ b/simplified-ui-neutrality/src/main/java/org/nypl/simplified/ui/neutrality/NeutralToolbar.kt
@@ -6,6 +6,8 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.appcompat.widget.ActionMenuView
+import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.widget.TextViewCompat
 import org.nypl.simplified.ui.neutrality.NeutralToolbar.IconKind.ICON_IS_LOGO
@@ -122,9 +124,38 @@ class NeutralToolbar(
     this.titleView.text = title
   }
 
+  private fun getSearchViewFromToolbar(): SearchView? {
+    var actionMenuView: ActionMenuView?
+
+    for (i in 0 until childCount) {
+      actionMenuView = getChildAt(i) as? ActionMenuView
+      if (actionMenuView != null) {
+        for (n in 0 until actionMenuView.childCount) {
+          val childView = actionMenuView.getChildAt(n) as? SearchView
+          if (childView != null) {
+            return childView
+          }
+        }
+        break
+      }
+    }
+
+    return null
+  }
+
   fun setLogoOnClickListener(listener: () -> Unit) {
     this.iconView.setOnClickListener {
-      listener()
+
+      // get the SearchView of the toolbar, if any
+      val searchView = getSearchViewFromToolbar()
+
+      // if the SearchView is not iconified, it means it's 'expanded' so the back action will close
+      // it instead of navigating between screens
+      if (searchView?.isIconified == false) {
+        searchView.isIconified = true
+      } else {
+        listener()
+      }
     }
   }
 }


### PR DESCRIPTION
**What's this do?**
This PR sets a fixed height to the Toolbar so on the "Add Library" screen opening the SearchView doesn't cause the Toolbar's height to be improperly increased. By doing that, there was the need of removing one of the actions from the SearchView in the XML to make the UI consistent. After that, when opening the SearchView, there were two buttons: the Toolbar's back button and the SearchView clear text button. Both of them should have the same action, i.e., close the SearchView when it's open, so there was also the need of changing the Back button clicking action by checking if the toolbar has a SearchView that's not iconified, i.e., that's open.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/Android-The-back-arrow-disappears-when-the-search-field-appears-cc14886f53fb4154a8c4327f27491f3b) saying the back button should always visible so the user can return to the previous screen without having to close the searching field manually.

**How should this be tested? / Do these changes have associated tests?**
Open Palace app
Go to "Settings"
Click on "Libraries"
Click on the + icon at the top right
Click on the search icon
Verify [the searching field is open with both the back button and clear icon](https://user-images.githubusercontent.com/79104027/184376480-d047cfd3-1418-4ce5-b47a-1a3116e8a85c.png)
Click on the clear icon and verify the searching field closed
Open the searching field again
Click on the back button
Verify the searching field closed

**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 