### PR TITLE
Switched default PDF reader to the PDF-JS Reader

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -221,12 +221,13 @@
         <c:change date="2022-08-05T00:00:00+00:00" summary="Fixed a &quot;Download&quot; button appearing after returning a book, that would lead to an error if tapped."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-16T17:38:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.0">
+    <c:release date="2022-08-23T14:05:23+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.0">
       <c:changes>
         <c:change date="2022-08-10T00:00:00+00:00" summary="Added &quot;content description&quot; text to back button and logo on toolbar."/>
         <c:change date="2022-08-12T00:00:00+00:00" summary="Added back button when search field appears."/>
         <c:change date="2022-08-16T00:00:00+00:00" summary="Changed the chapter duration display in the audio book player to a running remaining time display."/>
-        <c:change date="2022-08-16T17:38:31+00:00" summary="Added ability to always show the password in the account details screen."/>
+        <c:change date="2022-08-16T00:00:00+00:00" summary="Added ability to always show the password in the account details screen."/>
+        <c:change date="2022-08-23T14:05:23+00:00" summary="Switched default PDF reader to the PDF-JS Reader."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -619,8 +619,8 @@ internal class MainFragmentListenerDelegate(
     val viewerPreferences =
       ViewerPreferences(
         flags = mapOf(
-          "enablePDFJSReader" to
-            this.profilesController.profileCurrent().preferences().enablePDFJSReader
+          "enableOldPDFReader" to
+            this.profilesController.profileCurrent().preferences().enableOldPDFReader
         )
       )
 

--- a/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
+++ b/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
@@ -46,7 +46,7 @@ data class ProfilePreferences(
 
   val showDebugSettings: Boolean = false,
 
-  /** @return `true` if the pdf.js-based PDF reader should be used. */
+  /** @return `true` if the old PDF reader should be used. */
 
-  val enablePDFJSReader: Boolean = false
+  val enableOldPDFReader: Boolean = false
 )

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
@@ -206,8 +206,8 @@ object ProfileDescriptionJSON {
         ?.let { AccountID(UUID.fromString(it)) }
         ?: mostRecentAccountFallback
 
-    val enablePDFJSReader =
-      JSONParserUtilities.getBooleanDefault(objectNode, "enablePDFJSReader", false)
+    val enableOldPDFReader =
+      JSONParserUtilities.getBooleanDefault(objectNode, "enableOldPDFReader", false)
 
     return ProfilePreferences(
       dateOfBirth = dateOfBirth,
@@ -216,7 +216,7 @@ object ProfileDescriptionJSON {
       mostRecentAccount = mostRecentAccount,
       hasSeenLibrarySelectionScreen = hasSeenLibrarySelectionScreen,
       showDebugSettings = showDebugSettings,
-      enablePDFJSReader = enablePDFJSReader,
+      enableOldPDFReader = enableOldPDFReader,
       playbackRates = playbackRates
     )
   }
@@ -440,7 +440,7 @@ object ProfileDescriptionJSON {
     output.put("hasSeenLibrarySelectionScreen", preferences.hasSeenLibrarySelectionScreen)
     output.put("showDebugSettings", preferences.showDebugSettings)
     output.put("mostRecentAccount", preferences.mostRecentAccount.uuid.toString())
-    output.put("enablePDFJSReader", preferences.enablePDFJSReader)
+    output.put("enableOldPDFReader", preferences.enableOldPDFReader)
 
     output.set<ObjectNode>(
       "playbackRates",

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/pdf/PdfViewerProviderTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/pdf/PdfViewerProviderTest.kt
@@ -12,8 +12,9 @@ import org.nypl.simplified.viewer.spi.ViewerPreferences
 class PdfViewerProviderTest {
 
   @Test
-  fun supportsPdfBooksWhenEnabled() {
+  fun doesNotSupportPdfBooksWhenDisabled() {
     val preferences = ViewerPreferences(
+      // by setting the old PDF reader setting to true, we're disabling the PDF-JS reader
       flags = mapOf(
         "enableOldPDFReader" to true
       )
@@ -27,8 +28,9 @@ class PdfViewerProviderTest {
   }
 
   @Test
-  fun doesNotSupportPdfBooksWhenDisabled() {
+  fun supportsPdfBooksWhenEnabled() {
     val preferences = ViewerPreferences(
+      // by setting the old PDF reader setting to false, we're enabling the PDF-JS reader
       flags = mapOf(
         "enableOldPDFReader" to false
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/pdf/PdfViewerProviderTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/pdf/PdfViewerProviderTest.kt
@@ -15,22 +15,7 @@ class PdfViewerProviderTest {
   fun supportsPdfBooksWhenEnabled() {
     val preferences = ViewerPreferences(
       flags = mapOf(
-        "enablePDFJSReader" to true
-      )
-    )
-
-    val book = Mockito.mock(Book::class.java)
-    val format = Mockito.mock(BookFormat.BookFormatPDF::class.java)
-    val provider = PdfViewerProvider()
-
-    Assertions.assertTrue(provider.canSupport(preferences, book, format))
-  }
-
-  @Test
-  fun doesNotSupportPdfBooksWhenDisabled() {
-    val preferences = ViewerPreferences(
-      flags = mapOf(
-        "enablePDFJSReader" to false
+        "enableOldPDFReader" to true
       )
     )
 
@@ -39,6 +24,21 @@ class PdfViewerProviderTest {
     val provider = PdfViewerProvider()
 
     Assertions.assertFalse(provider.canSupport(preferences, book, format))
+  }
+
+  @Test
+  fun doesNotSupportPdfBooksWhenDisabled() {
+    val preferences = ViewerPreferences(
+      flags = mapOf(
+        "enableOldPDFReader" to false
+      )
+    )
+
+    val book = Mockito.mock(Book::class.java)
+    val format = Mockito.mock(BookFormat.BookFormatPDF::class.java)
+    val provider = PdfViewerProvider()
+
+    Assertions.assertTrue(provider.canSupport(preferences, book, format))
   }
 
   @Test

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
@@ -50,7 +50,7 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
   private lateinit var crashlyticsId: TextView
   private lateinit var customOPDS: Button
   private lateinit var drmTable: TableLayout
-  private lateinit var enablePDFJSReader: SwitchCompat
+  private lateinit var enableOldPDFReader: SwitchCompat
   private lateinit var failNextBoot: SwitchCompat
   private lateinit var forgetAnnouncementsButton: Button
   private lateinit var hasSeenLibrarySelection: SwitchCompat
@@ -111,8 +111,8 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       view.findViewById(R.id.libraryRegistryOverrideSet)
     this.enableOpenEBooksQA =
       view.findViewById(R.id.settingsVersionDevEnableOpenEBooksQA)
-    this.enablePDFJSReader =
-      view.findViewById(R.id.settingsVersionDevEnablePDFJSReaderSwitch)
+    this.enableOldPDFReader =
+      view.findViewById(R.id.settingsVersionDevEnableOldPDFReaderSwitch)
 
     this.drmTable.addView(
       this.createDrmSupportRow("Adobe Acs", this.viewModel.adeptSupported)
@@ -129,8 +129,8 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
 
     this.showTesting.isChecked =
       this.viewModel.showTestingLibraries
-    this.enablePDFJSReader.isChecked =
-      this.viewModel.enablePDFJSReader
+    this.enableOldPDFReader.isChecked =
+      this.viewModel.enableOldPDFReader
     this.failNextBoot.isChecked =
       this.viewModel.isBootFailureEnabled
     this.hasSeenLibrarySelection.isChecked =
@@ -246,8 +246,8 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       this.listener.post(SettingsDebugEvent.OpenCustomOPDS)
     }
 
-    this.enablePDFJSReader.setOnCheckedChangeListener { _, checked ->
-      this.viewModel.enablePDFJSReader = checked
+    this.enableOldPDFReader.setOnCheckedChangeListener { _, checked ->
+      this.viewModel.enableOldPDFReader = checked
     }
 
     this.configureLibraryRegistryCustomUI()

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
@@ -313,15 +313,15 @@ class SettingsDebugViewModel(application: Application) : AndroidViewModel(applic
     }
   }
 
-  var enablePDFJSReader: Boolean
+  var enableOldPDFReader: Boolean
     get() =
       this.profilesController
         .profileCurrent()
         .preferences()
-        .enablePDFJSReader
+        .enableOldPDFReader
     set(value) {
       this.profilesController.profileUpdate { description ->
-        description.copy(preferences = description.preferences.copy(enablePDFJSReader = value))
+        description.copy(preferences = description.preferences.copy(enableOldPDFReader = value))
       }
     }
 }

--- a/simplified-ui-settings/src/main/res/layout/settings_debug.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_debug.xml
@@ -167,13 +167,13 @@
       android:text="@string/settingsDevEnableHiddenLibraries" />
 
     <androidx.appcompat.widget.SwitchCompat
-      android:id="@+id/settingsVersionDevEnablePDFJSReaderSwitch"
+      android:id="@+id/settingsVersionDevEnableOldPDFReaderSwitch"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginBottom="16dp"
       android:checked="false"
       android:enabled="true"
-      android:text="@string/settingsDevEnablePDFJSReader" />
+      android:text="@string/settingsDevEnableOldPDFReader" />
 
     <androidx.appcompat.widget.SwitchCompat
       android:id="@+id/settingsVersionDevFailNextBootSwitch"

--- a/simplified-ui-settings/src/main/res/values/strings.xml
+++ b/simplified-ui-settings/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
   <string name="settingsDevCrashlyticsCurrentUserId">Current Crashlytics User ID</string>
   <string name="settingsDevDrmSupport">DRM Support</string>
   <string name="settingsDevEnableHiddenLibraries">Enable Hidden Libraries</string>
-  <string name="settingsDevEnablePDFJSReader">Use new PDF reader</string>
+  <string name="settingsDevEnableOldPDFReader">Use old PDF reader</string>
   <string name="settingsDevFailNextStartup">Cause the next application startup to fail</string>
   <string name="settingsDevForgetAllAnnouncements">Forget All Announcements</string>
   <string name="settingsDevPlaceholder">Placeholder</string>

--- a/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfViewerProvider.kt
+++ b/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfViewerProvider.kt
@@ -29,7 +29,7 @@ class PdfViewerProvider : ViewerProviderType {
         false
       }
       is BookFormat.BookFormatPDF -> {
-        preferences.flags["enablePDFJSReader"] == true
+        preferences.flags["enableOldPDFReader"] != true
       }
     }
   }

--- a/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfViewerProvider.kt
+++ b/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfViewerProvider.kt
@@ -29,7 +29,7 @@ class PdfViewerProvider : ViewerProviderType {
         false
       }
       is BookFormat.BookFormatPDF -> {
-        preferences.flags["enablePDFJSReader"] != true
+        preferences.flags["enableOldPDFReader"] == true
       }
     }
   }


### PR DESCRIPTION
**What's this do?**
This PR sets the PDF-JS reader as the default PDF reader and updates the dev settings so the user can set the old PDF reader if they want

**Why are we doing this? (w/ JIRA link if applicable)**
The PDF-JS reader seems to be stable and working very well so there's a [feature request](https://www.notion.so/lyrasis/Android-Promote-new-PDF-reader-to-be-the-default-reader-912b0a24b12042fcbf444f1c237902ec) to promote it as the default reader.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Choose "LYRASIS Reads" library
Open a pdf book from _New Biblioboard Test_ lane
Confirm the pdf reader [is the PDF-JS reader](https://user-images.githubusercontent.com/79104027/186181938-3e88af4b-0825-47d8-8b08-f79b3fedf283.png)
Go to settings
Enable debug options
Enable "Set old PDF reader" option
Return to the PDF book
Confirm the pdf reader [is the old PDF reader](https://user-images.githubusercontent.com/79104027/186181966-6ae86b95-299e-474d-8c08-c77586eb4cce.png)


**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 