### PR TITLE
Fixed searching field text overlapping back button

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -221,12 +221,13 @@
         <c:change date="2022-08-05T00:00:00+00:00" summary="Fixed a &quot;Download&quot; button appearing after returning a book, that would lead to an error if tapped."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-16T17:38:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.0">
+    <c:release date="2022-08-24T11:19:44+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.0">
       <c:changes>
         <c:change date="2022-08-10T00:00:00+00:00" summary="Added &quot;content description&quot; text to back button and logo on toolbar."/>
         <c:change date="2022-08-12T00:00:00+00:00" summary="Added back button when search field appears."/>
         <c:change date="2022-08-16T00:00:00+00:00" summary="Changed the chapter duration display in the audio book player to a running remaining time display."/>
-        <c:change date="2022-08-16T17:38:31+00:00" summary="Added ability to always show the password in the account details screen."/>
+        <c:change date="2022-08-16T00:00:00+00:00" summary="Added ability to always show the password in the account details screen."/>
+        <c:change date="2022-08-24T11:19:44+00:00" summary="Fixed searching field text overlapping back button."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryFragment.kt
@@ -9,7 +9,6 @@ import android.text.InputType
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
-import android.view.MenuItem.OnActionExpandListener
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.TextView
@@ -183,6 +182,8 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
     searchView.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_WORDS
     searchView.queryHint = getString(R.string.accountSearchHint)
 
+    searchView.maxWidth = getAvailableWidthForSearchView()
+
     searchView.setOnQueryTextListener(object : OnQueryTextListener {
       override fun onQueryTextSubmit(query: String): Boolean {
         search.collapseActionView()
@@ -210,18 +211,6 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
         return true
       }
     })
-
-    search.setOnActionExpandListener(object : OnActionExpandListener {
-      override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
-        // Do nothing
-        return true
-      }
-
-      override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
-        this@AccountListRegistryFragment.accountListAdapter.resetFilter()
-        return true
-      }
-    })
   }
 
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -232,6 +221,18 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
       }
       else -> super.onOptionsItemSelected(item)
     }
+  }
+
+  private fun getAvailableWidthForSearchView(): Int {
+    val fullWidth = this.resources.displayMetrics.widthPixels
+    val scale = this.resources.displayMetrics.density
+
+    // return the size of the 3 icons on the toolbar when the SearchView is expanded (navigation
+    // icon, clear button and more options icon)
+    val toolbarIconsWidth = (24 * 3 * scale).toDouble() + 0.5
+
+    // return the full width of the screen minus the icons width
+    return (fullWidth - toolbarIconsWidth).toInt()
   }
 
   private fun configureToolbar(activity: Activity) {


### PR DESCRIPTION
**What's this do?**
This PR adds logic to calculate the available width for the SearchView and set it as its maximum width value.

**Why are we doing this? (w/ JIRA link if applicable)**
There's been found [a bug in some devices](https://www.notion.so/lyrasis/Android-The-back-arrow-disappears-when-the-search-field-appears-cc14886f53fb4154a8c4327f27491f3b) where the searching field overlaps the back button or is very close to it, which doesn't look good in terms of UI

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Go to Settings
Click on Libraries
Click on the + at the top right
Click on the searching icon
See the searching field is not overlapping anything

_Note: In order to reproduce the reported bug, there are some devices listed in [this ticket](https://www.notion.so/lyrasis/Android-The-back-arrow-disappears-when-the-search-field-appears-cc14886f53fb4154a8c4327f27491f3b) comments. I tested in some of them to see if it was working:
[Samsung Galaxy S22 Ultra-12 0](https://user-images.githubusercontent.com/79104027/186406763-8a594b64-e206-4a78-8ec1-7895306c1d96.png)
[Samsung Galaxy S22-12 0](https://user-images.githubusercontent.com/79104027/186406767-f4753130-dbe0-4b3d-8f22-a324f8383503.png)
[Samsung Galaxy S9-8 0](https://user-images.githubusercontent.com/79104027/186406769-a8aafbeb-197a-4dcf-8673-07c9d650db0c.png)
[Xiaomi Mi8](https://user-images.githubusercontent.com/79104027/186406771-e8c3f178-01db-44b2-a93a-ac166783ddff.png)_

**Dependencies for merging? Releasing to production?**
No

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 