### PR TITLE
Fixed back button action on some screens

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -221,7 +221,7 @@
         <c:change date="2022-08-05T00:00:00+00:00" summary="Fixed a &quot;Download&quot; button appearing after returning a book, that would lead to an error if tapped."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-31T00:16:57+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.0">
+    <c:release date="2022-09-01T10:37:17+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.0">
       <c:changes>
         <c:change date="2022-08-09T00:00:00+00:00" summary="Added bookmarks for PDF books."/>
         <c:change date="2022-08-10T00:00:00+00:00" summary="Added &quot;content description&quot; text to back button and logo on toolbar."/>
@@ -232,7 +232,8 @@
         <c:change date="2022-08-23T00:00:00+00:00" summary="Switched default PDF reader to the PDF-JS Reader."/>
         <c:change date="2022-08-24T00:00:00+00:00" summary="Fixed searching field text overlapping back button."/>
         <c:change date="2022-08-30T00:00:00+00:00" summary="Fixed back button not returning to catalog."/>
-        <c:change date="2022-08-31T00:16:57+00:00" summary="Added remaining time display to audio book player."/>
+        <c:change date="2022-08-31T00:00:00+00:00" summary="Added remaining time display to audio book player."/>
+        <c:change date="2022-09-01T10:37:17+00:00" summary="Fixed back button not working on onboarding's account selection screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -221,7 +221,7 @@
         <c:change date="2022-08-05T00:00:00+00:00" summary="Fixed a &quot;Download&quot; button appearing after returning a book, that would lead to an error if tapped."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-24T11:19:44+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.0">
+    <c:release date="2022-08-30T22:41:15+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.0">
       <c:changes>
         <c:change date="2022-08-09T00:00:00+00:00" summary="Added bookmarks for PDF books."/>
         <c:change date="2022-08-10T00:00:00+00:00" summary="Added &quot;content description&quot; text to back button and logo on toolbar."/>
@@ -230,7 +230,8 @@
         <c:change date="2022-08-16T00:00:00+00:00" summary="Added ability to always show the password in the account details screen."/>
         <c:change date="2022-08-17T00:00:00+00:00" summary="Fixed sample preview being handled as full content acquisition link."/>
         <c:change date="2022-08-23T00:00:00+00:00" summary="Switched default PDF reader to the PDF-JS Reader."/>
-        <c:change date="2022-08-24T11:19:44+00:00" summary="Fixed searching field text overlapping back button."/>
+        <c:change date="2022-08-24T00:00:00+00:00" summary="Fixed searching field text overlapping back button."/>
+        <c:change date="2022-08-30T22:41:15+00:00" summary="Fixed back button not returning to catalog."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentListenerDelegate.kt
@@ -251,6 +251,10 @@ internal class MainFragmentListenerDelegate(
         this.openErrorPage(event.parameters)
         state
       }
+      is AccountListRegistryEvent.GoUpwards -> {
+        this.goUpwards()
+        state
+      }
     }
   }
 
@@ -270,7 +274,7 @@ internal class MainFragmentListenerDelegate(
         state
       }
       AccountListEvent.AddAccount -> {
-        this.openSettingsAccountRegistry()
+        this.openAccountRegistry(tab = R.id.tabSettings)
         state
       }
       is AccountListEvent.OpenErrorPage -> {
@@ -348,7 +352,7 @@ internal class MainFragmentListenerDelegate(
         state
       }
       AccountPickerEvent.AddAccount -> {
-        this.openSettingsAccountRegistry()
+        this.openAccountRegistry(tab = R.id.tabCatalog)
         state
       }
     }
@@ -596,10 +600,10 @@ internal class MainFragmentListenerDelegate(
     )
   }
 
-  private fun openSettingsAccountRegistry() {
+  private fun openAccountRegistry(tab: Int) {
     this.navigator.addFragment(
       fragment = AccountListRegistryFragment(),
-      tab = R.id.tabSettings
+      tab = tab
     )
   }
 

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryEvent.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryEvent.kt
@@ -12,4 +12,6 @@ sealed class AccountListRegistryEvent {
   data class OpenErrorPage(
     val parameters: ErrorPageParameters
   ) : AccountListRegistryEvent()
+
+  object GoUpwards : AccountListRegistryEvent()
 }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryFragment.kt
@@ -1,7 +1,6 @@
 package org.nypl.simplified.ui.accounts
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
 import android.location.LocationManager
 import android.os.Bundle
@@ -12,7 +11,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.TextView
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.SearchView.OnQueryTextListener
@@ -28,11 +26,11 @@ import org.nypl.simplified.accounts.api.AccountEventCreation
 import org.nypl.simplified.accounts.api.AccountProviderDescription
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryEvent
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryStatus
-import org.nypl.simplified.android.ktx.supportActionBar
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.listeners.api.fragmentListeners
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.nypl.simplified.ui.images.ImageLoaderType
+import org.nypl.simplified.ui.neutrality.NeutralToolbar
 import org.slf4j.LoggerFactory
 
 /**
@@ -45,10 +43,6 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
   private val subscriptions = CompositeDisposable()
   private val listener: FragmentListenerType<AccountListRegistryEvent> by fragmentListeners()
 
-  private val requestLocationPermission = registerForActivityResult(
-    ActivityResultContracts.RequestPermission(),
-    ::getLocation
-  )
   private val viewModel: AccountListRegistryViewModel by assistedViewModels {
     val locationManager =
       requireContext().getSystemService(Context.LOCATION_SERVICE) as LocationManager
@@ -58,9 +52,10 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
   private lateinit var accountList: RecyclerView
   private lateinit var accountListAdapter: FilterableAccountListAdapter
   private lateinit var imageLoader: ImageLoaderType
+  private lateinit var noLocation: TextView
   private lateinit var progress: ContentLoadingProgressBar
   private lateinit var title: TextView
-  private lateinit var noLocation: TextView
+  private lateinit var toolbar: NeutralToolbar
   private var reload: MenuItem? = null
   private var errorDialog: AlertDialog? = null
 
@@ -86,6 +81,8 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
       view.findViewById(R.id.accountRegistryList)
     this.noLocation =
       view.findViewById(R.id.accountRegistryNoLocation)
+    this.toolbar =
+      view.rootView.findViewWithTag(NeutralToolbar.neutralToolbarName)
 
     this.accountListAdapter =
       FilterableAccountListAdapter(
@@ -117,7 +114,7 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
 
   override fun onStart() {
     super.onStart()
-    this.configureToolbar(this.requireActivity())
+    this.configureToolbar()
 
     this.viewModel.accountRegistryEvents
       .subscribe(this::onAccountRegistryEvent)
@@ -235,10 +232,10 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
     return (fullWidth - toolbarIconsWidth).toInt()
   }
 
-  private fun configureToolbar(activity: Activity) {
-    this.supportActionBar?.apply {
-      title = getString(R.string.accountAdd)
-      subtitle = null
+  private fun configureToolbar() {
+    this.toolbar.title = getString(R.string.accountAdd)
+    this.toolbar.setLogoOnClickListener {
+      this.listener.post(AccountListRegistryEvent.GoUpwards)
     }
   }
 

--- a/simplified-ui-onboarding/src/main/java/org/nypl/simplified/ui/onboarding/OnboardingFragment.kt
+++ b/simplified-ui-onboarding/src/main/java/org/nypl/simplified/ui/onboarding/OnboardingFragment.kt
@@ -119,7 +119,7 @@ class OnboardingFragment :
       is AccountListRegistryEvent.OpenErrorPage ->
         this.openErrorPage(event.parameters)
       is AccountListRegistryEvent.GoUpwards -> {
-        // do nothing
+        this.childFragmentManager.popBackStack()
       }
     }
   }

--- a/simplified-ui-onboarding/src/main/java/org/nypl/simplified/ui/onboarding/OnboardingFragment.kt
+++ b/simplified-ui-onboarding/src/main/java/org/nypl/simplified/ui/onboarding/OnboardingFragment.kt
@@ -118,6 +118,9 @@ class OnboardingFragment :
         this.onAccountCreated(event.accountID)
       is AccountListRegistryEvent.OpenErrorPage ->
         this.openErrorPage(event.parameters)
+      is AccountListRegistryEvent.GoUpwards -> {
+        // do nothing
+      }
     }
   }
 


### PR DESCRIPTION
**What's this do?**
This PR changes the way the back button actions are handled. When the user goes to the account selection from the catalog, we're now overriding the logo click action so the app can perform the action of returning to the catalog. When the user is on the onboarding screen and wants to choose a library, the account list screen is now being removed from the fragment manager so the user can return to the previous screen. Also, this PR changes the source tab that called the account list screen as it can be opened from two different areas: the Catalog and the Settings.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [reported bug](https://www.notion.so/lyrasis/Android-The-Back-button-doesn-t-return-to-the-Catalog-screen-a21a148239e34935a70794bf697644c9) saying the back button is not returning the user to the Catalog when opening the account list screen from there. There's also a [reported bug](https://www.notion.so/lyrasis/Android-The-Back-button-doesn-t-return-to-the-previous-screen-16718360278c45079668079619fa0939) saying the back button is not working on the onboarding screen

**How should this be tested? / Do these changes have associated tests?**
_First test_
Uninstall the app and install it again.
Open the palace app
Skip the Onboarding
Click on "Find Library"
Click on the back button at the top left corner
Verify the app returned to the previous screen

_Second Test_
Open the Palace app
On the Catalog, click on the logo at the top left corner
Click on "Add Library"
Press the back button at the top left corner
Verify the app returned to the Catalog

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 