### PR TITLE
Updated method to calculate the width of the SearchView

### DIFF
--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryFragment.kt
@@ -1,7 +1,6 @@
 package org.nypl.simplified.ui.accounts
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
 import android.location.LocationManager
 import android.os.Bundle
@@ -28,11 +27,11 @@ import org.nypl.simplified.accounts.api.AccountEventCreation
 import org.nypl.simplified.accounts.api.AccountProviderDescription
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryEvent
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryStatus
-import org.nypl.simplified.android.ktx.supportActionBar
 import org.nypl.simplified.listeners.api.FragmentListenerType
 import org.nypl.simplified.listeners.api.fragmentListeners
 import org.nypl.simplified.ui.errorpage.ErrorPageParameters
 import org.nypl.simplified.ui.images.ImageLoaderType
+import org.nypl.simplified.ui.neutrality.NeutralToolbar
 import org.slf4j.LoggerFactory
 
 /**
@@ -58,9 +57,10 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
   private lateinit var accountList: RecyclerView
   private lateinit var accountListAdapter: FilterableAccountListAdapter
   private lateinit var imageLoader: ImageLoaderType
+  private lateinit var noLocation: TextView
   private lateinit var progress: ContentLoadingProgressBar
   private lateinit var title: TextView
-  private lateinit var noLocation: TextView
+  private lateinit var toolbar: NeutralToolbar
   private var reload: MenuItem? = null
   private var errorDialog: AlertDialog? = null
 
@@ -86,6 +86,8 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
       view.findViewById(R.id.accountRegistryList)
     this.noLocation =
       view.findViewById(R.id.accountRegistryNoLocation)
+    this.toolbar =
+      view.rootView.findViewWithTag(NeutralToolbar.neutralToolbarName)
 
     this.accountListAdapter =
       FilterableAccountListAdapter(
@@ -117,7 +119,7 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
 
   override fun onStart() {
     super.onStart()
-    this.configureToolbar(this.requireActivity())
+    this.configureToolbar()
 
     this.viewModel.accountRegistryEvents
       .subscribe(this::onAccountRegistryEvent)
@@ -181,8 +183,7 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
     searchView.imeOptions = EditorInfo.IME_ACTION_DONE
     searchView.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_WORDS
     searchView.queryHint = getString(R.string.accountSearchHint)
-
-    searchView.maxWidth = getAvailableWidthForSearchView()
+    searchView.maxWidth = toolbar.getAvailableWidthForSearchView()
 
     searchView.setOnQueryTextListener(object : OnQueryTextListener {
       override fun onQueryTextSubmit(query: String): Boolean {
@@ -223,23 +224,8 @@ class AccountListRegistryFragment : Fragment(R.layout.account_list_registry) {
     }
   }
 
-  private fun getAvailableWidthForSearchView(): Int {
-    val fullWidth = this.resources.displayMetrics.widthPixels
-    val scale = this.resources.displayMetrics.density
-
-    // return the size of the 3 icons on the toolbar when the SearchView is expanded (navigation
-    // icon, clear button and more options icon)
-    val toolbarIconsWidth = (24 * 3 * scale).toDouble() + 0.5
-
-    // return the full width of the screen minus the icons width
-    return (fullWidth - toolbarIconsWidth).toInt()
-  }
-
-  private fun configureToolbar(activity: Activity) {
-    this.supportActionBar?.apply {
-      title = getString(R.string.accountAdd)
-      subtitle = null
-    }
+  private fun configureToolbar() {
+    this.toolbar.title = getString(R.string.accountAdd)
   }
 
   private fun reload() {

--- a/simplified-ui-neutrality/src/main/java/org/nypl/simplified/ui/neutrality/NeutralToolbar.kt
+++ b/simplified-ui-neutrality/src/main/java/org/nypl/simplified/ui/neutrality/NeutralToolbar.kt
@@ -160,4 +160,13 @@ class NeutralToolbar(
       }
     }
   }
+
+  fun getAvailableWidthForSearchView(): Int {
+    val fullWidth = this.resources.displayMetrics.widthPixels
+
+    // the contentInsetStartWithNavigation already returns the size of the navigation icon, so the
+    // available width for the SearchView can be calculated from the entire screen's width minus
+    // that value
+    return fullWidth - contentInsetStartWithNavigation
+  }
 }


### PR DESCRIPTION
**What's this do?**
This PR updates the logic of how the maximum width for the SearchView on the account list screen is calculated. Instead of relying on the number of icons, it's now using the start inset navigation value of the toolbar.

**Why are we doing this? (w/ JIRA link if applicable)**
Even though [this bug](https://www.notion.so/lyrasis/Android-The-back-arrow-disappears-when-the-search-field-appears-cc14886f53fb4154a8c4327f27491f3b) was fixed, the solution could be improved

**How should this be tested? / Do these changes have associated tests?**
_Note: I've ran the app on [the bug reported devices](https://www.notion.so/lyrasis/Android-The-back-arrow-disappears-when-the-search-field-appears-cc14886f53fb4154a8c4327f27491f3b) and the results were:
[Samsung Galaxy S9-8](https://user-images.githubusercontent.com/79104027/187974515-64f57071-f32f-41a0-a840-40871513b9e8.png)
[XiaoMI Mi9](https://user-images.githubusercontent.com/79104027/187974520-eb12dc02-e518-444d-94ec-14f2c0f2b108.png)
[Samsung Galaxy S22-12](https://user-images.githubusercontent.com/79104027/187974521-d5277c7d-b800-4fc1-85b0-364e40f1661d.png)
[Samsung Galaxy S22 Ultra-12](https://user-images.githubusercontent.com/79104027/187974524-2185ec87-adce-4856-a1bf-b87805528547.png)
_

Open the app
Go to Settings
Click on "Libraries"
Click on the "+" at the top right corner
Click on the search icon
Verify the SearchView is not overlapping the back button

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 