### PR TITLE
Fixed app crashing when opening TOC or settings before loading the PDF

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -237,9 +237,10 @@
         <c:change date="2022-09-19T00:00:00+00:00" summary="Fixed a crash that occurred on some Samsung devices."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-09-21T15:04:47+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
+    <c:release date="2022-09-22T17:25:39+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
       <c:changes>
-        <c:change date="2022-09-21T15:04:47+00:00" summary="Removed delete option from book details screen."/>
+        <c:change date="2022-09-21T00:00:00+00:00" summary="Removed delete option from book details screen."/>
+        <c:change date="2022-09-22T17:25:39+00:00" summary="Fixed app crashing when opening TOC or settings before the PDF was completely loaded."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
@@ -228,13 +228,17 @@ class PdfReaderActivity : AppCompatActivity() {
   }
 
   private fun toggleSidebar() {
-    this.webView.evaluateJavascript("toggleSidebar()") { result ->
-      this.isSidebarOpen = (result == "true")
+    if (::webView.isInitialized) {
+      this.webView.evaluateJavascript("toggleSidebar()") { result ->
+        this.isSidebarOpen = (result == "true")
+      }
     }
   }
 
   private fun onReaderMenuSettingsSelected(): Boolean {
-    this.webView.evaluateJavascript("toggleSecondaryToolbar()", null)
+    if (::webView.isInitialized) {
+      this.webView.evaluateJavascript("toggleSecondaryToolbar()", null)
+    }
 
     return true
   }


### PR DESCRIPTION
**What's this do?**
This PR checks if the PDF Viewer WebView has been initialized before applying any of the selected options by the user. When the PDF is loading, the user may already select the Settings or TOC options and if the WebView hasn't been initialized yet nothing should happen.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [reported bug](https://www.notion.so/lyrasis/Android-PDF-There-is-a-redirection-to-the-Catalog-or-the-app-stops-when-we-tap-TOC-or-Settings-str-f441d733c81e4486b8425d000652c6ee) saying the app is crashing when selecting the TOC/Settings option while the PDF is being loaded.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads"
Search for "Who lives in a tree"
Download the PDF and open it
Select both TOC and Settings option before the PDF loads
Verify nothing happens and the app doesn't crash

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 