### PR TITLE
Added content description to back button on reader screen

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -237,11 +237,12 @@
         <c:change date="2022-09-19T00:00:00+00:00" summary="Fixed a crash that occurred on some Samsung devices."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-09-22T17:25:39+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
+    <c:release date="2022-09-27T10:36:01+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
       <c:changes>
-        <c:change date="2022-09-21T15:04:47+00:00" summary="Removed delete option from book details screen."/>
-        <c:change date="2022-09-21T15:01:57+00:00" summary="Fixed logging out action not being performed sometimes."/>
-        <c:change date="2022-09-22T17:25:39+00:00" summary="Fixed app crashing when opening TOC or settings before the PDF was completely loaded."/>
+        <c:change date="2022-09-21T00:00:00+00:00" summary="Removed delete option from book details screen."/>
+        <c:change date="2022-09-21T00:00:00+00:00" summary="Fixed logging out action not being performed sometimes."/>
+        <c:change date="2022-09-22T00:00:00+00:00" summary="Fixed app crashing when opening TOC or settings before the PDF was completely loaded."/>
+        <c:change date="2022-09-27T10:36:01+00:00" summary="Added content description to back button on reader screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
@@ -157,6 +157,7 @@ class PdfReaderActivity : AppCompatActivity() {
     val toolbar = this.findViewById(R.id.pdf_toolbar) as Toolbar
 
     this.setSupportActionBar(toolbar)
+    this.supportActionBar?.setHomeActionContentDescription(R.string.content_description_back)
 
     this.supportActionBar?.setDisplayHomeAsUpEnabled(true)
     this.supportActionBar?.setDisplayShowHomeEnabled(true)

--- a/simplified-viewer-pdf-pdfjs/src/main/res/values/strings.xml
+++ b/simplified-viewer-pdf-pdfjs/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
   <string name="table_of_contents_empty_message">No Table of Contents available for this work</string>
   <string name="accessibility_settings">Open the settings menu</string>
   <string name="settings_title">Settings</string>
+  <string name="content_description_back">Back</string>
 </resources>

--- a/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf/src/main/java/org/nypl/simplified/viewer/pdf/PdfReaderActivity.kt
@@ -142,6 +142,7 @@ class PdfReaderActivity :
     this.setSupportActionBar(toolbar)
     this.supportActionBar?.setDisplayHomeAsUpEnabled(true)
     this.supportActionBar?.setDisplayShowHomeEnabled(true)
+    this.supportActionBar?.setHomeActionContentDescription(R.string.content_description_back)
     this.supportActionBar?.title = ""
 
     val backgroundThread = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1))

--- a/simplified-viewer-pdf/src/main/res/values/strings.xml
+++ b/simplified-viewer-pdf/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
 <resources>
   <string name="table_of_contents_title">Table of Contents</string>
   <string name="table_of_contents_empty_message">No Table of Contents available for this work</string>
+  <string name="content_description_back">Back</string>
 </resources>


### PR DESCRIPTION
**What's this do?**
This PR adds a content description to the back button on the toolbar of the reader screen.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/Android-There-are-unlabeled-buttons-on-the-book-reading-and-listening-screens-1847df33398945e487c8f0e6b3a136df) saying that the back button of the reader's toolbar doesn't display a "Text" value when selecting on the inspect mode of the BrowserStack.

**How should this be tested? / Do these changes have associated tests?**
The [BrowserStack now displays the "Back" label](https://user-images.githubusercontent.com/79104027/192505454-7dd41e87-dcdb-4fd3-9846-449329c60a01.png) on the Inspect Mode, but this can be tested by:
1. Turn the TalkBack feature of the phone in the Accessibility options
2. Open the Palace app
3. Open any book to start reading it
4. Click on the "Back" button.

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 