### PR TITLE
Move LCP configuration into external script.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ ext {
   android_min_sdk_version = 21
   android_target_sdk_version = 30
 
+  credentialsPath = project.findProperty('org.thepalaceproject.app.credentials.palace') ?: rootDir
+  lcpProfile = "prod"
+
   // Required for some dependencies only available from our private S3
   //
   nyplS3Depend =
@@ -104,38 +107,11 @@ ext {
       throw new GradleException(text);
     }
   }
-
-  credentialsPath =
-    project.findProperty('org.thepalaceproject.app.credentials.palace') ?: ''
-  lcpLicenseFile = "${credentialsPath}/LCP/prod_license_key.txt"
-  lcpLicenseKey = 'test'
-
-  try {
-    lcpLicenseKey = new File(lcpLicenseFile).text.trim()
-  } catch (Exception ex) {
-    logger.error("Failed to read production LCP license key from {}", lcpLicenseFile)
-    logger.error("Test liblcp will be used")
-  }
-}
-
-//
-// If we're not using the production LCP module, the only version available is 1.0.0, so
-// substitute out the version that was requested.
-//
-
-if (lcpLicenseKey == 'test') {
-  allprojects {
-    configurations.all {
-      resolutionStrategy {
-        dependencySubstitution {
-          substitute module('readium:liblcp') using module('readium:liblcp:1.0.0') because 'no LCP production license key was found, and the LCP test repository only contains version 1.0.0'
-        }
-      }
-    }
-  }
 }
 
 subprojects { project ->
+  apply from: file("${credentialsPath}/LCP/Android/build_lcp_${lcpProfile}.gradle")
+
   group = project.ext["GROUP"]
   version = project.ext["VERSION_NAME"]
 
@@ -204,21 +180,6 @@ subprojects { project ->
         mavenContent {
           releasesOnly()
         }
-      }
-    }
-
-    /*
-     * LCP repository.
-     */
-
-    ivy {
-      name = "LCP"
-      url = uri('https://liblcp.dita.digital')
-      patternLayout {
-        artifact ("/[organisation]/[module]/android/aar/$lcpLicenseKey/[revision].[ext]")
-      }
-      metadataSources {
-        artifact()
       }
     }
 


### PR DESCRIPTION
**What's this do?**

This moves the configuration for downloading the LCP library into an external script.

**Why are we doing this? (w/ JIRA link if applicable)**

This is required for this ticket: https://www.notion.so/lyrasis/Move-LCP-recipe-to-properties-c508747ff48b416a9a6f31096e1f8e03

**How should this be tested? / Do these changes have associated tests?**

I tried builds using the test and production LCP libraries, and verified that the builds succeeded.

**Dependencies for merging? Releasing to production?**

https://github.com/ThePalaceProject/mobile-certificates/pull/23 should be merged first.

**Have you updated the changelog?**

No, this is not an externally visible change.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran some builds.