### PR TITLE
Fixed login button being disabled when reentering the app

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -237,7 +237,7 @@
         <c:change date="2022-09-19T00:00:00+00:00" summary="Fixed a crash that occurred on some Samsung devices."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-04T19:35:59+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
+    <c:release date="2022-10-08T21:06:00+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
       <c:changes>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Removed delete option from book details screen."/>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Fixed logging out action not being performed sometimes."/>
@@ -245,7 +245,8 @@
         <c:change date="2022-09-27T00:00:00+00:00" summary="Added content description to back button on reader screen."/>
         <c:change date="2022-09-28T00:00:00+00:00" summary="Fixed audiobooks not pausing when other apps start playing audio."/>
         <c:change date="2022-10-04T00:00:00+00:00" summary="Fixed audiobook chapter's time elapsed and remaining and book remaining time not being updated when dragging the player seekbar."/>
-        <c:change date="2022-10-04T19:35:59+00:00" summary="Fixed track durations not being displayed on Overdrive audio books."/>
+        <c:change date="2022-10-04T00:00:00+00:00" summary="Fixed track durations not being displayed on Overdrive audio books."/>
+        <c:change date="2022-10-08T21:06:00+00:00" summary="Fixed login button being disabled when reentering the app."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -585,8 +585,6 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     this.logger.debug("broadcasting login state")
     this.viewModel.account.setLoginState(this.viewModel.account.loginState)
 
-    this.accountIcon.setImageDrawable(null)
-    this.authenticationViews.clear()
     this.subscriptions.clear()
   }
 


### PR DESCRIPTION
**What's this do?**
This PR removes two lines of code that had impact on how the UI behaves in the account detail screen when the user send the app to background. There's no point in clearing the views list and setting the image to null and when the user returns those two objects weren't restored, which was causing the login button to being disabled and the account logo image to disappear.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a comment in [this ticket](https://www.notion.so/lyrasis/Android-Investigate-the-cases-of-Log-in-button-unavailability-f3dfc83441c54ba79618a2c5c08e7e85) saying the login button is disabled when reentering the app

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select a library where you're logged in to
Logout
Wait for the logout to be completed and send the app to background
Return to the app and insert your barcode and pin
Confirm the "Login" button is enabled

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 