### PR TITLE
Fixed sidebar automatically opening when opening some pdfs

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -237,7 +237,7 @@
         <c:change date="2022-09-19T00:00:00+00:00" summary="Fixed a crash that occurred on some Samsung devices."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-08T21:06:00+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
+    <c:release date="2022-10-12T22:59:39+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
       <c:changes>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Removed delete option from book details screen."/>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Fixed logging out action not being performed sometimes."/>
@@ -246,7 +246,8 @@
         <c:change date="2022-09-28T00:00:00+00:00" summary="Fixed audiobooks not pausing when other apps start playing audio."/>
         <c:change date="2022-10-04T00:00:00+00:00" summary="Fixed audiobook chapter's time elapsed and remaining and book remaining time not being updated when dragging the player seekbar."/>
         <c:change date="2022-10-04T00:00:00+00:00" summary="Fixed track durations not being displayed on Overdrive audio books."/>
-        <c:change date="2022-10-08T21:06:00+00:00" summary="Fixed login button being disabled when reentering the app."/>
+        <c:change date="2022-10-08T00:00:00+00:00" summary="Fixed login button being disabled when reentering the app."/>
+        <c:change date="2022-10-12T22:59:39+00:00" summary="Fixed sidebar automatically opening when opening some pdfs."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-pdf-pdfjs/src/main/assets/pdf-viewer/viewer.js
+++ b/simplified-viewer-pdf-pdfjs/src/main/assets/pdf-viewer/viewer.js
@@ -14,6 +14,16 @@ PDFViewerApplication.initializedPromise.then(() => {
 });
 
 /**
+ * Check if the side bar is open.
+ *
+ * @return true if the sidebar is open, false if it is closed.
+ **/
+
+function isSideBarOpen() {
+    return PDFViewerApplication.pdfSidebar.isOpen;
+}
+
+/**
  * Toggle the sidebar.
  *
  * @return true if the sidebar is open after toggling, false if it is closed.
@@ -21,7 +31,7 @@ PDFViewerApplication.initializedPromise.then(() => {
 function toggleSidebar() {
   PDFViewerApplication.pdfSidebar.toggle();
 
-  return PDFViewerApplication.pdfSidebar.isOpen;
+  return isSideBarOpen();
 }
 
 /**

--- a/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
@@ -36,7 +36,6 @@ import java.net.ServerSocket
 import java.util.ServiceLoader
 import java.util.concurrent.Executors
 
-
 class PdfReaderActivity : AppCompatActivity() {
 
   companion object {

--- a/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
@@ -33,7 +33,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.net.ServerSocket
-import java.util.*
+import java.util.ServiceLoader
 import java.util.concurrent.Executors
 
 

--- a/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf-pdfjs/src/main/java/org/nypl/simplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
@@ -9,6 +9,7 @@ import android.view.MenuItem
 import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import android.widget.ProgressBar
 import androidx.appcompat.app.AlertDialog
@@ -32,8 +33,9 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.net.ServerSocket
-import java.util.ServiceLoader
+import java.util.*
 import java.util.concurrent.Executors
+
 
 class PdfReaderActivity : AppCompatActivity() {
 
@@ -116,6 +118,16 @@ class PdfReaderActivity : AppCompatActivity() {
             this.webView.loadUrl(
               "http://localhost:${it.port}/assets/pdf-viewer/viewer.html?file=%2Fbook.pdf#page=${this.documentPageIndex}"
             )
+
+            this.webView.webViewClient = object : WebViewClient() {
+              override fun onPageFinished(view: WebView, url: String) {
+                webView.evaluateJavascript("isSideBarOpen()") { result ->
+                  if (result == "true") {
+                    toggleSidebar()
+                  }
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
**What's this do?**
This PR adds a listener to the webview's page loading to be aware of when the pdf is loaded so it can check if the sidebar is open and, if so, close it.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/Android-Pdfs-in-Palace-Bookshelf-library-are-opened-with-already-opened-TOC-page-8a3b6a90a004490ebc083c6ffbddf2a2) reporting this unwanted behavior that is causing a bad UX.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Selected "Palace Bookshelf" library
Get a pdf (eg. “Deep into Pharo”)
Tap “Read”
Confirm [the sidebar is not automatically opening when the pdf is loaded](https://user-images.githubusercontent.com/79104027/195463662-9ff8a219-9fd0-4013-b58b-e48975b90e8f.mp4)


**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 