### PR TITLE
Externalize LCP build configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ audiobook player module, but there is also an NYPL-developed Findaway
 module for Findaway licensees. Please get in touch with us if you have
 a Findaway license and want to produce a Findaway-enabled build.
 
+#### LCP DRM Support
+
+The project uses Readium's liblcp module to provide support for LCP
+content protection. This module must be available on the classpath
+when the `org.thepalaceproject.drm.enabled` property is true. Otherwise,
+the project will not compile. Please get in touch with us if you have
+an LCP license and want to produce a DRM-enabled build.
+
 ## Development
 
 ### Branching/Merging

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ ext {
   android_min_sdk_version = 21
   android_target_sdk_version = 30
 
+  credentialsPath = project.findProperty('org.thepalaceproject.app.credentials.palace')
+  lcpProfile = "prod"
+
   // Required for some dependencies only available from our private S3
   //
   nyplS3Depend =
@@ -104,38 +107,13 @@ ext {
       throw new GradleException(text);
     }
   }
-
-  credentialsPath =
-    project.findProperty('org.thepalaceproject.app.credentials.palace') ?: ''
-  lcpLicenseFile = "${credentialsPath}/LCP/prod_license_key.txt"
-  lcpLicenseKey = 'test'
-
-  try {
-    lcpLicenseKey = new File(lcpLicenseFile).text.trim()
-  } catch (Exception ex) {
-    logger.error("Failed to read production LCP license key from {}", lcpLicenseFile)
-    logger.error("Test liblcp will be used")
-  }
-}
-
-//
-// If we're not using the production LCP module, the only version available is 1.0.0, so
-// substitute out the version that was requested.
-//
-
-if (lcpLicenseKey == 'test') {
-  allprojects {
-    configurations.all {
-      resolutionStrategy {
-        dependencySubstitution {
-          substitute module('readium:liblcp') using module('readium:liblcp:1.0.0') because 'no LCP production license key was found, and the LCP test repository only contains version 1.0.0'
-        }
-      }
-    }
-  }
 }
 
 subprojects { project ->
+  if (credentialsPath) {
+    apply from: file("${credentialsPath}/LCP/Android/build_lcp_${lcpProfile}.gradle")
+  }
+
   group = project.ext["GROUP"]
   version = project.ext["VERSION_NAME"]
 
@@ -204,21 +182,6 @@ subprojects { project ->
         mavenContent {
           releasesOnly()
         }
-      }
-    }
-
-    /*
-     * LCP repository.
-     */
-
-    ivy {
-      name = "LCP"
-      url = uri('https://liblcp.dita.digital')
-      patternLayout {
-        artifact ("/[organisation]/[module]/android/aar/$lcpLicenseKey/[revision].[ext]")
-      }
-      metadataSources {
-        artifact()
       }
     }
 

--- a/simplified-books-borrowing/build.gradle
+++ b/simplified-books-borrowing/build.gradle
@@ -21,12 +21,6 @@ dependencies {
   implementation libs.r2.shared
   implementation libs.slf4j
 
-  implementation (libs.readium.lcp) {
-    artifact {
-      type = "aar"
-    }
-  }
-
   implementation(libs.truevfs.access)
   implementation(libs.truevfs.driver.zip)
   implementation(libs.truecommons.key.disable)

--- a/simplified-main/build.gradle
+++ b/simplified-main/build.gradle
@@ -89,10 +89,4 @@ dependencies {
   api libs.rxjava2
   api libs.rxjava2.extensions
   api libs.slf4j
-
-  implementation (libs.readium.lcp) {
-    artifact {
-      type = "aar"
-    }
-  }
 }

--- a/simplified-tests/build.gradle
+++ b/simplified-tests/build.gradle
@@ -100,12 +100,6 @@ dependencies {
   implementation libs.r2.shared
   implementation libs.slf4j
 
-  implementation (libs.readium.lcp) {
-    artifact {
-      type = "aar"
-    }
-  }
-
   testImplementation libs.logback.classic
   testImplementation libs.junit
   testImplementation libs.org.json


### PR DESCRIPTION
**What's this do?**

This is a refinement of #145, to avoid breaking PR builds.

This moves the configuration for downloading the LCP decryption library into an external script. It also removes dependencies on the LCP library from modules where it wasn't being used, so that the only remaining use is in `simplified-app-palace`.

**Why are we doing this? (w/ JIRA link if applicable)**

This makes the LCP build recipe private. Notion: https://www.notion.so/lyrasis/Move-LCP-recipe-to-properties-c508747ff48b416a9a6f31096e1f8e03

**How should this be tested? / Do these changes have associated tests?**

Verify that LCP books (e.g. epubs from the DPLA Titles lane in LYRASIS Reads, such as "The Great Illyrian Revolt" can be downloaded.

**Dependencies for merging? Releasing to production?**

https://github.com/ThePalaceProject/mobile-certificates/pull/23 should be merged first.

**Have you updated the changelog?**

No, this is not an externally visible change.

**Has the application documentation been updated for these changes?**

The README has been updated.

**Did someone actually run this code to verify it works?**

@ray-lee ran some builds and checked LCP downloads.
