### PR TITLE
Target Android 12 (API 32).

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -237,7 +237,7 @@
         <c:change date="2022-09-19T00:00:00+00:00" summary="Fixed a crash that occurred on some Samsung devices."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-08T21:06:00+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
+    <c:release date="2022-10-19T15:20:27+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
       <c:changes>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Removed delete option from book details screen."/>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Fixed logging out action not being performed sometimes."/>
@@ -246,7 +246,8 @@
         <c:change date="2022-09-28T00:00:00+00:00" summary="Fixed audiobooks not pausing when other apps start playing audio."/>
         <c:change date="2022-10-04T00:00:00+00:00" summary="Fixed audiobook chapter's time elapsed and remaining and book remaining time not being updated when dragging the player seekbar."/>
         <c:change date="2022-10-04T00:00:00+00:00" summary="Fixed track durations not being displayed on Overdrive audio books."/>
-        <c:change date="2022-10-08T21:06:00+00:00" summary="Fixed login button being disabled when reentering the app."/>
+        <c:change date="2022-10-08T00:00:00+00:00" summary="Fixed login button being disabled when reentering the app."/>
+        <c:change date="2022-10-19T15:20:27+00:00" summary="Changed target version to Android 12."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,12 @@ buildscript {
   ext.kotlin_version = "1.5.30"
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.0.3'
+    classpath 'com.android.tools.build:gradle:7.3.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.4"
+    classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1'
     classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0"
     classpath "com.nabilhachicha:android-native-dependencies:0.1.2"
-    classpath 'com.google.gms:google-services:4.3.4'
+    classpath 'com.google.gms:google-services:4.3.10'
     classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
     classpath "de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1"
   }
@@ -28,10 +28,10 @@ plugins {
 }
 
 ext {
-  android_build_tools_version = "30.0.2"
-  android_compile_sdk_version = 31
+  android_build_tools_version = "32.0.0"
+  android_compile_sdk_version = 32
   android_min_sdk_version = 21
-  android_target_sdk_version = 30
+  android_target_sdk_version = 32
 
   credentialsPath = project.findProperty('org.thepalaceproject.app.credentials.palace')
   lcpProfile = "prod"
@@ -202,6 +202,21 @@ subprojects { project ->
   if (nyplDrmRequired) {
     project.tasks.all { task ->
       task.onlyIf { nyplDrmEnabled }
+    }
+  }
+  // Workaround for failing readium nanohttpd artifact downloads. Remove this when readium has
+  // fixed the issue.
+  if (nyplDrmEnabled || !nyplDrmRequired) {
+    project.configurations.all {
+      resolutionStrategy {
+        dependencySubstitution {
+          all { DependencySubstitution dependency ->
+            if (dependency.requested instanceof ModuleComponentSelector && dependency.requested.group == 'com.github.edrlab.nanohttpd') {
+              dependency.useTarget ('com.github.readium.nanohttpd:' + dependency.requested.module + ':' + dependency.requested.version, 'because nanohttpd ownership changed from edrlab to readium')
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/simplified-app-palace/src/main/AndroidManifest.xml
+++ b/simplified-app-palace/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
       android:screenOrientation="portrait"
       android:exported="true"
       android:label="@string/app_name">
-    <intent-filter>
+      <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>

--- a/simplified-cardcreator/build.gradle
+++ b/simplified-cardcreator/build.gradle
@@ -8,7 +8,6 @@ dependencies {
   implementation project(':simplified-webview')
 
   implementation libs.slf4j
-  implementation libs.androidx.legacy.support.v4
   implementation libs.androidx.activity
   implementation libs.androidx.app.compat
   implementation libs.androidx.constraint.layout

--- a/simplified-reports/build.gradle
+++ b/simplified-reports/build.gradle
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-  api libs.androidx.legacy.support.v4
+  api libs.androidx.core
   api libs.kotlin.stdlib
   api libs.slf4j
 }

--- a/simplified-tests-sandbox/build.gradle
+++ b/simplified-tests-sandbox/build.gradle
@@ -45,7 +45,6 @@ dependencies {
 
   implementation libs.androidx.app.compat
   implementation libs.androidx.constraint.layout
-  implementation libs.androidx.legacy.support.v4
   implementation libs.androidx.lifecycle
   implementation libs.google.material
   implementation libs.io7m.jfunctional

--- a/simplified-ui-catalog/build.gradle
+++ b/simplified-ui-catalog/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   implementation libs.androidx.lifecycle
   implementation libs.androidx.paging
   implementation libs.androidx.recycler.view
+  implementation libs.androidx.swiperefresh.layout
   implementation libs.google.material
   implementation libs.kotlin.stdlib
   implementation libs.kotlin.reflect

--- a/simplified-ui-splash/build.gradle
+++ b/simplified-ui-splash/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 
   implementation libs.androidx.app.compat
   implementation libs.androidx.constraint.layout
-  implementation libs.androidx.legacy.support.v4
   implementation libs.androidx.lifecycle
   implementation libs.androidx.fragment
   implementation libs.google.material


### PR DESCRIPTION
**What's this do?**

This updates the app to target Android 12 (API 32), including necessary dependency and gradle upgrades.

It also includes a workaround for the currently failing readium nanohttpd artifact downloads, which can be removed when that problem is fixed by readium.

**Why are we doing this? (w/ JIRA link if applicable)**

Apps will be required to target Android 12 in November. Notion: https://www.notion.so/lyrasis/Update-Android-app-to-target-Android-13-2d0216494ad846579321de4b5a4c932f

**How should this be tested? / Do these changes have associated tests?**

Basically the whole app should be tested to make sure everything looks good. Looking at the Android 12 release/upgrade docs, there are only a couple areas of concern:
- There was a change to cookie handling that may affect SAML logins/downloads. Downloads from SAML libraries should continue to work. 
- There were UI changes for tablets/large screens. We haven't really concentrated on tablets, but we should check that the experience is at least not worse.
- There were some changes required for audiobook control intents. Audiobook playback and controls should be tested.

**Dependencies for merging? Releasing to production?**

All of these PRs should be merged first:
- https://github.com/ThePalaceProject/android-audiobook/pull/47
- https://github.com/ThePalaceProject/android-audiobook-overdrive/pull/4
- https://github.com/ThePalaceProject/android-drm-adobe/pull/1
- https://github.com/ThePalaceProject/android-drm-audioengine/pull/14
- https://github.com/ThePalaceProject/android-drm-core/pull/1
- https://github.com/ThePalaceProject/android-http/pull/2
- https://github.com/ThePalaceProject/android-r2/pull/15

**Have you updated the changelog?**

Yes

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee did some general testing.