### PR TITLE
Target Android 13 (API 33).

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -237,7 +237,7 @@
         <c:change date="2022-09-19T00:00:00+00:00" summary="Fixed a crash that occurred on some Samsung devices."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-19T17:13:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
+    <c:release date="2022-10-27T17:52:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
       <c:changes>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Removed delete option from book details screen."/>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Fixed logging out action not being performed sometimes."/>
@@ -250,6 +250,7 @@
         <c:change date="2022-10-19T00:00:00+00:00" summary="Changed target version to Android 12."/>
         <c:change date="2022-10-19T00:00:00+00:00" summary="Fixed app not redirecting user to book details after logging in."/>
         <c:change date="2022-10-19T17:13:45+00:00" summary="Updated &quot;Log in&quot; and &quot;Log out&quot; to &quot;Sign in&quot; and &quot;Sign out&quot;"/>
+        <c:change date="2022-10-27T17:52:31+00:00" summary="Changed target version to Android 13."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,10 @@ plugins {
 }
 
 ext {
-  android_build_tools_version = "32.0.0"
-  android_compile_sdk_version = 32
+  android_build_tools_version = "33.0.0"
+  android_compile_sdk_version = 33
   android_min_sdk_version = 21
-  android_target_sdk_version = 32
+  android_target_sdk_version = 33
 
   credentialsPath = project.findProperty('org.thepalaceproject.app.credentials.palace')
   lcpProfile = "prod"
@@ -202,22 +202,6 @@ subprojects { project ->
   if (nyplDrmRequired) {
     project.tasks.all { task ->
       task.onlyIf { nyplDrmEnabled }
-    }
-  }
-
-  // Workaround for failing readium nanohttpd artifact downloads. Remove this when readium has
-  // fixed the issue.
-  if (nyplDrmEnabled || !nyplDrmRequired) {
-    project.configurations.all {
-      resolutionStrategy {
-        dependencySubstitution {
-          all { DependencySubstitution dependency ->
-            if (dependency.requested instanceof ModuleComponentSelector && dependency.requested.group == 'com.github.edrlab.nanohttpd') {
-              dependency.useTarget ('com.github.readium.nanohttpd:' + dependency.requested.module + ':' + dependency.requested.version, 'because nanohttpd ownership changed from edrlab to readium')
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
+++ b/simplified-cardcreator/src/main/java/org/nypl/simplified/cardcreator/ui/LocationFragment.kt
@@ -219,11 +219,11 @@ class LocationFragment : Fragment(), LocationListener {
 
     try {
       if (location != null) {
-        address = geocoder.getFromLocation(location.latitude, location.longitude, maxResults)[0]
-        logger.debug("Region is: ${address.adminArea} ${address.countryCode} ")
-        binding.regionEt.setText("${address.adminArea} ${address.countryCode}", TextView.BufferType.EDITABLE)
+        address = geocoder.getFromLocation(location.latitude, location.longitude, maxResults)?.get(0)
+        logger.debug("Region is: ${address?.adminArea} ${address?.countryCode} ")
+        binding.regionEt.setText("${address?.adminArea} ${address?.countryCode}", TextView.BufferType.EDITABLE)
 
-        if (address.countryCode == "US" && (address.adminArea == "New York" || address.adminArea == "NY")) {
+        if (address?.countryCode == "US" && (address?.adminArea == "New York" || address?.adminArea == "NY")) {
           logger.debug("User is in New York")
           logger.debug("Stopping location updates")
           locationManager.removeUpdates(this)
@@ -281,11 +281,11 @@ class LocationFragment : Fragment(), LocationListener {
       val address: Address?
 
       try {
-        address = geocoder.getFromLocation(location.latitude, location.longitude, maxResults)[0]
-        logger.debug("Region is: ${address.adminArea} ${address.countryCode} ")
-        binding.regionEt.setText("${address.adminArea} ${address.countryCode}", TextView.BufferType.EDITABLE)
+        address = geocoder.getFromLocation(location.latitude, location.longitude, maxResults)?.get(0)
+        logger.debug("Region is: ${address?.adminArea} ${address?.countryCode} ")
+        binding.regionEt.setText("${address?.adminArea} ${address?.countryCode}", TextView.BufferType.EDITABLE)
 
-        if (address.countryCode == "US" && (address.adminArea == "New York" || address.adminArea == "NY")) {
+        if (address?.countryCode == "US" && (address?.adminArea == "New York" || address?.adminArea == "NY")) {
           logger.debug("User is in New York")
           logger.debug("Stopping location updates")
           locationManager.removeUpdates(this)

--- a/simplified-viewer-pdf-pdfjs/build.gradle
+++ b/simplified-viewer-pdf-pdfjs/build.gradle
@@ -14,15 +14,15 @@ dependencies {
   implementation libs.kotlin.coroutines
   implementation libs.kotlin.reflect
   implementation libs.kotlin.stdlib
+  implementation (libs.nano.httpd) {
+    exclude group: "org.parboiled"
+  }
+  implementation (libs.nano.httpd.nanolets) {
+    exclude group: "org.parboiled"
+  }
   implementation libs.nypl.pdf.api
   implementation libs.nypl.pdf.viewer
   implementation libs.palace.drm.core
   implementation libs.r2.streamer
   implementation libs.slf4j
-  implementation("com.github.edrlab.nanohttpd:nanohttpd:master-SNAPSHOT") {
-    exclude group: "org.parboiled"
-  }
-  implementation("com.github.edrlab.nanohttpd:nanohttpd-nanolets:master-SNAPSHOT") {
-    exclude group: "org.parboiled"
-  }
 }


### PR DESCRIPTION
**What's this do?**

This updates the app to target Android 13 (API 33).

Some additional null checks that are now needed have been added.

It also removes the workaround for the failing readium nanohttpd artifact downloads, since that problem has been fixed by readium.

**Why are we doing this? (w/ JIRA link if applicable)**

Notion: https://www.notion.so/lyrasis/Update-Android-app-to-target-Android-13-2d0216494ad846579321de4b5a4c932f

**How should this be tested? / Do these changes have associated tests?**

Basically the whole app should be tested to make sure everything looks good. Looking at the Android 13 release/upgrade docs, there are only a couple areas of concern:

- There were some changes to the media player on the lock screen/notification area. Audiobook playback and controls should be tested on that player.
- The system theme is now applied automatically to WebView content. The epub and pdf readers should be tested to make sure they work the same, particularly when a color scheme is selected in the epub reader.

**Dependencies for merging? Releasing to production?**

All of these PRs should be merged first:
- https://github.com/ThePalaceProject/android-audiobook/pull/48
- https://github.com/ThePalaceProject/android-audiobook-overdrive/pull/5
- https://github.com/ThePalaceProject/android-drm-adobe/pull/2
- https://github.com/ThePalaceProject/android-drm-audioengine/pull/15
- https://github.com/ThePalaceProject/android-drm-core/pull/2
- https://github.com/ThePalaceProject/android-http/pull/3
- https://github.com/ThePalaceProject/android-r2/pull/17

**Have you updated the changelog?**

Yes

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee did some general testing.