### PR TITLE
Updated sign in and sign out labels

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -237,7 +237,7 @@
         <c:change date="2022-09-19T00:00:00+00:00" summary="Fixed a crash that occurred on some Samsung devices."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-27T17:52:31+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
+    <c:release date="2022-11-15T23:26:57+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
       <c:changes>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Removed delete option from book details screen."/>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Fixed logging out action not being performed sometimes."/>
@@ -249,8 +249,9 @@
         <c:change date="2022-10-08T00:00:00+00:00" summary="Fixed login button being disabled when reentering the app."/>
         <c:change date="2022-10-19T00:00:00+00:00" summary="Changed target version to Android 12."/>
         <c:change date="2022-10-19T00:00:00+00:00" summary="Fixed app not redirecting user to book details after logging in."/>
-        <c:change date="2022-10-19T17:13:45+00:00" summary="Updated &quot;Log in&quot; and &quot;Log out&quot; to &quot;Sign in&quot; and &quot;Sign out&quot;"/>
-        <c:change date="2022-10-27T17:52:31+00:00" summary="Changed target version to Android 13."/>
+        <c:change date="2022-10-19T00:00:00+00:00" summary="Updated &quot;Log in&quot; and &quot;Log out&quot; to &quot;Sign in&quot; and &quot;Sign out&quot;"/>
+        <c:change date="2022-10-27T00:00:00+00:00" summary="Changed target version to Android 13."/>
+        <c:change date="2022-11-15T23:26:57+00:00" summary="Updated sign in and sign out labels."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
   <string name="accountCreationFailedMessage">The library could not be created.</string>
   <string name="accountDelete">Delete</string>
   <string name="accountEULAStatement">By signing in, you agree to the End User License Agreement.</string>
-  <string name="accountLogin">Sign In</string>
+  <string name="accountLogin">Sign in</string>
   <string name="accountForgotPassword">Forgot your password?</string>
   <string name="accountWantChildCard">Want a card for your child?</string>
   <string name="accountCreateCard">Create Card</string>

--- a/simplified-ui-profiles/src/main/res/values/stringsProfiles.xml
+++ b/simplified-ui-profiles/src/main/res/values/stringsProfiles.xml
@@ -14,12 +14,12 @@
   <string name="profileDeletionFailedMessage">An error occurred whilst trying to delete the profile: %1$s</string>
   <string name="profileError">Error</string>
   <string name="profileLoggedInAs">You are currently logged in as: %1$s</string>
-  <string name="profileLogOut">Sign Out</string>
+  <string name="profileLogOut">Sign out</string>
   <string name="profileModify">Modify</string>
   <string name="profileName">Name</string>
   <string name="profilePlaceholder">Lorem ipsum dolor sit amet, probatus volutpat has at, vis adhuc iuvaret omittantur an, sadipscing conclusionemque his ad. Eam ut simul tempor. Primis consetetur appellantur vim eu, eum an iudico dolorum. Ad vis utamur honestatis, sanctus debitis referrentur an eam.</string>
   <string name="profileSelect">Please select a profile, or create a new one.</string>
-  <string name="profilesSwitch">Sign Out</string>
+  <string name="profilesSwitch">Sign out</string>
   <string name="profilesSwitchConfirm">Are you sure you want to sign out?</string>
   <string name="profilesTimeOutSoon">The current profile will soon be logged out due to inactivity. Please touch the screen if you want to stay logged in.</string>
   <string name="profilesTimeOutSoonTitle">Profile Inactivity</string>


### PR DESCRIPTION
**What's this do?**
This PR updates some sign in and sign out related labels

**Why are we doing this? (w/ JIRA link if applicable)**
There's a comment in [this ticket](https://www.notion.so/lyrasis/Change-Log-out-to-Sign-out-and-Log-in-to-Sign-in-on-Android-46c86aec81d14f28b063e5dfcb5cb6b6) requesting to change the "Sign Out" to "Sign out" and "Sign In" to "Sign in

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Go to "Settings" and then "Libraries"
Select a library that requires authentication
Confirm the button now says "Sign In" instead of "Log in"
Enter your credentials and sign in
Confirm the button now says "Sign Out" instead of "Log out"

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 