### PR TITLE
Changed the Switch's enabled color to green

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -237,7 +237,7 @@
         <c:change date="2022-09-19T00:00:00+00:00" summary="Fixed a crash that occurred on some Samsung devices."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-11-29T01:08:52+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
+    <c:release date="2022-12-02T23:42:52+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.3.0">
       <c:changes>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Removed delete option from book details screen."/>
         <c:change date="2022-09-21T00:00:00+00:00" summary="Fixed logging out action not being performed sometimes."/>
@@ -255,7 +255,8 @@
         <c:change date="2022-11-16T00:00:00+00:00" summary="Fixed error downloading some BiblioBoard titles."/>
         <c:change date="2022-11-17T00:00:00+00:00" summary="Added back button to audio book table of contents."/>
         <c:change date="2022-11-29T00:00:00+00:00" summary="Removed &quot;(file x of y)&quot; text from audio book chapter title."/>
-        <c:change date="2022-11-29T01:08:52+00:00" summary="Fixed audio book not pausing when headphones are unplugged."/>
+        <c:change date="2022-11-29T00:00:00+00:00" summary="Fixed audio book not pausing when headphones are unplugged."/>
+        <c:change date="2022-12-02T23:42:52+00:00" summary="Changed the Switch's enabled color to green."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -256,8 +256,10 @@
         <c:change date="2022-11-29T00:00:00+00:00" summary="Fixed audiobooks not pausing when headphones are unplugged."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-12-08T16:33:53+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
-      <c:changes/>
+    <c:release date="2022-12-12T15:54:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
+      <c:changes>
+        <c:change date="2022-12-12T15:54:45+00:00" summary="Changed the Switch's enabled color to green."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/simplified-ui-accounts/src/main/res/layout/account.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account.xml
@@ -243,6 +243,7 @@
                 android:layout_marginBottom="16dp"
                 android:enabled="false"
                 android:label="@id/accountSyncBookmarksLabel"
+                android:theme="@style/Enabled.Switch"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />

--- a/simplified-ui-accounts/src/main/res/layout/auth_coppa.xml
+++ b/simplified-ui-accounts/src/main/res/layout/auth_coppa.xml
@@ -30,6 +30,7 @@
     android:layout_marginTop="16dp"
     android:layout_marginEnd="16dp"
     android:layout_marginBottom="16dp"
+    android:theme="@style/Enabled.Switch"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintTop_toTopOf="parent" />

--- a/simplified-ui-neutrality/src/main/res/values/styles_common.xml
+++ b/simplified-ui-neutrality/src/main/res/values/styles_common.xml
@@ -19,4 +19,9 @@
     <item name="android:textColor">?attr/simplifiedColorText</item>
     <item name="android:fontFamily">@font/open_sans_regular</item>
   </style>
+
+  <style name="Enabled.Switch" parent="Theme.AppCompat.Light">
+    <item name="colorControlActivated">#2ED158</item>
+  </style>
+
 </resources>

--- a/simplified-ui-neutrality/src/main/res/values/styles_common.xml
+++ b/simplified-ui-neutrality/src/main/res/values/styles_common.xml
@@ -20,7 +20,8 @@
     <item name="android:fontFamily">@font/open_sans_regular</item>
   </style>
 
-  <style name="Enabled.Switch" parent="Theme.AppCompat.Light">
+  <style name="Enabled.Switch" parent="Widget.AppCompat.CompoundButton.Switch">
+    <item name="android:textSize">14sp</item>
     <item name="colorControlActivated">#2ED158</item>
   </style>
 

--- a/simplified-ui-settings/src/main/res/layout/settings_debug.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_debug.xml
@@ -159,6 +159,7 @@
 
     <androidx.appcompat.widget.SwitchCompat
       android:id="@+id/settingsVersionDevProductionLibrariesSwitch"
+      android:theme="@style/Enabled.Switch"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginBottom="16dp"
@@ -168,6 +169,7 @@
 
     <androidx.appcompat.widget.SwitchCompat
       android:id="@+id/settingsVersionDevEnableOldPDFReaderSwitch"
+      android:theme="@style/Enabled.Switch"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginBottom="16dp"
@@ -177,6 +179,7 @@
 
     <androidx.appcompat.widget.SwitchCompat
       android:id="@+id/settingsVersionDevFailNextBootSwitch"
+      android:theme="@style/Enabled.Switch"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginBottom="16dp"
@@ -186,6 +189,7 @@
 
     <androidx.appcompat.widget.SwitchCompat
       android:id="@+id/settingsVersionDevSeenLibrarySelectionScreen"
+      android:theme="@style/Enabled.Switch"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginBottom="16dp"
@@ -201,10 +205,12 @@
       android:checked="false"
       android:enabled="true"
       android:text="@string/settingsDevCardCreatorUserNewYork"
+      android:theme="@style/Enabled.Switch"
       android:visibility="gone" />
 
     <androidx.appcompat.widget.SwitchCompat
       android:id="@+id/settingsVersionDevShowOnlySupported"
+      android:theme="@style/Enabled.Switch"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_marginBottom="16dp"


### PR DESCRIPTION
**What's this do?**
This PR changes the enabled color of all the Switch elements in the app.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-Add-green-color-or-other-indicator-that-sync-bookmarks-is-enabled-1a47cff8e1634cc6af2f59f0ae076d93) saying the enabled color of the Switch should be different from what we got since it's hard to tell if it's enabled or not.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Go to Settings
Go to Libraries
Open, for example, the Lyrasis Reads library
Enable the "Sync Bookmarks" switch if it's not enabled
Confirm [the color of the "Sync Bookmarks" is now green](https://user-images.githubusercontent.com/79104027/205410132-4d8d1046-3d7c-4988-b564-dc859a2fa446.png)
Go to the mobile settings and switch to dark mode
Return to the Palace app
Confirm the switch is [green when enabled](https://user-images.githubusercontent.com/79104027/205898392-04d972a4-083d-42ea-ba3d-ee2fd1230c69.png) and [grey when disabled](https://user-images.githubusercontent.com/79104027/205898408-2d944d65-62dd-4375-b978-ecafa516709c.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 