### PR TITLE
Downgrade Gradle version

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -256,9 +256,10 @@
         <c:change date="2022-11-29T00:00:00+00:00" summary="Fixed audiobooks not pausing when headphones are unplugged."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-12-12T15:54:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
+    <c:release date="2022-12-14T14:42:56+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
       <c:changes>
-        <c:change date="2022-12-12T15:54:45+00:00" summary="Changed the Switch's enabled color to green."/>
+        <c:change date="2022-12-12T00:00:00+00:00" summary="Changed the Switch's enabled color to green."/>
+        <c:change date="2022-12-14T14:42:56+00:00" summary="Downgraded Gradle version."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
   ext.kotlin_version = "1.5.30"
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.3.1'
+    classpath 'com.android.tools.build:gradle:7.0.3'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.4.1'
     classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip


### PR DESCRIPTION
**What's this do?**
This PR downgrades the used Gradle versions to the ones before [this PR](https://github.com/ThePalaceProject/android-core/pull/149)

**Why are we doing this? (w/ JIRA link if applicable)**
After merging [this PR](https://github.com/ThePalaceProject/android-core/pull/149) I couldn't build the Palace app anymore and it's somehow related to that. Since several weeks have been gone and the building issues remain and this change doesn't impact the app's behavior, me and @ray-lee talked about downgrading the version

**How should this be tested? / Do these changes have associated tests?**
The app should compile and run without any issues

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 