### PR TITLE
Added "About Palace" option to Settings screen

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -256,10 +256,11 @@
         <c:change date="2022-11-29T00:00:00+00:00" summary="Fixed audiobooks not pausing when headphones are unplugged."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-12-14T14:42:56+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
+    <c:release date="2022-12-15T11:43:00+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
       <c:changes>
         <c:change date="2022-12-12T00:00:00+00:00" summary="Changed the Switch's enabled color to green."/>
-        <c:change date="2022-12-14T14:42:56+00:00" summary="Downgraded Gradle version."/>
+        <c:change date="2022-12-14T00:00:00+00:00" summary="Downgraded Gradle version."/>
+        <c:change date="2022-12-15T11:43:00+00:00" summary="Added &quot;About Palace&quot; option to Settings screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceDocumentStoreConfiguration.kt
+++ b/simplified-app-palace/src/main/java/org/thepalaceproject/palace/PalaceDocumentStoreConfiguration.kt
@@ -13,21 +13,24 @@ class PalaceDocumentStoreConfiguration : DocumentConfigurationServiceType {
     )
 
   override val about: DocumentConfiguration? =
-    null
+    DocumentConfiguration(
+      name = null,
+      remoteURI = URI.create("http://thepalaceproject.org/")
+    )
 
   override val acknowledgements: DocumentConfiguration? =
     null
 
   override val eula: DocumentConfiguration? =
     DocumentConfiguration(
-      "eula.html",
-      URI.create("https://legal.palaceproject.io/End%20User%20License%20Agreement.html")
+      name = "eula.html",
+      remoteURI = URI.create("https://legal.palaceproject.io/End%20User%20License%20Agreement.html")
     )
 
   override val licenses: DocumentConfiguration? =
     DocumentConfiguration(
-      "software-licenses.html",
-      URI.create("https://legal.palaceproject.io/software-licenses.html")
+      name = "software-licenses.html",
+      remoteURI = URI.create("https://legal.palaceproject.io/software-licenses.html")
     )
 
   override val faq: DocumentConfiguration? =

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/DocumentConfiguration.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/DocumentConfiguration.kt
@@ -12,7 +12,7 @@ data class DocumentConfiguration(
    * The name of the document file.
    */
 
-  val name: String,
+  val name: String?,
 
   /**
    * The remote URI used to fetch new versions of the document.

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/internal/DocumentStore.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/internal/DocumentStore.kt
@@ -110,16 +110,27 @@ internal class DocumentStore private constructor(
     ): EULAType {
       this.logger.debug("eula {} ({})", config.name, config.remoteURI)
 
-      return EULA(
-        http = http,
-        initialStreams = {
-          assetManager.open(config.name)
-        },
-        file = File(baseDirectory, config.name),
-        fileTmp = File(baseDirectory, config.name + ".tmp"),
-        fileAgreed = File(baseDirectory, "eula_agreed.dat"),
-        remoteURL = config.remoteURI.toURL()
-      )
+      return if (!config.name.isNullOrBlank()) {
+        EULA(
+          http = http,
+          initialStreams = {
+            assetManager.open(config.name)
+          },
+          file = File(baseDirectory, config.name),
+          fileTmp = File(baseDirectory, config.name + ".tmp"),
+          fileAgreed = File(baseDirectory, "eula_agreed.dat"),
+          remoteURL = config.remoteURI.toURL()
+        )
+      } else {
+        EULA(
+          http = http,
+          initialStreams = null,
+          file = null,
+          fileTmp = null,
+          fileAgreed = File(baseDirectory, "eula_agreed.dat"),
+          remoteURL = config.remoteURI.toURL()
+        )
+      }
     }
 
     private fun documentForMaybe(
@@ -141,15 +152,25 @@ internal class DocumentStore private constructor(
     ): DocumentType {
       this.logger.debug("plain document {} ({})", config.name, config.remoteURI)
 
-      return PlainDocument(
-        http = http,
-        initialStreams = {
-          assetManager.open(config.name)
-        },
-        file = File(baseDirectory, config.name),
-        fileTmp = File(baseDirectory, config.name + ".tmp"),
-        remoteURL = config.remoteURI.toURL()
-      )
+      return if (!config.name.isNullOrBlank()) {
+        PlainDocument(
+          http = http,
+          initialStreams = {
+            assetManager.open(config.name)
+          },
+          file = File(baseDirectory, config.name),
+          fileTmp = File(baseDirectory, config.name + ".tmp"),
+          remoteURL = config.remoteURI.toURL()
+        )
+      } else {
+        PlainDocument(
+          http = http,
+          initialStreams = null,
+          file = null,
+          fileTmp = null,
+          remoteURL = config.remoteURI.toURL()
+        )
+      }
     }
   }
 

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/internal/EULA.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/internal/EULA.kt
@@ -8,9 +8,9 @@ import java.net.URL
 
 internal class EULA internal constructor(
   http: LSHTTPClientType,
-  initialStreams: () -> InputStream,
-  file: File,
-  fileTmp: File,
+  initialStreams: (() -> InputStream)?,
+  file: File?,
+  fileTmp: File?,
   private val fileAgreed: File,
   remoteURL: URL
 ) : AbstractDocument(

--- a/simplified-documents/src/main/java/org/librarysimplified/documents/internal/PlainDocument.kt
+++ b/simplified-documents/src/main/java/org/librarysimplified/documents/internal/PlainDocument.kt
@@ -7,9 +7,9 @@ import java.net.URL
 
 internal class PlainDocument internal constructor(
   http: LSHTTPClientType,
-  initialStreams: () -> InputStream,
-  file: File,
-  fileTmp: File,
+  initialStreams: (() -> InputStream)?,
+  file: File?,
+  fileTmp: File?,
   remoteURL: URL
 ) : AbstractDocument(
   http = http,

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/documents/DocumentStoreTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/documents/DocumentStoreTest.kt
@@ -10,7 +10,12 @@ import org.librarysimplified.documents.DocumentConfiguration
 import org.librarysimplified.documents.DocumentConfigurationServiceType
 import org.librarysimplified.documents.DocumentStores
 import org.librarysimplified.documents.DocumentType
-import org.librarysimplified.http.api.*
+import org.librarysimplified.http.api.LSHTTPClientType
+import org.librarysimplified.http.api.LSHTTPRequestBuilderType
+import org.librarysimplified.http.api.LSHTTPRequestType
+import org.librarysimplified.http.api.LSHTTPResponseProperties
+import org.librarysimplified.http.api.LSHTTPResponseStatus
+import org.librarysimplified.http.api.LSHTTPResponseType
 import org.mockito.Mockito
 import org.nypl.simplified.tests.TestDirectories
 import java.io.File

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/documents/DocumentStoreTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/documents/DocumentStoreTest.kt
@@ -1,6 +1,8 @@
 package org.nypl.simplified.tests.documents
 
 import android.content.res.AssetManager
+import com.google.common.util.concurrent.MoreExecutors
+import one.irradia.mime.api.MIMEType
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -8,13 +10,13 @@ import org.librarysimplified.documents.DocumentConfiguration
 import org.librarysimplified.documents.DocumentConfigurationServiceType
 import org.librarysimplified.documents.DocumentStores
 import org.librarysimplified.documents.DocumentType
-import org.librarysimplified.http.api.LSHTTPClientType
-import org.librarysimplified.http.api.LSHTTPRequestBuilderType
+import org.librarysimplified.http.api.*
 import org.mockito.Mockito
 import org.nypl.simplified.tests.TestDirectories
 import java.io.File
 import java.io.InputStream
 import java.net.URI
+import java.util.concurrent.Executors
 
 class DocumentStoreTest {
 
@@ -30,11 +32,30 @@ class DocumentStoreTest {
     remoteURI = remoteURI
   )
 
+  private val executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1))
+
+  private val responseStatus = LSHTTPResponseStatus.Responded.OK(
+    properties = LSHTTPResponseProperties(
+      problemReport = null,
+      status = 200,
+      originalStatus = 200,
+      message = "",
+      contentType = MIMEType("text", "plain", mapOf()),
+      contentLength = null,
+      headers = mapOf(),
+      cookies = listOf(),
+      authorization = null
+    ),
+    bodyStream = InputStream.nullInputStream()
+  )
+
   private lateinit var assetManager: AssetManager
   private lateinit var baseDirectory: File
   private lateinit var configuration: DocumentConfigurationServiceType
   private lateinit var http: LSHTTPClientType
   private lateinit var requestBuilderType: LSHTTPRequestBuilderType
+  private lateinit var requestType: LSHTTPRequestType
+  private lateinit var responseType: LSHTTPResponseType
 
   @BeforeEach
   fun setup() {
@@ -43,15 +64,18 @@ class DocumentStoreTest {
     configuration = Mockito.mock(DocumentConfigurationServiceType::class.java)
     http = Mockito.mock(LSHTTPClientType::class.java)
     requestBuilderType = Mockito.mock(LSHTTPRequestBuilderType::class.java)
+    requestType = Mockito.mock(LSHTTPRequestType::class.java)
+    responseType = Mockito.mock(LSHTTPResponseType::class.java)
 
     Mockito.`when`(assetManager.open(Mockito.anyString())).thenReturn(InputStream.nullInputStream())
     Mockito.`when`(http.newRequest(documentWithName.remoteURI)).thenReturn(requestBuilderType)
-    Mockito.`when`(http.newRequest(documentWithoutName.remoteURI)).thenReturn(requestBuilderType)
+    Mockito.`when`(requestBuilderType.build()).thenReturn(requestType)
+    Mockito.`when`(requestType.execute()).thenReturn(responseType)
+    Mockito.`when`(responseType.status).thenReturn(responseStatus)
   }
 
   @Test
   fun testReadableUrl() {
-
     Mockito.`when`(configuration.about).thenReturn(documentWithoutName)
     Mockito.`when`(configuration.privacyPolicy).thenReturn(documentWithName)
 
@@ -81,14 +105,16 @@ class DocumentStoreTest {
     Mockito.`when`(configuration.licenses).thenReturn(documentWithoutName)
     Mockito.`when`(configuration.privacyPolicy).thenReturn(documentWithoutName)
 
-    DocumentStores.create(
+    val store = DocumentStores.create(
       assetManager = assetManager,
       http = http,
       baseDirectory = baseDirectory,
       configuration = configuration
     )
 
-    Mockito.verify(http.newRequest(documentWithoutName.remoteURI), Mockito.times(0))
+    store.update(executor)
+
+    Mockito.verify(http, Mockito.times(0)).newRequest(documentWithoutName.remoteURI)
   }
 
   @Test
@@ -100,14 +126,16 @@ class DocumentStoreTest {
     Mockito.`when`(configuration.licenses).thenReturn(documentWithoutName)
     Mockito.`when`(configuration.privacyPolicy).thenReturn(documentWithoutName)
 
-    DocumentStores.create(
+    val store = DocumentStores.create(
       assetManager = assetManager,
       http = http,
       baseDirectory = baseDirectory,
       configuration = configuration
     )
 
-    Mockito.verify(http.newRequest(documentWithName.remoteURI), Mockito.times(1))
+    store.update(executor)
+
+    Mockito.verify(http, Mockito.times(1)).newRequest(documentWithName.remoteURI)
   }
 
   @Test
@@ -119,13 +147,16 @@ class DocumentStoreTest {
     Mockito.`when`(configuration.licenses).thenReturn(documentWithName)
     Mockito.`when`(configuration.privacyPolicy).thenReturn(documentWithName)
 
-    DocumentStores.create(
+    val store = DocumentStores.create(
       assetManager = assetManager,
       http = http,
       baseDirectory = baseDirectory,
       configuration = configuration
     )
 
-    Mockito.verify(http.newRequest(documentWithName.remoteURI), Mockito.times(6))
+    store.update(executor)
+
+    // the faq document is not updated
+    Mockito.verify(http, Mockito.times(5)).newRequest(documentWithName.remoteURI)
   }
 }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/documents/DocumentStoreTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/documents/DocumentStoreTest.kt
@@ -140,6 +140,10 @@ class DocumentStoreTest {
 
     store.update(executor)
 
+    // this sleep is needed for some reason when this test and the 'testAllDocumentUpdates' test
+    // are both called in the test suite
+    Thread.sleep(50)
+
     Mockito.verify(http, Mockito.times(1)).newRequest(documentWithName.remoteURI)
   }
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/documents/DocumentStoreTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/documents/DocumentStoreTest.kt
@@ -1,0 +1,131 @@
+package org.nypl.simplified.tests.documents
+
+import android.content.res.AssetManager
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.librarysimplified.documents.DocumentConfiguration
+import org.librarysimplified.documents.DocumentConfigurationServiceType
+import org.librarysimplified.documents.DocumentStores
+import org.librarysimplified.documents.DocumentType
+import org.librarysimplified.http.api.LSHTTPClientType
+import org.librarysimplified.http.api.LSHTTPRequestBuilderType
+import org.mockito.Mockito
+import org.nypl.simplified.tests.TestDirectories
+import java.io.File
+import java.io.InputStream
+import java.net.URI
+
+class DocumentStoreTest {
+
+  private val remoteURI = URI.create("https://www.thepalaceproject.org")
+
+  private val documentWithName = DocumentConfiguration(
+    name = "document.html",
+    remoteURI = remoteURI
+  )
+
+  private val documentWithoutName = DocumentConfiguration(
+    name = null,
+    remoteURI = remoteURI
+  )
+
+  private lateinit var assetManager: AssetManager
+  private lateinit var baseDirectory: File
+  private lateinit var configuration: DocumentConfigurationServiceType
+  private lateinit var http: LSHTTPClientType
+  private lateinit var requestBuilderType: LSHTTPRequestBuilderType
+
+  @BeforeEach
+  fun setup() {
+    assetManager = Mockito.mock(AssetManager::class.java)
+    baseDirectory = TestDirectories.temporaryDirectory()
+    configuration = Mockito.mock(DocumentConfigurationServiceType::class.java)
+    http = Mockito.mock(LSHTTPClientType::class.java)
+    requestBuilderType = Mockito.mock(LSHTTPRequestBuilderType::class.java)
+
+    Mockito.`when`(assetManager.open(Mockito.anyString())).thenReturn(InputStream.nullInputStream())
+    Mockito.`when`(http.newRequest(documentWithName.remoteURI)).thenReturn(requestBuilderType)
+    Mockito.`when`(http.newRequest(documentWithoutName.remoteURI)).thenReturn(requestBuilderType)
+  }
+
+  @Test
+  fun testReadableUrl() {
+
+    Mockito.`when`(configuration.about).thenReturn(documentWithoutName)
+    Mockito.`when`(configuration.privacyPolicy).thenReturn(documentWithName)
+
+    val documentsStore = DocumentStores.create(
+      assetManager = assetManager,
+      http = http,
+      baseDirectory = baseDirectory,
+      configuration = configuration
+    )
+
+    Assertions.assertTrue(documentsStore.about is DocumentType)
+    Assertions.assertTrue((documentsStore.about as DocumentType).readableURL == remoteURI.toURL())
+
+    Assertions.assertTrue(documentsStore.privacyPolicy is DocumentType)
+    Assertions.assertTrue(
+      (documentsStore.privacyPolicy as DocumentType).readableURL ==
+        File(baseDirectory, documentWithName.name.orEmpty()).toURI().toURL()
+    )
+  }
+
+  @Test
+  fun testNoDocumentUpdates() {
+    Mockito.`when`(configuration.about).thenReturn(documentWithoutName)
+    Mockito.`when`(configuration.acknowledgements).thenReturn(documentWithoutName)
+    Mockito.`when`(configuration.eula).thenReturn(documentWithoutName)
+    Mockito.`when`(configuration.faq).thenReturn(documentWithoutName)
+    Mockito.`when`(configuration.licenses).thenReturn(documentWithoutName)
+    Mockito.`when`(configuration.privacyPolicy).thenReturn(documentWithoutName)
+
+    DocumentStores.create(
+      assetManager = assetManager,
+      http = http,
+      baseDirectory = baseDirectory,
+      configuration = configuration
+    )
+
+    Mockito.verify(http.newRequest(documentWithoutName.remoteURI), Mockito.times(0))
+  }
+
+  @Test
+  fun testOneDocumentUpdate() {
+    Mockito.`when`(configuration.about).thenReturn(documentWithName)
+    Mockito.`when`(configuration.acknowledgements).thenReturn(documentWithoutName)
+    Mockito.`when`(configuration.eula).thenReturn(documentWithoutName)
+    Mockito.`when`(configuration.faq).thenReturn(documentWithoutName)
+    Mockito.`when`(configuration.licenses).thenReturn(documentWithoutName)
+    Mockito.`when`(configuration.privacyPolicy).thenReturn(documentWithoutName)
+
+    DocumentStores.create(
+      assetManager = assetManager,
+      http = http,
+      baseDirectory = baseDirectory,
+      configuration = configuration
+    )
+
+    Mockito.verify(http.newRequest(documentWithName.remoteURI), Mockito.times(1))
+  }
+
+  @Test
+  fun testAllDocumentUpdates() {
+    Mockito.`when`(configuration.about).thenReturn(documentWithName)
+    Mockito.`when`(configuration.acknowledgements).thenReturn(documentWithName)
+    Mockito.`when`(configuration.eula).thenReturn(documentWithName)
+    Mockito.`when`(configuration.faq).thenReturn(documentWithName)
+    Mockito.`when`(configuration.licenses).thenReturn(documentWithName)
+    Mockito.`when`(configuration.privacyPolicy).thenReturn(documentWithName)
+
+    DocumentStores.create(
+      assetManager = assetManager,
+      http = http,
+      baseDirectory = baseDirectory,
+      configuration = configuration
+    )
+
+    Mockito.verify(http.newRequest(documentWithName.remoteURI), Mockito.times(6))
+  }
+}

--- a/simplified-ui-settings/src/main/res/values/strings.xml
+++ b/simplified-ui-settings/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 
 <resources>
   <string name="settings">Settings</string>
-  <string name="settingsAbout">About</string>
+  <string name="settingsAbout">About Palace</string>
   <string name="settingsAboutSummary" />
   <string name="settingsAccounts">Libraries</string>
   <string name="settingsAccountsSummary">Add, remove, or configure libraries</string>


### PR DESCRIPTION
**What's this do?**
This PR adds the "About Palace" option to the Settings screen and changes the way how a preference is opened. If the document configuration's name is not null or blank, then the behavior remains the same, but if it's name or file are null, then the returned URI is the _remoteURI_ so it can be opened and handled by the WebView instead of opening a local file.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-There-is-no-an-About-Palace-item-0d3449f757bc4be2a7d08017f58223e8) to include this option on the settings of the Android app as it's already on the iOS settings screen.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Go to Settings
Confirm the ["About Palace" option](https://user-images.githubusercontent.com/79104027/207855237-cc773af7-2946-4679-994a-ad2ee20f41e0.png) is there
Click on "About Palace"
Confirm the ["About Palace" contents are displayed](https://user-images.githubusercontent.com/79104027/207855601-8bdcb59c-1406-48ee-bf22-845e295f2fbc.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 