### PR TITLE
Added ability to open the app when clicking on the audiobook's player notification

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -256,11 +256,12 @@
         <c:change date="2022-11-29T00:00:00+00:00" summary="Fixed audiobooks not pausing when headphones are unplugged."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-12-15T11:43:00+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
+    <c:release date="2023-01-11T18:30:22+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
       <c:changes>
         <c:change date="2022-12-12T00:00:00+00:00" summary="Changed the Switch's enabled color to green."/>
         <c:change date="2022-12-14T00:00:00+00:00" summary="Downgraded Gradle version."/>
-        <c:change date="2022-12-15T11:43:00+00:00" summary="Added &quot;About Palace&quot; option to Settings screen."/>
+        <c:change date="2022-12-15T00:00:00+00:00" summary="Added &quot;About Palace&quot; option to Settings screen."/>
+        <c:change date="2023-01-11T18:30:22+00:00" summary="Added ability to open the app when clicking on the audiobook's player notification."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-palace/src/main/AndroidManifest.xml
+++ b/simplified-app-palace/src/main/AndroidManifest.xml
@@ -81,8 +81,9 @@
       android:name="org.nypl.simplified.viewer.audiobook.AudioBookPlayerActivity"
       android:contentDescription="@string/app_name"
       android:exported="false"
-      android:screenOrientation="portrait"
       android:label="@string/app_name"
+      android:parentActivityName="org.nypl.simplified.main.MainActivity"
+      android:screenOrientation="portrait"
       android:theme="@style/PalaceTheme.NoActionBar" />
 
     <activity

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -31,6 +31,7 @@ import org.librarysimplified.audiobook.api.PlayerPlaybackRate
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.api.PlayerSleepTimer
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadExpired
 import org.librarysimplified.audiobook.api.PlayerType
@@ -798,6 +799,10 @@ class AudioBookPlayerActivity :
 
   override fun onPlayerNotificationWantsIntent(): Intent {
     return parentActivityIntent ?: intent
+  }
+
+  override fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration) {
+    // do nothing for now
   }
 
   override fun onPlayerTOCWantsBook(): PlayerAudioBookType {

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -796,6 +796,10 @@ class AudioBookPlayerActivity :
     }
   }
 
+  override fun onPlayerNotificationWantsIntent(): Intent {
+    return parentActivityIntent ?: intent
+  }
+
   override fun onPlayerTOCWantsBook(): PlayerAudioBookType {
     return this.book
   }


### PR DESCRIPTION
**What's this do?**
This PR adds support to the new method from the Audiobook submodule and returns the intent that should be opened when clicking on the audiobook's player notification

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-There-is-no-redirection-to-the-app-from-an-audiobook-playback-screen-in-notification-area-62d04cd1384e438a9fdb5d6bf605288b) saying the current audiobook player notification does nothing when it's clicked and it should redirect the user to the app.

**How should this be tested? / Do these changes have associated tests?**
Reproduce the same steps than [here](https://github.com/ThePalaceProject/android-audiobook/pull/53)

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-audiobook/pull/53) should be merged first

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 