### PR TITLE
Added sleepTimers to profile preferences

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -256,11 +256,12 @@
         <c:change date="2022-11-29T00:00:00+00:00" summary="Fixed audiobooks not pausing when headphones are unplugged."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-12-15T11:43:00+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
+    <c:release date="2023-01-12T13:03:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
       <c:changes>
         <c:change date="2022-12-12T00:00:00+00:00" summary="Changed the Switch's enabled color to green."/>
         <c:change date="2022-12-14T00:00:00+00:00" summary="Downgraded Gradle version."/>
-        <c:change date="2022-12-15T11:43:00+00:00" summary="Added &quot;About Palace&quot; option to Settings screen."/>
+        <c:change date="2022-12-15T00:00:00+00:00" summary="Added &quot;About Palace&quot; option to Settings screen."/>
+        <c:change date="2023-01-12T13:03:43+00:00" summary="Added sleepTimers to profile preferences so the user can save all audiobook's current sleep timers."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
+++ b/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
@@ -1,6 +1,7 @@
 package org.nypl.simplified.profiles.api
 
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate
+import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.reader.api.ReaderPreferences
 
@@ -37,6 +38,10 @@ data class ProfilePreferences(
   /** @return The playback rates for every audiobook */
 
   val playbackRates: Map<String, PlayerPlaybackRate>,
+
+  /** @return The sleep timer for every audiobook */
+
+  val sleepTimers: Map<String, PlayerSleepTimerConfiguration>,
 
   /** The most recently used account provider. */
 

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
@@ -500,7 +500,8 @@ object ProfilesDatabases {
               readerPreferences = ReaderPreferences.builder().build(),
               mostRecentAccount = account.id,
               hasSeenLibrarySelectionScreen = false,
-              playbackRates = hashMapOf()
+              playbackRates = hashMapOf(),
+              sleepTimers = hashMapOf()
             ),
             attributes = ProfileAttributes(sortedMapOf())
           )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.joda.time.DateTime
 import org.joda.time.DateTimeUtils
 import org.joda.time.DateTimeZone
+import org.joda.time.Duration
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -53,7 +54,8 @@ class ProfileDescriptionJSONTest {
           hasSeenLibrarySelectionScreen = false,
           readerPreferences = ReaderPreferences.builder().build(),
           mostRecentAccount = AccountID.generate(),
-          playbackRates = hashMapOf()
+          playbackRates = hashMapOf(),
+          sleepTimers = hashMapOf()
         ),
         attributes = ProfileAttributes(
           sortedMapOf(
@@ -139,6 +141,7 @@ class ProfileDescriptionJSONTest {
 
     assertEquals("", description.displayName)
     assertEquals(0, description.preferences.playbackRates.size)
+    assertEquals(0, description.preferences.sleepTimers.size)
     assertEquals(1.0, description.preferences.readerPreferences.brightness())
     assertEquals(100.0, description.preferences.readerPreferences.fontScale())
     assertEquals(ReaderFontSelection.READER_FONT_OPEN_DYSLEXIC, description.preferences.readerPreferences.fontFamily())
@@ -162,6 +165,24 @@ class ProfileDescriptionJSONTest {
     assertEquals("bookid2", description.preferences.playbackRates.keys.last())
     assertEquals(1.0, description.preferences.playbackRates["bookid1"]?.speed)
     assertEquals(1.25, description.preferences.playbackRates["bookid2"]?.speed)
+  }
+
+  @Test
+  fun testSleepTimers() {
+    val mapper = ObjectMapper()
+    val mostRecentAccountFallback = AccountID.generate()
+    val description =
+      ProfileDescriptionJSON.deserializeFromText(
+        mapper,
+        this.ofResource("profile-sleep-timers.json"),
+        mostRecentAccountFallback
+      )
+
+    assertEquals(2, description.preferences.sleepTimers.size)
+    assertEquals("bookid1", description.preferences.sleepTimers.keys.first())
+    assertEquals("bookid2", description.preferences.sleepTimers.keys.last())
+    assertEquals(Duration.standardMinutes(15L), description.preferences.sleepTimers["bookid1"]?.duration)
+    assertEquals(Duration.standardMinutes(30L), description.preferences.sleepTimers["bookid2"]?.duration)
   }
 
   /**

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
@@ -35,7 +35,8 @@ class MockProfile(
         hasSeenLibrarySelectionScreen = false,
         readerPreferences = ReaderPreferences.builder().build(),
         mostRecentAccount = this.accounts.firstKey(),
-        playbackRates = hashMapOf()
+        playbackRates = hashMapOf(),
+        sleepTimers = hashMapOf()
       ),
       attributes = ProfileAttributes(sortedMapOf())
     )

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-sleep-timers.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-sleep-timers.json
@@ -1,0 +1,25 @@
+{
+  "@version" : 20200504,
+  "displayName" : "",
+  "preferences" : {
+    "showTestingLibraries" : true,
+    "hasSeenLibrarySelectionScreen" : true,
+    "useExperimentalR2" : true,
+    "showDebugSettings" : true,
+    "mostRecentAccount" : "5310437f-db1a-492e-a09f-1ceaa43303dd",
+    "readerPreferences" : {
+      "font_scale" : 100.0,
+      "font_family" : "READER_FONT_OPEN_DYSLEXIC",
+      "color_scheme" : "SCHEME_WHITE_ON_BLACK"
+    },
+    "sleepTimers" : {
+      "bookid1" : "MINUTES_15",
+      "bookid2" : "MINUTES_30"
+    },
+    "dateOfBirth" : {
+      "date" : "2006-08-07",
+      "isSynthesized" : true
+    }
+  },
+  "attributes" : { }
+}

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -824,10 +824,6 @@ class AudioBookPlayerActivity :
     return parentActivityIntent ?: intent
   }
 
-  override fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration) {
-    // do nothing for now
-  }
-
   override fun onPlayerTOCWantsBook(): PlayerAudioBookType {
     return this.book
   }


### PR DESCRIPTION
**What's this do?**
This PR adds logic to support, save and update the sleep timer values set by the user for each audiobook

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Audiobook-sleep-timer-not-saved-after-closing-book-bab815834a374893a0588ca96fc8caa7) saying the sleep timer is not being restored when the user sets it and closes and reopens the book.

**How should this be tested? / Do these changes have associated tests?**
When [this PR](https://github.com/ThePalaceProject/android-audiobook/pull/54) is merged, reproduce the testing steps

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-audiobook/pull/54) needs to be merged first

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 