### PR TITLE
Display the search query on the search bar

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -256,14 +256,15 @@
         <c:change date="2022-11-29T00:00:00+00:00" summary="Fixed audiobooks not pausing when headphones are unplugged."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-01-17T17:46:24+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
+    <c:release date="2023-01-18T17:52:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
       <c:changes>
         <c:change date="2022-12-12T00:00:00+00:00" summary="Changed the Switch's enabled color to green."/>
         <c:change date="2022-12-14T00:00:00+00:00" summary="Downgraded Gradle version."/>
         <c:change date="2022-12-15T00:00:00+00:00" summary="Added &quot;About Palace&quot; option to Settings screen."/>
         <c:change date="2023-01-11T00:00:00+00:00" summary="Added ability to open the app when clicking on the audiobook's player notification."/>
         <c:change date="2023-01-13T00:00:00+00:00" summary="Added the ability to hide the toolbar and show the PDF title when pressing the PDF's webview."/>
-        <c:change date="2023-01-17T17:46:24+00:00" summary="Added sleepTimers to profile preferences so the user can save all audiobook's current sleep timers."/>
+        <c:change date="2023-01-17T00:00:00+00:00" summary="Added sleepTimers to profile preferences so the user can save all audiobook's current sleep timers."/>
+        <c:change date="2023-01-18T17:52:43+00:00" summary="Display the search query on the search bar."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -311,8 +311,8 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
       }
       is CatalogFeedArguments.CatalogFeedArgumentsRemote -> {
         val uri =
-          Uri.parse((parameters as CatalogFeedArguments.CatalogFeedArgumentsRemote).feedURI
-            .toString()
+          Uri.parse(
+            (parameters as CatalogFeedArguments.CatalogFeedArgumentsRemote).feedURI.toString()
           )
         uri.getQueryParameter("q").orEmpty()
       }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -5,12 +5,12 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.text.InputType
 import android.text.TextUtils
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
-import android.view.MenuItem
 import android.view.View
 import android.view.View.TEXT_ALIGNMENT_TEXT_END
 import android.view.ViewGroup
@@ -25,6 +25,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.AppCompatTextView
+import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.setPadding
@@ -295,6 +296,46 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
 
   override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
     inflater.inflate(R.menu.catalog, menu)
+
+    val search = menu.findItem(R.id.catalogMenuActionSearch)
+    val searchView = search.actionView as SearchView
+
+    searchView.imeOptions = EditorInfo.IME_ACTION_DONE
+    searchView.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_CAP_WORDS
+    searchView.queryHint = getString(R.string.catalogSearch)
+    searchView.maxWidth = toolbar.getAvailableWidthForSearchView()
+
+    val currentQuery = when (parameters) {
+      is CatalogFeedArguments.CatalogFeedArgumentsLocalBooks -> {
+        (parameters as CatalogFeedArguments.CatalogFeedArgumentsLocalBooks).searchTerms.orEmpty()
+      }
+      is CatalogFeedArguments.CatalogFeedArgumentsRemote -> {
+        val uri =
+          Uri.parse((parameters as CatalogFeedArguments.CatalogFeedArgumentsRemote).feedURI
+            .toString()
+          )
+        uri.getQueryParameter("q").orEmpty()
+      }
+    }
+
+    searchView.setQuery(currentQuery, false)
+
+    // if there's no query, the search should be iconified, i.e., collapsed
+    searchView.isIconified = currentQuery.isBlank()
+
+    searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+      override fun onQueryTextSubmit(query: String): Boolean {
+        val viewModel = this@CatalogFeedFragment.viewModel
+        viewModel.stateLive.value?.search?.let { search ->
+          viewModel.performSearch(search, query)
+        }
+        return true
+      }
+
+      override fun onQueryTextChange(newText: String): Boolean {
+        return true
+      }
+    })
   }
 
   override fun onPrepareOptionsMenu(menu: Menu) {
@@ -302,18 +343,6 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
 
     // Necessary to reconfigure the Toolbar here due to the "Switch Account" action.
     this.configureToolbar()
-  }
-
-  override fun onOptionsItemSelected(item: MenuItem): Boolean {
-    return when (item.itemId) {
-      R.id.catalogMenuActionSearch -> {
-        this.viewModel.stateLive.value?.search?.let { search ->
-          this.openSearchDialog(requireContext(), search)
-        }
-        true
-      }
-      else -> super.onOptionsItemSelected(item)
-    }
   }
 
   private fun refresh() {

--- a/simplified-ui-catalog/src/main/res/menu/catalog.xml
+++ b/simplified-ui-catalog/src/main/res/menu/catalog.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:app="http://schemas.android.com/apk/res-auto"
-  xmlns:android="http://schemas.android.com/apk/res/android">
-  <item
-    android:id="@+id/catalogMenuActionSearch"
-    android:icon="@drawable/search"
-    android:title="@string/catalogSearch"
-    app:showAsAction="ifRoom" />
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/catalogMenuActionSearch"
+        android:icon="@drawable/search"
+        android:title="@string/catalogSearch"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/simplified-ui-neutrality/src/main/java/org/nypl/simplified/ui/neutrality/NeutralToolbar.kt
+++ b/simplified-ui-neutrality/src/main/java/org/nypl/simplified/ui/neutrality/NeutralToolbar.kt
@@ -164,9 +164,8 @@ class NeutralToolbar(
   fun getAvailableWidthForSearchView(): Int {
     val fullWidth = this.resources.displayMetrics.widthPixels
 
-    // the contentInsetStartWithNavigation already returns the size of the navigation icon, so the
-    // available width for the SearchView can be calculated from the entire screen's width minus
-    // that value
-    return fullWidth - contentInsetStartWithNavigation
+    // the available width for the SearchView can be calculated from the entire screen's width minus
+    // the existing number of toolbar items + 1 corresponding to the icon/logo on the left
+    return fullWidth - (menu.size() + 1) * this.dpToPixelsReal(24).toInt()
   }
 }


### PR DESCRIPTION
**What's this do?**
This PR updates the logic of searching with a feed catalog by replacing the searching dialog with the native searchview on the toolbar so the current search query can be displayed when the results are shown. This PR also updates the method of calculating the available width to be filled by the SearchView

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-The-search-bar-is-not-displayed-when-the-search-result-is-opened-a610c54b37b342d0a910589f826bbb85) saying the Android app is not displaying the current search query to the user on the search bar and the Android app should match the iOS version regarding this functionality.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select any library
Click on the search icon
Confirm [you're now typing on the search view](https://user-images.githubusercontent.com/79104027/213258753-9c416da1-5e11-46bd-999a-d495ee40ca38.png)
Press the submit button the keyboard
Wait for the results to be loaded
Confirm [the searching query is now being displayed on the search bar](https://user-images.githubusercontent.com/79104027/213258838-a39bcce7-eb19-4c5c-84bd-73f8b7512c75.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 