### PR TITLE
Updated audiobook sleep timer stored value so the can be resumed

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -256,14 +256,15 @@
         <c:change date="2022-11-29T00:00:00+00:00" summary="Fixed audiobooks not pausing when headphones are unplugged."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-01-17T17:46:24+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
+    <c:release date="2023-01-19T10:47:10+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
       <c:changes>
         <c:change date="2022-12-12T00:00:00+00:00" summary="Changed the Switch's enabled color to green."/>
         <c:change date="2022-12-14T00:00:00+00:00" summary="Downgraded Gradle version."/>
         <c:change date="2022-12-15T00:00:00+00:00" summary="Added &quot;About Palace&quot; option to Settings screen."/>
         <c:change date="2023-01-11T00:00:00+00:00" summary="Added ability to open the app when clicking on the audiobook's player notification."/>
         <c:change date="2023-01-13T00:00:00+00:00" summary="Added the ability to hide the toolbar and show the PDF title when pressing the PDF's webview."/>
-        <c:change date="2023-01-17T17:46:24+00:00" summary="Added sleepTimers to profile preferences so the user can save all audiobook's current sleep timers."/>
+        <c:change date="2023-01-17T00:00:00+00:00" summary="Added sleepTimers to profile preferences so the user can save all audiobook's current sleep timers."/>
+        <c:change date="2023-01-19T10:47:10+00:00" summary="Updated audiobook sleep timer stored value so the can be resumed instead of recreated when reopening an audiobook."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
+++ b/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
@@ -1,7 +1,6 @@
 package org.nypl.simplified.profiles.api
 
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate
-import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.reader.api.ReaderPreferences
 
@@ -41,7 +40,7 @@ data class ProfilePreferences(
 
   /** @return The sleep timer for every audiobook */
 
-  val sleepTimers: Map<String, PlayerSleepTimerConfiguration>,
+  val sleepTimers: Map<String, Long>,
 
   /** The most recently used account provider. */
 

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
@@ -12,7 +12,6 @@ import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormatter
 import org.joda.time.format.DateTimeFormatterBuilder
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate
-import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.files.FileUtilities
 import org.nypl.simplified.json.core.JSONParseException
@@ -394,7 +393,7 @@ object ProfileDescriptionJSON {
   private fun deserializeSleepTimers(
     objectMapper: ObjectMapper,
     node: ObjectNode?
-  ): Map<String, PlayerSleepTimerConfiguration> {
+  ): Map<String, Long> {
 
     val str = JSONParserUtilities.getObjectOrNull(
       node, "sleepTimers"
@@ -408,7 +407,7 @@ object ProfileDescriptionJSON {
     )
 
     return map.mapValues { entry ->
-      PlayerSleepTimerConfiguration.valueOf(entry.value)
+      entry.value.toLong()
     }
   }
 
@@ -516,11 +515,11 @@ object ProfileDescriptionJSON {
 
   fun serializeSleepTimersToJSON(
     objectMapper: ObjectMapper,
-    sleepTimers: Map<String, PlayerSleepTimerConfiguration>
+    sleepTimers: Map<String, Long>
   ): ObjectNode {
     val objectNode = objectMapper.createObjectNode()
     sleepTimers.keys.forEach { key ->
-      objectNode.put(key, sleepTimers[key]?.name)
+      objectNode.put(key, sleepTimers[key])
     }
     return objectNode
   }

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
@@ -401,15 +401,19 @@ object ProfileDescriptionJSON {
 
     val map = objectMapper.readValue(
       str.toString(),
-      object : TypeReference<Map<String, String>>() {
+      object : TypeReference<Map<String, String?>>() {
         // Do nothing
       }
     )
 
     return map.mapValues { entry ->
-      try {
-        entry.value.toLong()
-      } catch (exception: NumberFormatException) {
+      if (entry.value != null) {
+        try {
+          entry.value?.toLong()
+        } catch (exception: NumberFormatException) {
+          0L
+        }
+      } else {
         null
       }
     }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
@@ -181,8 +181,8 @@ class ProfileDescriptionJSONTest {
     assertEquals(2, description.preferences.sleepTimers.size)
     assertEquals("bookid1", description.preferences.sleepTimers.keys.first())
     assertEquals("bookid2", description.preferences.sleepTimers.keys.last())
-    assertEquals(Duration.standardMinutes(15L), description.preferences.sleepTimers["bookid1"]?.duration)
-    assertEquals(Duration.standardMinutes(30L), description.preferences.sleepTimers["bookid2"]?.duration)
+    assertEquals(Duration.standardMinutes(15L).millis, description.preferences.sleepTimers["bookid1"])
+    assertEquals(Duration.standardMinutes(30L).millis, description.preferences.sleepTimers["bookid2"])
   }
 
   /**

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-sleep-timers.json
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/books/profile-sleep-timers.json
@@ -13,8 +13,8 @@
       "color_scheme" : "SCHEME_WHITE_ON_BLACK"
     },
     "sleepTimers" : {
-      "bookid1" : "MINUTES_15",
-      "bookid2" : "MINUTES_30"
+      "bookid1" : 900000,
+      "bookid2" : 1800000
     },
     "dateOfBirth" : {
       "date" : "2006-08-07",

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -543,7 +543,7 @@ class AudioBookPlayerActivity :
   private fun getBookSleepTimerRemainingDuration(): Long? {
     val sleepTimers = this.profilesController.profileCurrent().preferences().sleepTimers
     val bookID = this.parameters.bookID.value()
-    return if (sleepTimers.containsKey(bookID)){
+    return if (sleepTimers.containsKey(bookID)) {
       sleepTimers[bookID]
     } else {
       0L

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -473,7 +473,7 @@ class AudioBookPlayerActivity :
         this.playerFragment = PlayerFragment.newInstance(
           PlayerFragmentParameters(
             currentRate = getBookCurrentPlaybackRate(),
-            currentSleepTimerDuration = getBookSleepTimerMissingDuration()
+            currentSleepTimerDuration = getBookSleepTimerRemainingDuration()
           )
         )
 
@@ -540,7 +540,7 @@ class AudioBookPlayerActivity :
     return playbackRates[bookID]
   }
 
-  private fun getBookSleepTimerMissingDuration(): Long? {
+  private fun getBookSleepTimerRemainingDuration(): Long? {
     val sleepTimers = this.profilesController.profileCurrent().preferences().sleepTimers
     val bookID = this.parameters.bookID.value()
     return sleepTimers[bookID]
@@ -765,7 +765,7 @@ class AudioBookPlayerActivity :
         PlayerPlaybackRateFragment.newInstance(
           PlayerFragmentParameters(
             currentRate = getBookCurrentPlaybackRate(),
-            currentSleepTimerDuration = getBookSleepTimerMissingDuration()
+            currentSleepTimerDuration = getBookSleepTimerRemainingDuration()
           )
         )
       fragment.show(this.supportFragmentManager, "PLAYER_RATE")
@@ -784,11 +784,11 @@ class AudioBookPlayerActivity :
     }
   }
 
-  override fun onPlayerSleepTimerUpdated(missingDuration: Long?) {
+  override fun onPlayerSleepTimerUpdated(remainingDuration: Long?) {
     val sleepTimers =
       HashMap(this.profilesController.profileCurrent().preferences().sleepTimers)
     val bookID = this.parameters.bookID.value()
-    sleepTimers[bookID] = missingDuration
+    sleepTimers[bookID] = remainingDuration
 
     this.profilesController.profileUpdate { current ->
       current.copy(

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -31,7 +31,6 @@ import org.librarysimplified.audiobook.api.PlayerPlaybackRate
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerResult
 import org.librarysimplified.audiobook.api.PlayerSleepTimer
-import org.librarysimplified.audiobook.api.PlayerSleepTimerConfiguration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.PlayerSpineElementDownloadExpired
 import org.librarysimplified.audiobook.api.PlayerType
@@ -474,7 +473,7 @@ class AudioBookPlayerActivity :
         this.playerFragment = PlayerFragment.newInstance(
           PlayerFragmentParameters(
             currentRate = getBookCurrentPlaybackRate(),
-            currentSleepTimer = getBookCurrentSleepTimer()
+            currentSleepTimerDuration = getBookSleepTimerMissingDuration()
           )
         )
 
@@ -541,7 +540,7 @@ class AudioBookPlayerActivity :
     return playbackRates[bookID]
   }
 
-  private fun getBookCurrentSleepTimer(): PlayerSleepTimerConfiguration? {
+  private fun getBookSleepTimerMissingDuration(): Long? {
     val sleepTimers = this.profilesController.profileCurrent().preferences().sleepTimers
     val bookID = this.parameters.bookID.value()
     return sleepTimers[bookID]
@@ -766,7 +765,7 @@ class AudioBookPlayerActivity :
         PlayerPlaybackRateFragment.newInstance(
           PlayerFragmentParameters(
             currentRate = getBookCurrentPlaybackRate(),
-            currentSleepTimer = getBookCurrentSleepTimer()
+            currentSleepTimerDuration = getBookSleepTimerMissingDuration()
           )
         )
       fragment.show(this.supportFragmentManager, "PLAYER_RATE")
@@ -785,11 +784,11 @@ class AudioBookPlayerActivity :
     }
   }
 
-  override fun onPlayerSleepTimerUpdated(item: PlayerSleepTimerConfiguration) {
+  override fun onPlayerSleepTimerUpdated(missingDuration: Long?) {
     val sleepTimers =
       HashMap(this.profilesController.profileCurrent().preferences().sleepTimers)
     val bookID = this.parameters.bookID.value()
-    sleepTimers[bookID] = item
+    sleepTimers[bookID] = missingDuration
 
     this.profilesController.profileUpdate { current ->
       current.copy(


### PR DESCRIPTION
**What's this do?**
This PR updates the existing logic to save/restore the current audio book sleep timer value but it now updates the value every time the timer changes so the remaining duration can be stored and the timer doesn't get restarted every time the audiobook is opened.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a comment in [this ticket](https://www.notion.so/lyrasis/Audiobook-sleep-timer-not-saved-after-closing-book-bab815834a374893a0588ca96fc8caa7) saying the timer shouldn't be restarted when reopening the audiobook but resumed.

**How should this be tested? / Do these changes have associated tests?**
Follow [this PR](https://github.com/ThePalaceProject/android-audiobook/pull/55) testing steps once that and [this PR](https://github.com/ThePalaceProject/android-audiobook/pull/56) are merged

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-audiobook/pull/55) and [this PR](https://github.com/ThePalaceProject/android-audiobook/pull/56) need to be merged first

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 