### PR TITLE
Updated Readium version and automatically close the Keyboard after performing a search

### DIFF
--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedFragment.kt
@@ -329,6 +329,7 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
         viewModel.stateLive.value?.search?.let { search ->
           viewModel.performSearch(search, query)
         }
+        searchView.clearFocus()
         return true
       }
 
@@ -336,6 +337,8 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
         return true
       }
     })
+
+    searchView.clearFocus()
   }
 
   override fun onPrepareOptionsMenu(menu: Menu) {


### PR DESCRIPTION
**What's this do?**
This PR updates the Readium submodule version and automatically closes the keyboard after performing a new search.

**Why are we doing this? (w/ JIRA link if applicable)**
Regarding the Readium version, one of the latest changes on the Readium submodule is not being seen on the Palace app. Regarding a new search, there was a comment on [this ticket](https://www.notion.so/lyrasis/Android-The-search-bar-is-not-displayed-when-the-search-result-is-opened-a610c54b37b342d0a910589f826bbb85) suggesting this feature to be implemented

**How should this be tested? / Do these changes have associated tests?**
_Readium:_
Reproduce the steps of [this PR](https://github.com/ThePalaceProject/android-r2/pull/18/files)

_New search:_
Open the Palace app
Select any library
Perform any search and confirm [the keyboard is now being automatically closed](https://user-images.githubusercontent.com/79104027/213734062-df3dcbf9-d22a-4ffb-8fb4-89157fb1791d.mp4)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 