### PR TITLE
Fix Android Studio test build failure.

### DIFF
--- a/simplified-tests/build.gradle
+++ b/simplified-tests/build.gradle
@@ -6,6 +6,10 @@ android {
   }
 }
 
+configurations.all {
+  exclude group: 'com.google.code.findbugs', module: 'annotations'
+}
+
 dependencies {
 
   api project(":simplified-accessibility")

--- a/simplified-tests/build.gradle
+++ b/simplified-tests/build.gradle
@@ -1,4 +1,12 @@
 android {
+  packagingOptions {
+    // The PDF library and Readium both provide this shared library. This will
+    // cause the build to fail because Gradle doesn't know which one to pick.
+    pickFirst "lib/arm64-v8a/libc++_shared.so"
+    pickFirst "lib/armeabi-v7a/libc++_shared.so"
+    pickFirst "lib/x86/libc++_shared.so"
+  }
+
   testOptions {
     unitTests {
       includeAndroidResources = true


### PR DESCRIPTION
**What's this do?**

This fixes build errors that happen when attempting to run Android Instrumented Tests in Android Studio. It just copies some gradle configuration from other modules into simplified-tests, where it is also needed.

**Why are we doing this? (w/ JIRA link if applicable)**

I ran into this when trying to run unit tests in Android Studio. I accidentally ran the Android instrumented tests instead of the unit tests, and found that there were build errors. This fixes those build errors. Since we don't have Android instrumented tests, nothing happens, but at least there aren't errors that prevent you from seeing the result.

**How should this be tested? / Do these changes have associated tests?**

- In Android Studio, open the Project tree view. 
- Right click on android-core/simplified-tests and select `Run 'All Tests'`.

No tests will run, since we don't have any Android instrumented tests, but there should be no build errors.

**Dependencies for merging? Releasing to production?**

None

**Have you updated the changelog?**

No, these are not end-user visible changes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee verified that the build errors no longer happen.
