### PR TITLE
Change position of 'Remove' button

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -268,7 +268,7 @@
         <c:change date="2023-01-27T00:00:00+00:00" summary="Updated audiobook sleep timer stored value so the can be resumed instead of recreated when reopening an audiobook."/>
         <c:change date="2023-02-13T00:00:00+00:00" summary="Added support for book previews."/>
         <c:change date="2023-02-20T00:00:00+00:00" summary="Fixed some audio books not appearing in the bookshelf when offline."/>
-        <c:change date="2023-02-23T19:27:04+00:00" summary="Change position of 'Remove' button."/>
+        <c:change date="2023-02-23T19:27:04+00:00" summary="Moved 'Remove' button after 'Get' button on Reservations screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -256,7 +256,7 @@
         <c:change date="2022-11-29T00:00:00+00:00" summary="Fixed audiobooks not pausing when headphones are unplugged."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-02-20T20:13:35+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
+    <c:release date="2023-02-23T19:27:04+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
       <c:changes>
         <c:change date="2022-12-12T00:00:00+00:00" summary="Changed the Switch's enabled color to green."/>
         <c:change date="2022-12-14T00:00:00+00:00" summary="Downgraded Gradle version."/>
@@ -267,7 +267,8 @@
         <c:change date="2023-01-18T00:00:00+00:00" summary="Display the search query on the search bar."/>
         <c:change date="2023-01-27T00:00:00+00:00" summary="Updated audiobook sleep timer stored value so the can be resumed instead of recreated when reopening an audiobook."/>
         <c:change date="2023-02-13T00:00:00+00:00" summary="Added support for book previews."/>
-        <c:change date="2023-02-20T20:13:35+00:00" summary="Fixed some audio books not appearing in the bookshelf when offline."/>
+        <c:change date="2023-02-20T00:00:00+00:00" summary="Fixed some audio books not appearing in the bookshelf when offline."/>
+        <c:change date="2023-02-23T19:27:04+00:00" summary="Change position of 'Remove' button."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailFragment.kt
@@ -696,18 +696,7 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
       }
 
       is BookStatus.Held.HeldReady -> {
-        if (bookStatus.isRevocable) {
-          this.buttons.addView(
-            this.buttonCreator.createRevokeHoldButton(
-              onClick = {
-                this.viewModel.revokeMaybeAuthenticated()
-              }
-            )
-          )
-          this.buttons.addView(this.buttonCreator.createButtonSpace())
-        } else {
-          this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
-        }
+        this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
 
         this.buttons.addView(
           this.buttonCreator.createGetButton(
@@ -717,8 +706,19 @@ class CatalogBookDetailFragment : Fragment(R.layout.book_detail) {
           )
         )
 
-        // if the book is not revocable, we need to add a dummy button on the right
-        if (!bookStatus.isRevocable) {
+        if (bookStatus.isRevocable) {
+          this.buttons.addView(this.buttonCreator.createButtonSpace())
+
+          this.buttons.addView(
+            this.buttonCreator.createRevokeHoldButton(
+              onClick = {
+                this.viewModel.revokeMaybeAuthenticated()
+              }
+            )
+          )
+        } else {
+
+          // if the book is not revocable, we need to add a dummy button on the right
           this.buttons.addView(this.buttonCreator.createButtonSizedSpace())
         }
       }

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogPagedViewHolder.kt
@@ -400,18 +400,6 @@ class CatalogPagedViewHolder(
     this.setVisibilityIfNecessary(this.progress, View.GONE)
 
     this.idleButtons.removeAllViews()
-    if (status.isRevocable) {
-      this.idleButtons.addView(
-        this.buttonCreator.createRevokeHoldButton(
-          onClick = {
-            this.listener.revokeMaybeAuthenticated(book)
-          }
-        )
-      )
-      this.idleButtons.addView(
-        this.buttonCreator.createButtonSpace()
-      )
-    }
     this.idleButtons.addView(
       this.buttonCreator.createGetButton(
         onClick = {
@@ -419,6 +407,19 @@ class CatalogPagedViewHolder(
         }
       )
     )
+
+    if (status.isRevocable) {
+      this.idleButtons.addView(
+        this.buttonCreator.createButtonSpace()
+      )
+      this.idleButtons.addView(
+        this.buttonCreator.createRevokeHoldButton(
+          onClick = {
+            this.listener.revokeMaybeAuthenticated(book)
+          }
+        )
+      )
+    }
   }
 
   private fun onBookStatusHeldInQueue(


### PR DESCRIPTION
**What's this do?**
This PR updates the button creation logic to place the "Remove" after the "Get" button on a book reservation item.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-Get-button-doesn-t-appear-first-in-the-Reservations-tab-92d7261bfe974a2ea42aea527b7e616b) saying the iOS app has the buttons in a different order than the Android app and they should have both the same order.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads" library
If you already have a book reservation that is available, go to the "Reservations" tab and confirm the "Get" button appears before the "Remove" button
If you have no reservations at all, reserve a book and wait until it's available.

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 