### PR TITLE
Fixed book preview webview commands not working

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -256,7 +256,7 @@
         <c:change date="2022-11-29T00:00:00+00:00" summary="Fixed audiobooks not pausing when headphones are unplugged."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-02-20T20:13:35+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
+    <c:release date="2023-02-24T11:39:29+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.4.0">
       <c:changes>
         <c:change date="2022-12-12T00:00:00+00:00" summary="Changed the Switch's enabled color to green."/>
         <c:change date="2022-12-14T00:00:00+00:00" summary="Downgraded Gradle version."/>
@@ -267,7 +267,8 @@
         <c:change date="2023-01-18T00:00:00+00:00" summary="Display the search query on the search bar."/>
         <c:change date="2023-01-27T00:00:00+00:00" summary="Updated audiobook sleep timer stored value so the can be resumed instead of recreated when reopening an audiobook."/>
         <c:change date="2023-02-13T00:00:00+00:00" summary="Added support for book previews."/>
-        <c:change date="2023-02-20T20:13:35+00:00" summary="Fixed some audio books not appearing in the bookshelf when offline."/>
+        <c:change date="2023-02-20T00:00:00+00:00" summary="Fixed some audio books not appearing in the bookshelf when offline."/>
+        <c:change date="2023-02-24T11:39:29+00:00" summary="Fixed book preview webview commands not working."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -71,8 +71,11 @@
                 android:id="@+id/bookPreviewButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="@id/bookDetailTitle"
+                app:layout_constraintTop_toBottomOf="@id/bookDetailAuthors"
+                app:layout_constraintVertical_bias="1"
                 tools:text="@string/catalogBookPreviewBook" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/simplified-viewer-preview/src/main/java/org/nypl/simplified/viewer/preview/BookPreviewEmbeddedFragment.kt
+++ b/simplified-viewer-preview/src/main/java/org/nypl/simplified/viewer/preview/BookPreviewEmbeddedFragment.kt
@@ -49,6 +49,13 @@ class BookPreviewEmbeddedFragment : Fragment() {
     configureWebView()
   }
 
+  override fun onDestroyView() {
+    if (::webView.isInitialized) {
+      webView.destroy()
+    }
+    super.onDestroyView()
+  }
+
   private fun configureToolbar() {
     this.toolbar.setNavigationOnClickListener {
       requireActivity().finish()

--- a/simplified-viewer-preview/src/main/java/org/nypl/simplified/viewer/preview/BookPreviewEmbeddedFragment.kt
+++ b/simplified-viewer-preview/src/main/java/org/nypl/simplified/viewer/preview/BookPreviewEmbeddedFragment.kt
@@ -7,7 +7,9 @@ import android.view.ViewGroup
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.FrameLayout
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import org.nypl.simplified.webview.WebViewUtilities
 
@@ -57,7 +59,7 @@ class BookPreviewEmbeddedFragment : Fragment() {
   private fun configureWebView() {
     webView.apply {
       webViewClient = WebViewClient()
-      webChromeClient = WebChromeClient()
+      webChromeClient = CustomWebChromeClient()
       settings.allowFileAccess = true
       settings.javaScriptEnabled = true
       settings.domStorageEnabled = true
@@ -65,6 +67,37 @@ class BookPreviewEmbeddedFragment : Fragment() {
       WebViewUtilities.setForcedDark(settings, resources.configuration)
 
       loadUrl(requireArguments().getString(BUNDLE_EXTRA_URL).orEmpty())
+    }
+  }
+
+  inner class CustomWebChromeClient : WebChromeClient() {
+    private var fullscreenView: View? = null
+
+    override fun onHideCustomView() {
+      fullscreenView?.isVisible = false
+      webView.isVisible = true
+    }
+
+    override fun onShowCustomView(view: View?, callback: CustomViewCallback?) {
+
+      val decorView = requireActivity().window.decorView as? FrameLayout ?: return
+      webView.isVisible = false
+
+      if (fullscreenView != null) {
+        decorView.removeView(fullscreenView)
+      }
+
+      fullscreenView = view
+
+      decorView.addView(
+        fullscreenView,
+        FrameLayout.LayoutParams(
+          FrameLayout.LayoutParams.MATCH_PARENT,
+          FrameLayout.LayoutParams.MATCH_PARENT
+        )
+      )
+
+      fullscreenView?.isVisible = true
     }
   }
 }

--- a/simplified-viewer-preview/src/main/java/org/nypl/simplified/viewer/preview/BookPreviewEmbeddedFragment.kt
+++ b/simplified-viewer-preview/src/main/java/org/nypl/simplified/viewer/preview/BookPreviewEmbeddedFragment.kt
@@ -9,6 +9,9 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import org.nypl.simplified.webview.WebViewUtilities
@@ -78,11 +81,22 @@ class BookPreviewEmbeddedFragment : Fragment() {
   }
 
   inner class CustomWebChromeClient : WebChromeClient() {
+
+    private val window = requireActivity().window
+    private val windowInsetsController =
+      WindowCompat.getInsetsController(window, window.decorView)
+
     private var fullscreenView: View? = null
+
+    init {
+      windowInsetsController?.systemBarsBehavior =
+        WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+    }
 
     override fun onHideCustomView() {
       fullscreenView?.isVisible = false
       webView.isVisible = true
+      windowInsetsController?.show(WindowInsetsCompat.Type.systemBars())
     }
 
     override fun onShowCustomView(view: View?, callback: CustomViewCallback?) {
@@ -105,6 +119,7 @@ class BookPreviewEmbeddedFragment : Fragment() {
       )
 
       fullscreenView?.isVisible = true
+      windowInsetsController?.hide(WindowInsetsCompat.Type.systemBars())
     }
   }
 }

--- a/simplified-viewer-preview/src/main/res/layout/fragment_book_preview_audiobook.xml
+++ b/simplified-viewer-preview/src/main/res/layout/fragment_book_preview_audiobook.xml
@@ -13,6 +13,7 @@
         android:background="?attr/simplifiedColorBackground"
         android:minHeight="?attr/actionBarSize"
         android:padding="0dp"
+        android:theme="?android:attr/actionBarTheme"
         app:navigationIcon="@drawable/back"
         app:titleTextColor="?attr/simplifiedColorText"
         tools:title="Placeholder" />

--- a/simplified-viewer-preview/src/main/res/layout/fragment_book_preview_embedded.xml
+++ b/simplified-viewer-preview/src/main/res/layout/fragment_book_preview_embedded.xml
@@ -13,6 +13,7 @@
         android:background="?attr/simplifiedColorBackground"
         android:minHeight="?attr/actionBarSize"
         android:padding="0dp"
+        android:theme="?android:attr/actionBarTheme"
         app:navigationIcon="@drawable/back"
         app:titleTextColor="?attr/simplifiedColorText"
         tools:title="Placeholder" />


### PR DESCRIPTION
**What's this do?**
This PR updates the preview webview's WebChromeClient in order to handle some of the available commands. This also changes the webview and audiobook preview screens' toolbar back button color and fixes the audiobook preview's webview not being destroyed when returning from that screen.

**Why are we doing this? (w/ JIRA link if applicable)**
There was a [bug report](https://www.notion.so/lyrasis/Investigate-options-for-controlling-reader-for-Palace-Marketplace-previews-f04fb983e0f34f448bfab59bd424170f) saying the webview commands were not working for some previews. I've also noticed the audiobook and webview's preview screen back button color weren't properly set. There's also a [bug report](https://www.notion.so/lyrasis/OverDrive-audiobook-preview-keeps-playing-after-exiting-the-preview-26175c4568924102a8da788f28524eb4) saying the audiobook's previews are not being stopped when returning from the preview's webview player screen.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads" library
Open "A Guide to Tracing Your Family History Using the Census" book
Click on "Read Preview"
Confirm the [toolbar back arrow is now black](https://user-images.githubusercontent.com/79104027/221173511-452b6ab3-c33e-4ca2-beff-17490c193c71.png)
Click on the 3 dot icon and then on "Full screen"
Confirm the webview [is now in full screen mode](https://user-images.githubusercontent.com/79104027/221830152-f9be353e-54dd-4a59-80df-81e8e06ab505.png)
Click on the center of the screen, on the 3 dot icon again and then on "Exit full screen"
Confirm the webview is no longer in full screen mode
Click on the center of the screen and then drag the progress bar on the bottom
Confirm the book preview pages change
Click on the 3 dots icon and then on "Go to position"
Insert a page number and confirm the book preview is now on that page

(_Testing fix on audiobook previews not stopping_)
Go back and select "OverDrive Integration Test Library" library
Open any audiobook (p.e., "The Girl Who Loved Tom Gordon")
Click on "Play Sample"
Start playing the sample
Click on the back button
Confirm the audiobook's preview has stopped playing

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 