### PR TITLE
Upgrade actions to use node 16.

### DIFF
--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -9,12 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Build
         env:
@@ -27,7 +28,7 @@ jobs:
           CI_AWS_SECRET_KEY: ${{ secrets.CI_AWS_SECRET_KEY }}
         run: .ci/ci-main.sh normal
       - name: Upload test report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: junit-test-report

--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -9,17 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Build PR
         run: .ci/ci-main.sh pull-request
       - name: Upload test report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: junit-test-report

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Finish release
         run: .ci/ci-release-finish.sh --tag
       - name: Create GitHub release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
@@ -26,7 +26,7 @@ jobs:
           VERSION_NUM: ${{ env.VERSION_NUM }}
         with:
           tag_name: ${{ env.TAG_NAME }}
-          release_name: ${{ env.VERSION_NUM }}
+          name: ${{ env.VERSION_NUM }}
           body_path: ${{ env.RELEASE_NOTES_PATH }}
           draft: false
       - name: Build

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -5,11 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Verify release branch
@@ -40,7 +41,7 @@ jobs:
           TAG_NAME: ${{ env.TAG_NAME }}
         run: .ci/ci-main.sh normal
       - name: Upload test report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: junit-test-report


### PR DESCRIPTION
**What's this do?**

This upgrades github actions that are used in our workflows to versions that use Node 16 instead of Node 12.

**Why are we doing this? (w/ JIRA link if applicable)**

GitHub is disabling actions that use Node 12, which causes this warning when we run actions:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-java@v1, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

**How should this be tested? / Do these changes have associated tests?**

CI builds should continue to run successfully. The Node.js 12 warning should no longer appear.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

No, this is not a user visible change.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

The PR build works, but we need to merge this to main to be able to run some of the other actions.