### PR TITLE
Upgrade setup-java action to v3.

### DIFF
--- a/.github/workflows/android-main.yml
+++ b/.github/workflows/android-main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11

--- a/.github/workflows/android-pr.yml
+++ b/.github/workflows/android-pr.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout submodules
         run: git submodule update --init --recursive
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11


### PR DESCRIPTION
**What's this do?**

This is a follow-up to #171. In that PR I upgraded setup-java from v1 to v2, but I should have gone to v3, in order to use Node 16.

**Why are we doing this? (w/ JIRA link if applicable)**

GitHub is disabling actions that use Node 12, which causes this warning when we run actions:

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-java@v1, actions/upload-artifact@v2. For more information see: **https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.**

**How should this be tested? / Do these changes have associated tests?**

CI builds should continue to run successfully. The Node.js 12 warning should no longer appear.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

No, this is not a user visible change.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

The PR build works, but we need to merge this to main to be able to run some of the other actions.