### PR TITLE
Update reading position on play, pause, and stop

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -271,10 +271,9 @@
       </c:changes>
     </c:release>
     <c:release date="2023-03-14T23:06:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
-      <c:changes/>
-    </c:release>
-    <c:release date="2023-03-14T23:06:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.1">
+      <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -273,6 +273,9 @@
     <c:release date="2023-03-14T23:06:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes/>
     </c:release>
+    <c:release date="2023-03-14T23:06:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.1">
+        <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
+    </c:release>
   </c:releases>
   <c:ticket-systems>
     <c:ticket-system default="true" id="org.nypl.jira" url="https://jira.nypl.org/browse/"/>

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -649,18 +649,27 @@ class AudioBookPlayerActivity :
       }
 
       is PlayerEventPlaybackStarted -> {
-        this.savePlayerPosition(PlayerEventCreateBookmark(event.spineElement, event.offsetMilliseconds,
-          isLocalBookmark = false))
+        this.savePlayerPosition(PlayerEventCreateBookmark(
+          event.spineElement,
+          event.offsetMilliseconds,
+          isLocalBookmark = false)
+        )
       }
 
       is PlayerEventPlaybackPaused -> {
-        this.savePlayerPosition(PlayerEventCreateBookmark(event.spineElement, event.offsetMilliseconds,
-          isLocalBookmark = false))
+        this.savePlayerPosition(PlayerEventCreateBookmark(
+          event.spineElement,
+          event.offsetMilliseconds,
+          isLocalBookmark = false)
+        )
       }
 
       is PlayerEventPlaybackStopped -> {
-        this.savePlayerPosition(PlayerEventCreateBookmark(event.spineElement, event.offsetMilliseconds,
-          isLocalBookmark = false))
+        this.savePlayerPosition(PlayerEventCreateBookmark(
+          event.spineElement,
+          event.offsetMilliseconds,
+          isLocalBookmark = false)
+        )
       }
 
       is PlayerEventPlaybackBuffering,

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -667,11 +667,11 @@ class AudioBookPlayerActivity :
         this.savePlayerPosition(event)
       }
 
-      is PlayerEventPlaybackPaused  -> {
+      is PlayerEventPlaybackPaused -> {
         this.savePlayerPosition(event)
       }
 
-      is PlayerEventPlaybackStopped  -> {
+      is PlayerEventPlaybackStopped -> {
         this.savePlayerPosition(event)
       }
 

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.util.Log
 import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -319,6 +320,7 @@ class AudioBookPlayerActivity :
   }
 
   private fun savePlayerPosition(event: PlayerEventCreateBookmark) {
+    Log.d("savePlayerPosition", "bookmark created");
     savePlayerPosition(event as PlayerEvent.PlayerEventWithSpineElement, event.offsetMilliseconds)
   }
 

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
-import android.util.Log
 import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -320,7 +319,6 @@ class AudioBookPlayerActivity :
   }
 
   private fun savePlayerPosition(event: PlayerEventCreateBookmark) {
-    Log.d("savePlayerPosition", "bookmark created");
     savePlayerPosition(event as PlayerEvent.PlayerEventWithSpineElement, event.offsetMilliseconds)
   }
 

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -649,26 +649,32 @@ class AudioBookPlayerActivity :
       }
 
       is PlayerEventPlaybackStarted -> {
-        this.savePlayerPosition(PlayerEventCreateBookmark(
-          event.spineElement,
-          event.offsetMilliseconds,
-          isLocalBookmark = false)
+        this.savePlayerPosition(
+          PlayerEventCreateBookmark(
+            event.spineElement,
+            event.offsetMilliseconds,
+            isLocalBookmark = false
+          )
         )
       }
 
       is PlayerEventPlaybackPaused -> {
-        this.savePlayerPosition(PlayerEventCreateBookmark(
-          event.spineElement,
-          event.offsetMilliseconds,
-          isLocalBookmark = false)
+        this.savePlayerPosition(
+          PlayerEventCreateBookmark(
+            event.spineElement,
+            event.offsetMilliseconds,
+            isLocalBookmark = false
+          )
         )
       }
 
       is PlayerEventPlaybackStopped -> {
-        this.savePlayerPosition(PlayerEventCreateBookmark(
-          event.spineElement,
-          event.offsetMilliseconds,
-          isLocalBookmark = false)
+        this.savePlayerPosition(
+          PlayerEventCreateBookmark(
+            event.spineElement,
+            event.offsetMilliseconds,
+            isLocalBookmark = false
+          )
         )
       }
 

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -363,7 +363,6 @@ class AudioBookPlayerActivity :
           bookmark = bookmark
         )
       }
-
     } catch (e: Exception) {
       this.log.error("could not save player position: ", e)
     }

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -353,6 +353,81 @@ class AudioBookPlayerActivity :
     }
   }
 
+  private fun savePlayerPosition(event: PlayerEventPlaybackStarted) {
+    try {
+      val bookmark = Bookmark.AudiobookBookmark.create(
+        opdsId = this.parameters.opdsEntry.id,
+        location = PlayerPosition(
+          title = event.spineElement.position.title,
+          part = event.spineElement.position.part,
+          chapter = event.spineElement.position.chapter,
+          offsetMilliseconds = event.offsetMilliseconds
+        ),
+        duration = event.spineElement.duration?.millis ?: 0L,
+        kind = BookmarkKind.BookmarkLastReadLocation,
+        time = DateTime.now(),
+        deviceID = AudioBookDevices.deviceId(this.profilesController, this.parameters.bookID),
+        uri = null
+      )
+      this.bookmarkService.bookmarkCreateRemote(
+        accountID = this.parameters.accountID,
+        bookmark = bookmark
+      )
+    } catch (e: Exception) {
+      this.log.error("could not save player position: ", e)
+    }
+  }
+
+  private fun savePlayerPosition(event: PlayerEventPlaybackPaused) {
+    try {
+      val bookmark = Bookmark.AudiobookBookmark.create(
+        opdsId = this.parameters.opdsEntry.id,
+        location = PlayerPosition(
+          title = event.spineElement.position.title,
+          part = event.spineElement.position.part,
+          chapter = event.spineElement.position.chapter,
+          offsetMilliseconds = event.offsetMilliseconds
+        ),
+        duration = event.spineElement.duration?.millis ?: 0L,
+        kind = BookmarkKind.BookmarkLastReadLocation,
+        time = DateTime.now(),
+        deviceID = AudioBookDevices.deviceId(this.profilesController, this.parameters.bookID),
+        uri = null
+      )
+      this.bookmarkService.bookmarkCreateRemote(
+        accountID = this.parameters.accountID,
+        bookmark = bookmark
+      )
+    } catch (e: Exception) {
+      this.log.error("could not save player position: ", e)
+    }
+  }
+  private fun savePlayerPosition(event: PlayerEventPlaybackStopped) {
+    try {
+      val bookmark = Bookmark.AudiobookBookmark.create(
+        opdsId = this.parameters.opdsEntry.id,
+        location = PlayerPosition(
+          title = event.spineElement.position.title,
+          part = event.spineElement.position.part,
+          chapter = event.spineElement.position.chapter,
+          offsetMilliseconds = event.offsetMilliseconds
+        ),
+        duration = event.spineElement.duration?.millis ?: 0L,
+        kind = BookmarkKind.BookmarkLastReadLocation,
+        time = DateTime.now(),
+        deviceID = AudioBookDevices.deviceId(this.profilesController, this.parameters.bookID),
+        uri = null
+      )
+      this.bookmarkService.bookmarkCreateRemote(
+        accountID = this.parameters.accountID,
+        bookmark = bookmark
+      )
+    } catch (e: Exception) {
+      this.log.error("could not save player position: ", e)
+    }
+  }
+
+
   override fun onLoadingFragmentWantsIOExecutor(): ListeningExecutorService {
     return this.downloadExecutor
   }
@@ -648,11 +723,20 @@ class AudioBookPlayerActivity :
         this.savePlayerPosition(event)
       }
 
-      is PlayerEventPlaybackStarted,
+      is PlayerEventPlaybackStarted -> {
+        this.savePlayerPosition(event)
+      }
+
+      is PlayerEventPlaybackPaused  -> {
+        this.savePlayerPosition(event)
+      }
+
+      is PlayerEventPlaybackStopped  -> {
+        this.savePlayerPosition(event)
+      }
+
       is PlayerEventPlaybackBuffering,
       is PlayerEventPlaybackProgressUpdate,
-      is PlayerEventPlaybackPaused,
-      is PlayerEventPlaybackStopped,
       is PlayerEventPlaybackWaitingForAction -> {
       }
 

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -319,30 +319,15 @@ class AudioBookPlayerActivity :
   }
 
   private fun savePlayerPosition(event: PlayerEventCreateBookmark) {
-    savePlayerPosition(event as PlayerEvent.PlayerEventWithSpineElement, event.offsetMilliseconds)
-  }
-
-  private fun savePlayerPosition(event: PlayerEventPlaybackStarted) {
-    savePlayerPosition(event as PlayerEvent.PlayerEventWithSpineElement, event.offsetMilliseconds)
-  }
-
-  private fun savePlayerPosition(event: PlayerEventPlaybackPaused) {
-    savePlayerPosition(event as PlayerEvent.PlayerEventWithSpineElement, event.offsetMilliseconds)
-  }
-
-  private fun savePlayerPosition(event: PlayerEventPlaybackStopped) {
-    savePlayerPosition(event as PlayerEvent.PlayerEventWithSpineElement, event.offsetMilliseconds)
-  }
-
-  private fun savePlayerPosition(event: PlayerEvent.PlayerEventWithSpineElement, offsetMilliseconds: Long) {
     try {
+
       val bookmark = Bookmark.AudiobookBookmark.create(
         opdsId = this.parameters.opdsEntry.id,
         location = PlayerPosition(
           title = event.spineElement.position.title,
           part = event.spineElement.position.part,
           chapter = event.spineElement.position.chapter,
-          offsetMilliseconds = offsetMilliseconds
+          offsetMilliseconds = event.offsetMilliseconds
         ),
         duration = event.spineElement.duration?.millis ?: 0L,
         kind = BookmarkKind.BookmarkLastReadLocation,
@@ -351,7 +336,7 @@ class AudioBookPlayerActivity :
         uri = null
       )
 
-      if (event is PlayerEventCreateBookmark && event.isLocalBookmark) {
+      if (event.isLocalBookmark) {
         lastLocalBookmark = bookmark
         this.bookmarkService.bookmarkCreateLocal(
           accountID = this.parameters.accountID,
@@ -664,15 +649,18 @@ class AudioBookPlayerActivity :
       }
 
       is PlayerEventPlaybackStarted -> {
-        this.savePlayerPosition(event)
+        this.savePlayerPosition(PlayerEventCreateBookmark(event.spineElement, event.offsetMilliseconds,
+          isLocalBookmark = false))
       }
 
       is PlayerEventPlaybackPaused -> {
-        this.savePlayerPosition(event)
+        this.savePlayerPosition(PlayerEventCreateBookmark(event.spineElement, event.offsetMilliseconds,
+          isLocalBookmark = false))
       }
 
       is PlayerEventPlaybackStopped -> {
-        this.savePlayerPosition(event)
+        this.savePlayerPosition(PlayerEventCreateBookmark(event.spineElement, event.offsetMilliseconds,
+          isLocalBookmark = false))
       }
 
       is PlayerEventPlaybackBuffering,

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -319,15 +319,30 @@ class AudioBookPlayerActivity :
   }
 
   private fun savePlayerPosition(event: PlayerEventCreateBookmark) {
-    try {
+    savePlayerPosition(event as PlayerEvent.PlayerEventWithSpineElement, event.offsetMilliseconds)
+  }
 
+  private fun savePlayerPosition(event: PlayerEventPlaybackStarted) {
+    savePlayerPosition(event as PlayerEvent.PlayerEventWithSpineElement, event.offsetMilliseconds)
+  }
+
+  private fun savePlayerPosition(event: PlayerEventPlaybackPaused) {
+    savePlayerPosition(event as PlayerEvent.PlayerEventWithSpineElement, event.offsetMilliseconds)
+  }
+
+  private fun savePlayerPosition(event: PlayerEventPlaybackStopped) {
+    savePlayerPosition(event as PlayerEvent.PlayerEventWithSpineElement, event.offsetMilliseconds)
+  }
+
+  private fun savePlayerPosition(event: PlayerEvent.PlayerEventWithSpineElement, offsetMilliseconds: Long) {
+    try {
       val bookmark = Bookmark.AudiobookBookmark.create(
         opdsId = this.parameters.opdsEntry.id,
         location = PlayerPosition(
           title = event.spineElement.position.title,
           part = event.spineElement.position.part,
           chapter = event.spineElement.position.chapter,
-          offsetMilliseconds = event.offsetMilliseconds
+          offsetMilliseconds = offsetMilliseconds
         ),
         duration = event.spineElement.duration?.millis ?: 0L,
         kind = BookmarkKind.BookmarkLastReadLocation,
@@ -336,7 +351,7 @@ class AudioBookPlayerActivity :
         uri = null
       )
 
-      if (event.isLocalBookmark) {
+      if (event is PlayerEventCreateBookmark && event.isLocalBookmark) {
         lastLocalBookmark = bookmark
         this.bookmarkService.bookmarkCreateLocal(
           accountID = this.parameters.accountID,
@@ -348,85 +363,11 @@ class AudioBookPlayerActivity :
           bookmark = bookmark
         )
       }
-    } catch (e: Exception) {
-      this.log.error("could not save player position: ", e)
-    }
-  }
 
-  private fun savePlayerPosition(event: PlayerEventPlaybackStarted) {
-    try {
-      val bookmark = Bookmark.AudiobookBookmark.create(
-        opdsId = this.parameters.opdsEntry.id,
-        location = PlayerPosition(
-          title = event.spineElement.position.title,
-          part = event.spineElement.position.part,
-          chapter = event.spineElement.position.chapter,
-          offsetMilliseconds = event.offsetMilliseconds
-        ),
-        duration = event.spineElement.duration?.millis ?: 0L,
-        kind = BookmarkKind.BookmarkLastReadLocation,
-        time = DateTime.now(),
-        deviceID = AudioBookDevices.deviceId(this.profilesController, this.parameters.bookID),
-        uri = null
-      )
-      this.bookmarkService.bookmarkCreateRemote(
-        accountID = this.parameters.accountID,
-        bookmark = bookmark
-      )
     } catch (e: Exception) {
       this.log.error("could not save player position: ", e)
     }
   }
-
-  private fun savePlayerPosition(event: PlayerEventPlaybackPaused) {
-    try {
-      val bookmark = Bookmark.AudiobookBookmark.create(
-        opdsId = this.parameters.opdsEntry.id,
-        location = PlayerPosition(
-          title = event.spineElement.position.title,
-          part = event.spineElement.position.part,
-          chapter = event.spineElement.position.chapter,
-          offsetMilliseconds = event.offsetMilliseconds
-        ),
-        duration = event.spineElement.duration?.millis ?: 0L,
-        kind = BookmarkKind.BookmarkLastReadLocation,
-        time = DateTime.now(),
-        deviceID = AudioBookDevices.deviceId(this.profilesController, this.parameters.bookID),
-        uri = null
-      )
-      this.bookmarkService.bookmarkCreateRemote(
-        accountID = this.parameters.accountID,
-        bookmark = bookmark
-      )
-    } catch (e: Exception) {
-      this.log.error("could not save player position: ", e)
-    }
-  }
-  private fun savePlayerPosition(event: PlayerEventPlaybackStopped) {
-    try {
-      val bookmark = Bookmark.AudiobookBookmark.create(
-        opdsId = this.parameters.opdsEntry.id,
-        location = PlayerPosition(
-          title = event.spineElement.position.title,
-          part = event.spineElement.position.part,
-          chapter = event.spineElement.position.chapter,
-          offsetMilliseconds = event.offsetMilliseconds
-        ),
-        duration = event.spineElement.duration?.millis ?: 0L,
-        kind = BookmarkKind.BookmarkLastReadLocation,
-        time = DateTime.now(),
-        deviceID = AudioBookDevices.deviceId(this.profilesController, this.parameters.bookID),
-        uri = null
-      )
-      this.bookmarkService.bookmarkCreateRemote(
-        accountID = this.parameters.accountID,
-        bookmark = bookmark
-      )
-    } catch (e: Exception) {
-      this.log.error("could not save player position: ", e)
-    }
-  }
-
 
   override fun onLoadingFragmentWantsIOExecutor(): ListeningExecutorService {
     return this.downloadExecutor


### PR DESCRIPTION
**What's this do?**
Save listening position on play, pause, and stop

**Why are we doing this? (w/ JIRA link if applicable)**
Reduce server load
https://www.notion.so/lyrasis/Android-Save-listening-position-less-frequently-ff7c6dc43caa492d98105a48e56d4c26

**How should this be tested? / Do these changes have associated tests?**
Open an audiobook, navigate to another chapter in the book. Exit the audiobook and open the same audiobook within the same account on a different device and confirm the bookmark was saved.

You can also confirm that locations within chapters are saved and synced between different devices, in the same book and same account. 

**Dependencies for merging? Releasing to production?**
Related to: https://github.com/ThePalaceProject/android-audiobook/pull/58 (not a dependency)

**Have you updated the changelog?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes (@jdempcy)