### PR TITLE
Updated library logos loading source in registry feed

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,8 +270,10 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-03-14T23:06:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
-      <c:changes/>
+    <c:release date="2023-03-28T18:49:54+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+      <c:changes>
+        <c:change date="2023-03-28T18:49:54+00:00" summary="Updated library logos loading source in registry feed."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProviderDescriptionCollectionParser.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProviderDescriptionCollectionParser.kt
@@ -116,7 +116,7 @@ class AccountProviderDescriptionCollectionParser internal constructor(
       description = catalog.metadata.description,
       updated = updated!!,
       links = catalog.links,
-      images = listOf(),
+      images = catalog.images,
       isAutomatic = catalog.metadata.isAutomatic,
       isProduction = catalog.metadata.isProduction,
       location = location

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountProviderDescriptionCollectionParserTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountProviderDescriptionCollectionParserTest.kt
@@ -42,7 +42,7 @@ class AccountProviderDescriptionCollectionParserTest {
       val collection = success.result
       Assertions.assertEquals(182, collection.providers.size)
       Assertions.assertTrue(collection.providers.any { p -> p.links.isNotEmpty() })
-      Assertions.assertFalse(collection.providers.any { p -> p.images.isNotEmpty() })
+      Assertions.assertTrue(collection.providers.any { p -> p.images.isNotEmpty() })
       Assertions.assertEquals(4, collection.links.size)
       Assertions.assertEquals("Libraries", collection.metadata.title)
     }

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryViewModel.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountListRegistryViewModel.kt
@@ -23,7 +23,6 @@ import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryStatus
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
-import org.nypl.simplified.taskrecorder.api.TaskResult
 import org.nypl.simplified.threads.NamedThreadPools
 import org.slf4j.LoggerFactory
 import java.net.URI
@@ -150,30 +149,8 @@ class AccountListRegistryViewModel(private val locationManager: LocationManager)
    */
 
   fun determineAvailableAccountProviderDescriptions() {
-
     val accountListToDisplay = updateListToDisplay()
     accountProvidersList.onNext(accountListToDisplay)
-
-    this.backgroundExecutor.execute {
-
-      accountListToDisplay.filterNotNull().forEach {
-        val result = accountRegistry.resolve(
-          { _, _ -> },
-          it
-        )
-
-        when (result) {
-          is TaskResult.Success -> {
-            this.logger.debug("successfully resolved the account provider")
-          }
-          is TaskResult.Failure -> {
-            this.logger.error("failed to resolve account provider: ", result.exception)
-          }
-        }
-      }
-
-      accountProvidersList.onNext(updateListToDisplay())
-    }
   }
 
   private fun updateListToDisplay(): List<AccountProviderDescription?> {


### PR DESCRIPTION
**What's this do?**
This PR updates the source of the library logo loading by passing the catalog images list obtained from the catalog parsing instead of passing an empty list. Then, this PR removes theauthentication document fetching from the registry feed because it was retrieving a large document just to get a thumbnail image.

**Why are we doing this? (w/ JIRA link if applicable)**
The logic of downloading the library logos was a bit heavy for the app and the backend since the app was fetching the authentication document of each library when adding a library, as explained in [this ticket](https://www.notion.so/lyrasis/Android-Load-library-logos-from-s3-links-in-registry-feed-4227877d179d4a1ca943b39b9dca9d3a).

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Go to the Settings tab
Click on "Libraries"
Click on the + icon on the top right corner to add a library
Confirm the library logos are [immediately displayed](https://user-images.githubusercontent.com/79104027/228339498-c498eb74-7746-4977-a4f1-244e85c679fc.png)

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 