### PR TITLE
Hidden expired loans in offline mode

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,8 +270,10 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-03-14T23:06:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
-      <c:changes/>
+    <c:release date="2023-03-29T14:57:15+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+      <c:changes>
+        <c:change date="2023-03-29T14:57:15+00:00" summary="Hidden expired loans in offline mode."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>


### PR DESCRIPTION
**What's this do?**
This PR filters the loaned and available books with an expired loan end date.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-Hide-titles-on-My-Books-while-offline-if-expiry-date-has-passed-7ea413f3a3d5413a9eeec24d60f70b4a) to hide the expired books from "My Books" in offline mode.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads" library
Get some books if you don't have any on "My Books"
Close the app, turn off your internet connection and change the device's date to 1 or 2 months later
Still offline, return to the app and go to "My Books"
Confirm some or even all titles are not there

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 