### PR TITLE
Changed position and text of preview button

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,8 +270,11 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-03-14T23:06:06+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
-      <c:changes/>
+    <c:release date="2023-04-04T18:38:13+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+      <c:changes>
+        <c:change date="2023-04-04T00:00:00+00:00" summary="Changed position and text of preview button."/>
+        <c:change date="2023-04-04T18:38:13+00:00" summary="Removed preview button when the user already have the full book."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogBookDetailViewModel.kt
@@ -79,14 +79,11 @@ class CatalogBookDetailViewModel(
 
   private var feedEntry = parameters.feedEntry
 
-  private val bookPreviewStatusMutable: MutableLiveData<BookPreviewStatus> =
-    MutableLiveData(getBookPreviewStatus())
-
-  private val bookWithStatusMutable: MutableLiveData<BookWithStatus> =
-    MutableLiveData(this.createBookWithStatus())
+  private val bookWithStatusMutable: MutableLiveData<Pair<BookWithStatus, BookPreviewStatus>> =
+    MutableLiveData(Pair(this.createBookWithStatus(), getBookPreviewStatus()))
 
   private val bookWithStatus: BookWithStatus
-    get() = bookWithStatusMutable.value!!
+    get() = bookWithStatusMutable.value!!.first
 
   private val relatedBooksFeedStateMutable: MutableLiveData<CatalogFeedState?> =
     MutableLiveData(null)
@@ -109,7 +106,7 @@ class CatalogBookDetailViewModel(
 
   private fun onBookStatusEvent(event: BookStatusEvent) {
     val bookWithStatus = this.createBookWithStatus()
-    this.bookWithStatusMutable.value = bookWithStatus
+    this.bookWithStatusMutable.value = Pair(bookWithStatus, bookWithStatusMutable.value!!.second)
   }
 
   /*
@@ -153,11 +150,8 @@ class CatalogBookDetailViewModel(
     subscriptions.clear()
   }
 
-  val bookWithStatusLive: LiveData<BookWithStatus>
+  val bookWithStatusLive: LiveData<Pair<BookWithStatus, BookPreviewStatus>>
     get() = bookWithStatusMutable
-
-  val bookPreviewLive: LiveData<BookPreviewStatus>
-    get() = bookPreviewStatusMutable
 
   val accountProvider = try {
     this.profilesController.profileCurrent()
@@ -297,7 +291,7 @@ class CatalogBookDetailViewModel(
   override fun resetInitialBookStatus(feedEntry: FeedEntry.FeedEntryOPDS) {
     val initialBookStatus = synthesizeBookWithStatus(feedEntry)
     this.bookRegistry.update(initialBookStatus)
-    this.bookWithStatusMutable.value = initialBookStatus
+    this.bookWithStatusMutable.value = Pair(initialBookStatus, BookPreviewStatus.None)
   }
 
   override fun borrowMaybeAuthenticated(book: Book) {

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogButtons.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
+import org.nypl.simplified.books.book_database.api.BookFormats
 import org.nypl.simplified.ui.screen.ScreenSizeInformationType
 
 /**
@@ -178,6 +179,27 @@ class CatalogButtons(
       text = R.string.catalogRead,
       description = R.string.catalogAccessibilityBookRead,
       heightMatchParent = heightMatchParent,
+      onClick = onClick
+    )
+  }
+
+  @UiThread
+  fun createReadPreviewButton(
+    bookFormat: BookFormats.BookFormatDefinition?,
+    onClick: (Button) -> Unit
+  ): Button {
+    return this.createButton(
+      context = this.context,
+      text = if (bookFormat == BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO) {
+        R.string.catalogBookPreviewAudioBook
+      } else {
+        R.string.catalogBookPreviewBook
+      },
+      description = if (bookFormat == BookFormats.BookFormatDefinition.BOOK_FORMAT_AUDIO) {
+        R.string.catalogAccessibilityBookPreviewPlay
+      } else {
+        R.string.catalogAccessibilityBookPreviewRead
+      },
       onClick = onClick
     )
   }

--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -67,17 +67,6 @@
                 app:layout_constraintTop_toBottomOf="@id/bookDetailTitle"
                 tools:text="Mary Shelley" />
 
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/bookPreviewButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="@id/bookDetailTitle"
-                app:layout_constraintTop_toBottomOf="@id/bookDetailAuthors"
-                app:layout_constraintVertical_bias="1"
-                tools:text="@string/catalogBookPreviewBook" />
-
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <View

--- a/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
+++ b/simplified-ui-catalog/src/main/res/values/stringsCatalog.xml
@@ -9,6 +9,8 @@
   <string name="catalogAccessibilityBookErrorDismiss">Dismiss Button</string>
   <string name="catalogAccessibilityBookErrorRetry">Retry Button</string>
   <string name="catalogAccessibilityBookListen">Listen Button</string>
+  <string name="catalogAccessibilityBookPreviewPlay">Play Sample</string>
+  <string name="catalogAccessibilityBookPreviewRead">Read Sample</string>
   <string name="catalogAccessibilityBookRead">Read Button</string>
   <string name="catalogAccessibilityBookReserve">Reserve Button</string>
   <string name="catalogAccessibilityBookRevokeHold">Remove Button</string>
@@ -44,7 +46,7 @@
   <string name="catalogBookIntervalWeeksShort">w</string>
   <string name="catalogBookIntervalYearsShort">y</string>
   <string name="catalogBookPreviewAudioBook">Play Sample</string>
-  <string name="catalogBookPreviewBook">Read Preview</string>
+  <string name="catalogBookPreviewBook">Read Sample</string>
   <string name="catalogCancel">Cancel</string>
   <string name="catalogCancelHold">Remove</string>
   <string name="catalogCancelling">Cancelling…</string>


### PR DESCRIPTION
**What's this do?**
This PR updates the position of the preview button so it can be side by side with the other button options. This PR also hides the preview button in case the user already has the full book. Finally, the PR also changes the label "Read Preview" to "Read Sample"

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/Don-t-show-the-preview-button-after-the-user-gets-the-full-book-8b1caaf026c04e769361184f9f77415b) to update the preview button position, text and displaying logic to match the iOS version of the app.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open the "Palace Marketplace Integration Library"
Open the book "Love, Penelope" by Joanne Rocklin
Confirm the "Read Preview" button now says "Read Sample"
Get the book
Confirm the "Read Sample" button is no longer there

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 