### PR TITLE
Fixed WebView audiobook preview not pausing when earphones are unplugged

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,14 +270,15 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-04-06T16:24:51+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-04-11T08:09:57+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
         <c:change date="2023-04-06T00:00:00+00:00" summary="Hidden expired loans in offline mode."/>
         <c:change date="2023-04-06T00:00:00+00:00" summary="Changed position and text of preview button."/>
         <c:change date="2023-04-06T00:00:00+00:00" summary="Removed preview button when the user already have the full book."/>
-        <c:change date="2023-04-06T16:24:51+00:00" summary="Added support to the new Audible TOC."/>
+        <c:change date="2023-04-06T00:00:00+00:00" summary="Added support to the new Audible TOC."/>
+        <c:change date="2023-04-11T08:09:57+00:00" summary="Fixed WebView audiobook preview not pausing when earphones are unplugged."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-preview/src/main/assets/preview_player_commands.js
+++ b/simplified-viewer-preview/src/main/assets/preview_player_commands.js
@@ -1,0 +1,7 @@
+function pausePlayer() {
+    const button = document.getElementsByClassName('playback-toggle halo')[0];
+    const event = document.createEvent('HTMLEvents');
+
+    event.initEvent('click', true, true);
+    button.dispatchEvent(event);
+}

--- a/simplified-viewer-preview/src/main/assets/preview_player_commands.js
+++ b/simplified-viewer-preview/src/main/assets/preview_player_commands.js
@@ -1,7 +1,11 @@
-function pausePlayer() {
-    const button = document.getElementsByClassName('playback-toggle halo')[0];
-    const event = document.createEvent('HTMLEvents');
+PalacePreviewPlayerCommands = {
+  pausePlayer: () => {
+    const button = document.querySelector('button[aria-label="Pause"]');
+    if (button) {
+      const event = document.createEvent('HTMLEvents');
 
-    event.initEvent('click', true, true);
-    button.dispatchEvent(event);
-}
+      event.initEvent('click', true, true);
+      button.dispatchEvent(event);
+    }
+  }
+};


### PR DESCRIPTION
**What's this do?**
This PR runs a Javascript code block when the earphones are unplugged while the audiobook preview is being played, so the WebView can get that action and pause the preview.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/Android-Audiobook-samples-keep-playing-after-headphones-are-removed-2f32122e07e24bea8024716a73954634) saying that for some audiobooks the preview is not stopped when the earphones are unplugged.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "OverDrive Integration Test Library"
Open any audiobook
Click on "Play Sample"
Confirm the layout and commands are similar to [this](https://user-images.githubusercontent.com/79104027/231117054-c97eff43-49c5-412d-a812-81ea8a8edffa.png) (meaning it's a preview on a WebView)
Plug your earphones and start playing the preview
Unplug your earphones and confirm the preview is automatically paused

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 