### PR TITLE
Added support to audiobook bookmarks

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,14 +270,15 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-04-06T16:24:51+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-04-19T10:27:13+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
         <c:change date="2023-04-06T00:00:00+00:00" summary="Hidden expired loans in offline mode."/>
         <c:change date="2023-04-06T00:00:00+00:00" summary="Changed position and text of preview button."/>
         <c:change date="2023-04-06T00:00:00+00:00" summary="Removed preview button when the user already have the full book."/>
-        <c:change date="2023-04-06T16:24:51+00:00" summary="Added support to the new Audible TOC."/>
+        <c:change date="2023-04-06T00:00:00+00:00" summary="Added support to the new Audible TOC."/>
+        <c:change date="2023-04-19T10:27:13+00:00" summary="Added support to audiobook bookmarks."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookHelpers.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookHelpers.kt
@@ -1,11 +1,13 @@
 package org.nypl.simplified.viewer.audiobook
 
+import org.librarysimplified.audiobook.api.PlayerBookmark
 import org.librarysimplified.audiobook.manifest_fulfill.spi.ManifestFulfilled
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.bookmarks.api.BookmarkServiceUsableType
 import org.nypl.simplified.bookmarks.api.Bookmarks
 import org.nypl.simplified.books.api.BookID
 import org.nypl.simplified.books.api.bookmark.Bookmark
+import org.nypl.simplified.books.api.bookmark.BookmarkKind
 import org.nypl.simplified.books.book_database.api.BookDatabaseEntryFormatHandle.BookDatabaseEntryFormatHandleAudioBook
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.slf4j.LoggerFactory
@@ -92,5 +94,26 @@ internal object AudioBookHelpers {
     lastRead?.let(results::add)
     results.addAll(explicits)
     return results.toList()
+  }
+
+  fun toPlayerBookmark(bookmark: Bookmark.AudiobookBookmark): PlayerBookmark {
+    return PlayerBookmark(
+      date = bookmark.time,
+      position = bookmark.location,
+      duration = bookmark.duration,
+      uri = bookmark.uri
+    )
+  }
+
+  fun fromPlayerBookmark(opdsId: String, deviceID: String, playerBookmark: PlayerBookmark): Bookmark.AudiobookBookmark {
+    return Bookmark.AudiobookBookmark(
+      opdsId = opdsId,
+      deviceID = deviceID,
+      time = playerBookmark.date,
+      kind = BookmarkKind.BookmarkExplicit,
+      uri = playerBookmark.uri,
+      location = playerBookmark.position,
+      duration = playerBookmark.duration
+    )
   }
 }

--- a/simplified-viewer-audiobook/src/main/res/values/strings.xml
+++ b/simplified-viewer-audiobook/src/main/res/values/strings.xml
@@ -2,6 +2,9 @@
 
 <resources>
   <string name="audio_book_player">Audiobook Player</string>
+  <string name="audio_book_player_bookmark_added">Bookmark added</string>
+  <string name="audio_book_player_bookmark_already_added">There\'s already a bookmark on this position</string>
+  <string name="audio_book_player_bookmark_error_adding">There was an error while adding the bookmark</string>
   <string name="audio_book_player_do_keep">Keep</string>
   <string name="audio_book_player_do_return">Return</string>
   <string name="audio_book_player_error_book_open">Unable to open audio book</string>


### PR DESCRIPTION
**What's this do?**
This PR adds support to the audiobook bookmarks by keeping a list of the loaded bookmarks from the server and updating both locally and remotely when a bookmark is added or removed. Also, this PR adds some auxiliary methods to convert the `PlayerBookmark` class to a "normal" bookmark and the other way around.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Add-bookmarks-to-audiobooks-on-Android-dde1ef5897654609b2129673f2ca7ed6) to add support to the audiobook bookmarks as we currently have for the ebooks.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads"
Open any audiobook
Click on the bookmark icon
Open the TOC, swipe to Bookmarks and confirm the bookmark has been added
Return to the player, listen for a few more seconds, pause the player and add another bookmark
Then, while the player is still paused, try to add another bookmark.
Confirm a message saying there's already a bookmark for that position is shown
Open the TOC, open any random chapter
Open the TOC again, swipe to Bookmarks and click on one of your bookmarks
Confirm the player is now at the selected bookmark's position
Open the TOC again, swipe to Bookmarks and delete one of your bookmarks
Return to the player and close it
Reopen the audiobook, go to the TOC screen, swipe to bookmarks and confirm the deleted bookmark is no longer there

**Dependencies for merging? Releasing to production?**
This PR needs to be merged first

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 