### PR TITLE
Updated changelog

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -279,6 +279,7 @@
         <c:change date="2023-04-06T00:00:00+00:00" summary="Removed preview button when the user already have the full book."/>
         <c:change date="2023-04-06T00:00:00+00:00" summary="Added support to the new Audible TOC."/>
         <c:change date="2023-04-11T08:09:57+00:00" summary="Fixed WebView audiobook preview not pausing when earphones are unplugged."/>
+        <c:change date="2023-04-26T08:09:57+00:00" summary="Added support for Bluetooth audio controls to play, pause, and skip tracks."/>
       </c:changes>
     </c:release>
   </c:releases>


### PR DESCRIPTION
**What's this do?**
Updated changeling to include Bluetooth audio controls change. Now Bluetooth media controls (e.g. on headphones) can be used to play, pause, and skip to previous or next track.

**Why are we doing this? (w/ JIRA link if applicable)**
Bluetooth audio controls are useful for navigating via Bluetooth devices such as standalone media controllers or headphones.

**How should this be tested? / Do these changes have associated tests?**
Bluetooth headphones with a minimum of play, pause, next, and previous track (or standalone Bluetooth medial controls devices) should be used to test this.

**Dependencies for merging? Releasing to production?**
No dependencies.

**Have you updated the changelog?**
Yes.

**Has the application documentation been updated for these changes?**
No.

**Did someone actually run this code to verify it works?**
Yes, in the android-audiobook module demo activity. The integration testing will occur in the build of android-core.