### PR TITLE
Feature/add badge to holds tab

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,7 +270,7 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-04-27T09:01:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-05-02T22:31:26+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
@@ -280,7 +280,8 @@
         <c:change date="2023-04-06T00:00:00+00:00" summary="Added support to the new Audible TOC."/>
         <c:change date="2023-04-11T00:00:00+00:00" summary="Fixed WebView audiobook preview not pausing when earphones are unplugged."/>
         <c:change date="2023-04-26T00:00:00+00:00" summary="Added support for Bluetooth audio controls to play, pause, and skip tracks."/>
-        <c:change date="2023-04-27T09:01:38+00:00" summary="Added support to audiobook bookmarks."/>
+        <c:change date="2023-04-27T00:00:00+00:00" summary="Added support to audiobook bookmarks."/>
+        <c:change date="2023-05-02T22:31:26+00:00" summary="Added badge to holds tab with the number of available holds."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookHoldsUpdateEvent.kt
+++ b/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookHoldsUpdateEvent.kt
@@ -1,0 +1,3 @@
+package org.nypl.simplified.books.book_registry
+
+class BookHoldsUpdateEvent(val numberOfHolds: Int)

--- a/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookRegistry.kt
+++ b/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookRegistry.kt
@@ -21,6 +21,8 @@ class BookRegistry private constructor(
     Collections.unmodifiableSortedMap(this.books)
   private val observable: PublishSubject<BookStatusEvent> =
     PublishSubject.create()
+  private val bookHoldsUpdate: PublishSubject<BookHoldsUpdateEvent> =
+    PublishSubject.create()
 
   override fun books(): SortedMap<BookID, BookWithStatus> {
     return this.booksReadOnly
@@ -28,6 +30,10 @@ class BookRegistry private constructor(
 
   override fun bookEvents(): Observable<BookStatusEvent> {
     return this.observable
+  }
+
+  override fun bookHoldsUpdateEvents(): Observable<BookHoldsUpdateEvent> {
+    return this.bookHoldsUpdate
   }
 
   override fun bookStatus(id: BookID): OptionType<BookStatus> {
@@ -97,6 +103,14 @@ class BookRegistry private constructor(
     if (oldStatus != null) {
       this.observable.onNext(BookStatusEvent.BookStatusEventRemoved(id, oldStatus.status))
     }
+  }
+
+  override fun updateHolds(numberOfHolds: Int) {
+    this.bookHoldsUpdate.onNext(
+      BookHoldsUpdateEvent(
+        numberOfHolds = numberOfHolds
+      )
+    )
   }
 
   companion object {

--- a/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookRegistryReadableType.kt
+++ b/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookRegistryReadableType.kt
@@ -30,6 +30,12 @@ interface BookRegistryReadableType {
   fun bookEvents(): Observable<BookStatusEvent>
 
   /**
+   * @return An observable that publishes book holds events
+   */
+
+  fun bookHoldsUpdateEvents(): Observable<BookHoldsUpdateEvent>
+
+  /**
    * @param id The book ID
    * @return The status for the given book, if any.
    */

--- a/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookRegistryType.kt
+++ b/simplified-books-registry-api/src/main/java/org/nypl/simplified/books/book_registry/BookRegistryType.kt
@@ -34,4 +34,10 @@ interface BookRegistryType : BookRegistryReadableType {
    */
 
   fun clearFor(id: BookID)
+
+  /**
+   * Update the current number of holds the current logged user has.
+   */
+
+  fun updateHolds(numberOfHolds: Int)
 }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragment.kt
@@ -280,7 +280,6 @@ class MainFragment : Fragment(R.layout.main_tabbed_host) {
     }
   }
 
-
   private fun checkForAnnouncements() {
     val currentProfile = this.viewModel.profilesController.profileCurrent()
     val mostRecentAccountId = currentProfile.preferences().mostRecentAccount

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
@@ -1,29 +1,53 @@
 package org.nypl.simplified.main
 
+import android.content.res.Resources
 import androidx.lifecycle.ViewModel
 import hu.akarnokd.rxjava2.subjects.UnicastWorkSubject
+import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposable
+import io.reactivex.schedulers.Schedulers
 import org.librarysimplified.services.api.Services
 import org.nypl.simplified.accounts.api.AccountEvent
+import org.nypl.simplified.accounts.api.AccountLoginState
 import org.nypl.simplified.accounts.registry.api.AccountProviderRegistryType
+import org.nypl.simplified.books.book_registry.BookHoldsUpdateEvent
 import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.books.book_registry.BookStatusEvent
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
+import org.nypl.simplified.feeds.api.FeedBooksSelection
+import org.nypl.simplified.feeds.api.FeedEntry
+import org.nypl.simplified.feeds.api.FeedFacet
+import org.nypl.simplified.feeds.api.FeedFacetPseudoTitleProviderType
+import org.nypl.simplified.opds.core.OPDSAvailabilityHeldReady
 import org.nypl.simplified.profiles.api.ProfileEvent
+import org.nypl.simplified.profiles.controller.api.ProfileFeedRequest
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
+import org.nypl.simplified.ui.catalog.R
+import java.net.URI
+import java.util.concurrent.TimeUnit
 
 /**
  * The view model for the main fragment.
  */
 
-class MainFragmentViewModel : ViewModel() {
+class MainFragmentViewModel(
+  private val resources: Resources
+) : ViewModel() {
+
+  companion object {
+    // 30 minutes in milliseconds
+    private const val REQUEST_HOLDS_INTERVAL = 30 * 60 * 1000L
+  }
 
   val accountEvents: UnicastWorkSubject<AccountEvent> =
     UnicastWorkSubject.create()
   val profileEvents: UnicastWorkSubject<ProfileEvent> =
     UnicastWorkSubject.create()
   val registryEvents: UnicastWorkSubject<BookStatusEvent> =
+    UnicastWorkSubject.create()
+  val bookHoldEvents: UnicastWorkSubject<BookHoldsUpdateEvent> =
     UnicastWorkSubject.create()
 
   private val services =
@@ -43,6 +67,8 @@ class MainFragmentViewModel : ViewModel() {
   private val subscriptions: CompositeDisposable =
     CompositeDisposable()
 
+  private var holdsCallSubscription: Disposable? = null
+
   init {
     profilesController.accountEvents()
       .observeOn(AndroidSchedulers.mainThread())
@@ -59,10 +85,72 @@ class MainFragmentViewModel : ViewModel() {
       .observeOn(AndroidSchedulers.mainThread())
       .subscribe(this::onProfileEvent)
       .let { subscriptions.add(it) }
+
+    this.bookRegistry.bookHoldsUpdateEvents()
+      .observeOn(AndroidSchedulers.mainThread())
+      .subscribe(this::onBookHoldsUpdateEvent)
+      .let { subscriptions.add(it) }
+
+    initializeHoldsCallTimer()
   }
 
   private fun onProfileEvent(event: ProfileEvent) {
     profileEvents.onNext(event)
+    initializeHoldsCallTimer()
+  }
+
+  private fun onBookHoldsUpdateEvent(event: BookHoldsUpdateEvent) {
+    bookHoldEvents.onNext(event)
+  }
+
+  private fun initializeHoldsCallTimer() {
+    holdsCallSubscription?.dispose()
+    holdsCallSubscription = Observable.interval(
+      0L, REQUEST_HOLDS_INTERVAL, TimeUnit.MILLISECONDS
+    )
+      .filter {
+        val getHolds = showHoldsTab &&
+          profilesController.profileCurrent().mostRecentAccount().loginState is
+            AccountLoginState.AccountLoggedIn
+
+        if (!getHolds) {
+          bookRegistry.updateHolds(
+            numberOfHolds = 0
+          )
+        }
+
+        getHolds
+      }
+      .map {
+        val booksUri = URI.create("Books")
+        val request =
+          ProfileFeedRequest(
+            facetTitleProvider = CatalogFacetPseudoTitleProvider(this.resources),
+            feedSelection = FeedBooksSelection.BOOKS_FEED_HOLDS,
+            filterByAccountID = profilesController.profileCurrent().mostRecentAccount().id,
+            search = null,
+            sortBy = FeedFacet.FeedFacetPseudo.Sorting.SortBy.SORT_BY_TITLE,
+            title = "Reservations",
+            uri = booksUri
+          )
+
+        val numberOfHolds = this.profilesController.profileFeed(request)
+          .get()
+          .entriesInOrder
+          .filter { feedEntry ->
+            feedEntry is FeedEntry.FeedEntryOPDS &&
+              feedEntry.feedEntry.availability is OPDSAvailabilityHeldReady
+          }
+          .size
+
+        bookRegistry.updateHolds(
+          numberOfHolds = numberOfHolds
+        )
+      }
+      .subscribeOn(Schedulers.io())
+      .subscribe()
+
+    subscriptions.add(holdsCallSubscription!!)
   }
 
   init {
@@ -79,5 +167,26 @@ class MainFragmentViewModel : ViewModel() {
   override fun onCleared() {
     super.onCleared()
     subscriptions.clear()
+  }
+
+  private class CatalogFacetPseudoTitleProvider(
+    val resources: Resources
+  ) : FeedFacetPseudoTitleProviderType {
+    override val sortByTitle: String
+      get() = this.resources.getString(R.string.feedByTitle)
+    override val sortByAuthor: String
+      get() = this.resources.getString(R.string.feedByAuthor)
+    override val collection: String
+      get() = this.resources.getString(R.string.feedCollection)
+    override val collectionAll: String
+      get() = this.resources.getString(R.string.feedCollectionAll)
+    override val sortBy: String
+      get() = this.resources.getString(R.string.feedSortBy)
+    override val show: String
+      get() = this.resources.getString(R.string.feedShow)
+    override val showAll: String
+      get() = this.resources.getString(R.string.feedShowAll)
+    override val showOnLoan: String
+      get() = this.resources.getString(R.string.feedShowOnLoan)
   }
 }

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
@@ -111,7 +111,7 @@ class MainFragmentViewModel(
       .filter {
         val getHolds = showHoldsTab &&
           profilesController.profileCurrent().mostRecentAccount().loginState is
-            AccountLoginState.AccountLoggedIn
+          AccountLoginState.AccountLoggedIn
 
         if (!getHolds) {
           bookRegistry.updateHolds(

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModelFactory.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModelFactory.kt
@@ -1,0 +1,25 @@
+package org.nypl.simplified.main
+
+import android.content.res.Resources
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import org.slf4j.LoggerFactory
+
+/**
+ * A view model factory that can produce view models for each of the sections of the application
+ * that view feeds.
+ */
+
+class MainFragmentViewModelFactory(
+  private val resources: Resources
+) : ViewModelProvider.Factory {
+
+  private val logger =
+    LoggerFactory.getLogger(MainFragmentViewModelFactory::class.java)
+
+  override fun <T : ViewModel> create(modelClass: Class<T>): T {
+    this.logger.debug("requested creation of view model of type {}", modelClass)
+
+    return MainFragmentViewModel(resources) as T
+  }
+}

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedArguments.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedArguments.kt
@@ -61,7 +61,8 @@ sealed class CatalogFeedArguments : Serializable {
     val sortBy: SortBy = SortBy.SORT_BY_TITLE,
     val searchTerms: String?,
     val selection: FeedBooksSelection,
-    val filterAccount: AccountID?
+    val filterAccount: AccountID?,
+    val updateHolds: Boolean
   ) : CatalogFeedArguments() {
     override val isSearchResults: Boolean = false
     override val isLocallyGenerated: Boolean = true

--- a/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/nypl/simplified/ui/catalog/CatalogFeedViewModel.kt
@@ -46,6 +46,7 @@ import org.nypl.simplified.feeds.api.FeedSearch
 import org.nypl.simplified.futures.FluentFutureExtensions.map
 import org.nypl.simplified.futures.FluentFutureExtensions.onAnyError
 import org.nypl.simplified.listeners.api.FragmentListenerType
+import org.nypl.simplified.opds.core.OPDSAvailabilityHeldReady
 import org.nypl.simplified.opds.core.OPDSAvailabilityLoaned
 import org.nypl.simplified.opds.core.getOrNull
 import org.nypl.simplified.profiles.api.ProfileDateOfBirth
@@ -350,6 +351,14 @@ class CatalogFeedViewModel(
           feedEntry is FeedEntry.FeedEntryOPDS &&
             feedEntry.feedEntry.availability is OPDSAvailabilityLoaned &&
             feedEntry.feedEntry.availability.endDate.getOrNull()?.isBeforeNow == true
+        }
+        if (arguments.updateHolds) {
+          bookRegistry.updateHolds(
+            numberOfHolds = feed.entriesInOrder.filter { feedEntry ->
+              feedEntry is FeedEntry.FeedEntryOPDS &&
+                feedEntry.feedEntry.availability is OPDSAvailabilityHeldReady
+            }.size
+          )
         }
         FeedLoaderResult.FeedLoaderSuccess(feed) as FeedLoaderResult
       }
@@ -770,7 +779,8 @@ class CatalogFeedViewModel(
               searchTerms = query,
               selection = currentArguments.selection,
               sortBy = currentArguments.sortBy,
-              title = currentArguments.title
+              title = currentArguments.title,
+              updateHolds = currentArguments.updateHolds
             )
           }
           is FeedSearch.FeedSearchOpen1_1 -> {
@@ -780,7 +790,8 @@ class CatalogFeedViewModel(
               searchTerms = query,
               selection = currentArguments.selection,
               sortBy = currentArguments.sortBy,
-              title = currentArguments.title
+              title = currentArguments.title,
+              updateHolds = currentArguments.updateHolds
             )
           }
         }
@@ -869,7 +880,8 @@ class CatalogFeedViewModel(
               searchTerms = currentArguments.searchTerms,
               selection = currentArguments.selection,
               sortBy = facet.sortBy,
-              title = facet.title
+              title = facet.title,
+              updateHolds = currentArguments.updateHolds
             )
 
           is FilteringForAccount ->
@@ -879,7 +891,8 @@ class CatalogFeedViewModel(
               searchTerms = currentArguments.searchTerms,
               selection = currentArguments.selection,
               sortBy = currentArguments.sortBy,
-              title = facet.title
+              title = facet.title,
+              updateHolds = currentArguments.updateHolds
             )
         }
       }

--- a/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/BottomNavigators.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/nypl/simplified/ui/navigation/tabs/BottomNavigators.kt
@@ -185,7 +185,8 @@ object BottomNavigators {
         searchTerms = null,
         selection = FeedBooksSelection.BOOKS_FEED_HOLDS,
         sortBy = FeedFacet.FeedFacetPseudo.Sorting.SortBy.SORT_BY_TITLE,
-        title = context.getString(R.string.tabHolds)
+        title = context.getString(R.string.tabHolds),
+        updateHolds = true
       )
     )
   }
@@ -221,7 +222,8 @@ object BottomNavigators {
         searchTerms = null,
         selection = FeedBooksSelection.BOOKS_FEED_LOANED,
         sortBy = FeedFacet.FeedFacetPseudo.Sorting.SortBy.SORT_BY_TITLE,
-        title = context.getString(R.string.tabBooks)
+        title = context.getString(R.string.tabBooks),
+        updateHolds = false
       )
     )
   }

--- a/simplified-ui-navigation-tabs/src/main/res/drawable/background_menu_item_badge.xml
+++ b/simplified-ui-navigation-tabs/src/main/res/drawable/background_menu_item_badge.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="24dp" />
+    <solid android:color="#F73A29" />
+</shape>

--- a/simplified-ui-navigation-tabs/src/main/res/layout/layout_menu_item_badge.xml
+++ b/simplified-ui-navigation-tabs/src/main/res/layout/layout_menu_item_badge.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/badgeView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5" />
+
+    <TextView
+        android:id="@+id/badgeNumber"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginTop="2dp"
+        android:layout_marginEnd="4dp"
+        android:background="@drawable/background_menu_item_badge"
+        android:gravity="center"
+        android:padding="2dp"
+        android:textColor="@color/white"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="10" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**What's this do?**
This PR adds logic to make automatic requests to retrieve the number of loans and to show/hide/update a badge with the available holds next to the "Holds" tab icon.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Add-badge-number-to-indicate-when-a-reservation-is-available-892d0e77b27a45db8abfa8e9bb5a24b1) to add this badge and repeated automatic requests from time to time to make the app similar to the iOS version.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app in two different devices and with two different accounts for the LYRASIS Reads
Search for the audiobook "In Defense of Open Society" (or any other book / audiobook with just one available copy) on both devices
On one device, get the book
On the other device, click on "Reserve"
Go to the "Holds" tab and confirm there's a title in there
On the first device, return the book
On the second device, close and reopen the app and confirm a badge with the number "1" appears on the "Holds" tab
Go to the "Holds tab" on the second device, get the book and confirm the badge is now gone

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 