### PR TITLE
Updated changelog: always show lock screen audio controls

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -282,6 +282,7 @@
         <c:change date="2023-04-26T00:00:00+00:00" summary="Added support for Bluetooth audio controls to play, pause, and skip tracks."/>
         <c:change date="2023-04-27T00:00:00+00:00" summary="Added support to audiobook bookmarks."/>
         <c:change date="2023-05-02T22:31:26+00:00" summary="Added badge to holds tab with the number of available holds."/>
+        <c:change date="2023-05-09T22:31:26+00:00" summary="Always show audio controls on lock screen."/>
       </c:changes>
     </c:release>
   </c:releases>


### PR DESCRIPTION
**What's this do?**
Update changelog to include new change to android-audiobook to always show lock screen audio controls.

**Why are we doing this? (w/ JIRA link if applicable)**
Better user experience. 
[android-audiobook PR here] (https://github.com/ThePalaceProject/android-audiobook/pull/65)
[Notion ticket here](https://www.notion.so/lyrasis/Lock-screen-controls-do-not-appear-on-Android-13-87fdfcebc86547e8896473bba0f4c02d)

**How should this be tested? / Do these changes have associated tests?**
Play an audiobook. Lock the device (turn off the screen). Turn the screen back on. Notice the audio playback controls are showing on the lock screen. Test that they work as expected. Swipe the playback controls to dismiss them. Unlock the phone. Now lock/unlock the device again (turn the screen off and back on). The playback controls should be there again.

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Yes, in android-audiobook demo app