### PR TITLE
Add option to manually insert a LCP passphrase

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,7 +270,7 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-05-11T13:48:54+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-06-13T10:16:17+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
@@ -283,8 +283,9 @@
         <c:change date="2023-04-27T00:00:00+00:00" summary="Added support to audiobook bookmarks."/>
         <c:change date="2023-05-02T00:00:00+00:00" summary="Added badge to holds tab with the number of available holds."/>
         <c:change date="2023-05-09T00:00:00+00:00" summary="Always show audio controls on lock screen."/>
-        <c:change date="2023-05-11T13:48:54+00:00" summary="Removed old pdf reader."/>
+        <c:change date="2023-05-11T00:00:00+00:00" summary="Removed old pdf reader."/>
         <c:change date="2023-05-10T00:00:00+00:00" summary="Bluetooth media controls now support play/pause on more devices and now support fast forwarding and rewinding."/>
+        <c:change date="2023-06-13T10:16:17+00:00" summary="Add option to manually insert a LCP passphrase."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookContentProtections.kt
+++ b/simplified-books-api/src/main/java/org/nypl/simplified/books/api/BookContentProtections.kt
@@ -17,7 +17,9 @@ object BookContentProtections {
   fun create(
     context: Context,
     contentProtectionProviders: List<ContentProtectionProvider>,
-    drmInfo: BookDRMInformation
+    drmInfo: BookDRMInformation,
+    isManualPassphraseEnabled: Boolean = false,
+    onLCPDialogDismissed: () -> Unit = {}
   ): List<ContentProtection> {
     return contentProtectionProviders.mapNotNull { provider ->
       this.logger.debug("instantiating content protection provider {}", provider.javaClass.canonicalName)
@@ -30,11 +32,13 @@ object BookContentProtections {
 
       if (provider is LCPContentProtectionProvider) {
         when (drmInfo) {
-          is BookDRMInformation.LCP ->
+          is BookDRMInformation.LCP -> {
             provider.passphrase = drmInfo.hashedPassphrase
+            provider.isManualPassphraseEnabled = isManualPassphraseEnabled
+            provider.onLcpDialogDismissed = onLCPDialogDismissed
+          }
         }
       }
-
       provider.create(context)
     }
   }

--- a/simplified-lcp/src/main/res/layout/view_manual_lcp_passphrase.xml
+++ b/simplified-lcp/src/main/res/layout/view_manual_lcp_passphrase.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <EditText
+        android:id="@+id/inputPassphrase"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:hint="@string/dialog_manual_passphrase_hint"
+        android:inputType="textPassword" />
+
+</FrameLayout>

--- a/simplified-lcp/src/main/res/values/strings.xml
+++ b/simplified-lcp/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<resources>
+  <string name="dialog_manual_passphrase_cancel">Cancel</string>
+  <string name="dialog_manual_passphrase_done">Done</string>
+  <string name="dialog_manual_passphrase_hint">Passphrase</string>
+  <string name="dialog_manual_passphrase_message">Please contact your administrator to restore the passphrase</string>
+  <string name="dialog_manual_passphrase_title">Enter LCP Passphrase</string>
+</resources>

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
@@ -2,6 +2,7 @@ package org.nypl.simplified.main
 
 import android.content.res.Resources
 import androidx.lifecycle.ViewModel
+import com.google.common.util.concurrent.FluentFuture
 import hu.akarnokd.rxjava2.subjects.UnicastWorkSubject
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -16,6 +17,7 @@ import org.nypl.simplified.books.book_registry.BookHoldsUpdateEvent
 import org.nypl.simplified.books.book_registry.BookRegistryType
 import org.nypl.simplified.books.book_registry.BookStatusEvent
 import org.nypl.simplified.buildconfig.api.BuildConfigurationServiceType
+import org.nypl.simplified.feeds.api.Feed
 import org.nypl.simplified.feeds.api.FeedBooksSelection
 import org.nypl.simplified.feeds.api.FeedEntry
 import org.nypl.simplified.feeds.api.FeedFacet
@@ -25,6 +27,7 @@ import org.nypl.simplified.profiles.api.ProfileEvent
 import org.nypl.simplified.profiles.controller.api.ProfileFeedRequest
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.ui.catalog.R
+import org.slf4j.LoggerFactory
 import java.net.URI
 import java.util.concurrent.TimeUnit
 
@@ -67,6 +70,11 @@ class MainFragmentViewModel(
   private val subscriptions: CompositeDisposable =
     CompositeDisposable()
 
+  private var getHoldsFuture: FluentFuture<Feed.FeedWithoutGroups>? = null
+
+  private val logger =
+    LoggerFactory.getLogger(MainFragmentViewModel::class.java)
+
   private var holdsCallSubscription: Disposable? = null
 
   init {
@@ -104,6 +112,7 @@ class MainFragmentViewModel(
   }
 
   private fun initializeHoldsCallTimer() {
+    getHoldsFuture?.cancel(true)
     holdsCallSubscription?.dispose()
     holdsCallSubscription = Observable.interval(
       0L, REQUEST_HOLDS_INTERVAL, TimeUnit.MILLISECONDS
@@ -134,9 +143,11 @@ class MainFragmentViewModel(
             uri = booksUri
           )
 
-        val numberOfHolds = this.profilesController.profileFeed(request)
-          .get()
-          .entriesInOrder
+        getHoldsFuture = this.profilesController.profileFeed(request)
+        val numberOfHolds = getHoldsFuture
+          ?.get()
+          ?.entriesInOrder
+          .orEmpty()
           .filter { feedEntry ->
             feedEntry is FeedEntry.FeedEntryOPDS &&
               feedEntry.feedEntry.availability is OPDSAvailabilityHeldReady
@@ -148,7 +159,10 @@ class MainFragmentViewModel(
         )
       }
       .subscribeOn(Schedulers.io())
-      .subscribe()
+      .subscribe(
+        { /* do nothing */ },
+        { error -> logger.debug(error.message.orEmpty()) }
+      )
 
     subscriptions.add(holdsCallSubscription!!)
   }

--- a/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
+++ b/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
@@ -46,6 +46,10 @@ data class ProfilePreferences(
 
   val mostRecentAccount: AccountID,
 
+  /** @return `true` if the manual lcp passphrase is enabled. */
+
+  val isManualLCPPassphraseEnabled: Boolean = false,
+
   /** @return `true` if the debug settings should be visible. */
 
   val showDebugSettings: Boolean = false

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
@@ -204,6 +204,9 @@ object ProfileDescriptionJSON {
     val sleepTimers =
       deserializeSleepTimers(objectMapper, objectNode)
 
+    val isManualLCPPassphraseEnabled =
+      JSONParserUtilities.getBooleanDefault(objectNode, "isManualLCPPassphraseEnabled", false)
+
     val mostRecentAccount =
       JSONParserUtilities.getStringOrNull(objectNode, "mostRecentAccount")
         ?.let { AccountID(UUID.fromString(it)) }
@@ -217,7 +220,8 @@ object ProfileDescriptionJSON {
       hasSeenLibrarySelectionScreen = hasSeenLibrarySelectionScreen,
       showDebugSettings = showDebugSettings,
       playbackRates = playbackRates,
-      sleepTimers = sleepTimers
+      sleepTimers = sleepTimers,
+      isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled
     )
   }
 
@@ -250,6 +254,9 @@ object ProfileDescriptionJSON {
     val sleepTimers =
       deserializeSleepTimers(objectMapper, objectNode)
 
+    val isManualLCPPassphraseEnabled =
+      JSONParserUtilities.getBoolean(objectNode, "isManualLCPPassphraseEnabled")
+
     val mostRecentAccount =
       JSONParserUtilities.getStringOrNull(objectNode, "mostRecentAccount")
         ?.let { AccountID(UUID.fromString(it)) }
@@ -262,7 +269,8 @@ object ProfileDescriptionJSON {
       mostRecentAccount = mostRecentAccount,
       hasSeenLibrarySelectionScreen = true,
       playbackRates = playbackRates,
-      sleepTimers = sleepTimers
+      sleepTimers = sleepTimers,
+      isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled
     )
   }
 
@@ -319,6 +327,9 @@ object ProfileDescriptionJSON {
     val readerPrefs =
       deserializeReaderPreferences(objectMapper, preferencesNode)
 
+    val isManualLCPPassphraseEnabled =
+      JSONParserUtilities.getBooleanDefault(preferencesNode, "isManualLCPPassphraseEnabled", false)
+
     val preferences =
       ProfilePreferences(
         dateOfBirth = this.someOrNull(dateOfBirth),
@@ -327,7 +338,8 @@ object ProfileDescriptionJSON {
         mostRecentAccount = mostRecentAccountFallback,
         hasSeenLibrarySelectionScreen = true,
         playbackRates = playbackRates,
-        sleepTimers = sleepTimers
+        sleepTimers = sleepTimers,
+        isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled
       )
 
     val attributeMap = mutableMapOf<String, String>()
@@ -474,6 +486,7 @@ object ProfileDescriptionJSON {
   ): ObjectNode {
     val output = objectMapper.createObjectNode()
     output.put("showTestingLibraries", preferences.showTestingLibraries)
+    output.put("isManualLCPPassphraseEnabled", preferences.isManualLCPPassphraseEnabled)
     output.put("hasSeenLibrarySelectionScreen", preferences.hasSeenLibrarySelectionScreen)
     output.put("showDebugSettings", preferences.showDebugSettings)
     output.put("mostRecentAccount", preferences.mostRecentAccount.uuid.toString())

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
@@ -501,7 +501,8 @@ object ProfilesDatabases {
               mostRecentAccount = account.id,
               hasSeenLibrarySelectionScreen = false,
               playbackRates = hashMapOf(),
-              sleepTimers = hashMapOf()
+              sleepTimers = hashMapOf(),
+              isManualLCPPassphraseEnabled = false
             ),
             attributes = ProfileAttributes(sortedMapOf())
           )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
@@ -55,7 +55,8 @@ class ProfileDescriptionJSONTest {
           readerPreferences = ReaderPreferences.builder().build(),
           mostRecentAccount = AccountID.generate(),
           playbackRates = hashMapOf(),
-          sleepTimers = hashMapOf()
+          sleepTimers = hashMapOf(),
+          isManualLCPPassphraseEnabled = false
         ),
         attributes = ProfileAttributes(
           sortedMapOf(

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
@@ -36,7 +36,8 @@ class MockProfile(
         readerPreferences = ReaderPreferences.builder().build(),
         mostRecentAccount = this.accounts.firstKey(),
         playbackRates = hashMapOf(),
-        sleepTimers = hashMapOf()
+        sleepTimers = hashMapOf(),
+        isManualLCPPassphraseEnabled = false
       ),
       attributes = ProfileAttributes(sortedMapOf())
     )

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
@@ -64,6 +64,7 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
   private lateinit var syncAccountsButton: Button
   private lateinit var enableOpenEBooksQA: Button
   private lateinit var toolbar: NeutralToolbar
+  private lateinit var isManualLCPPassphraseEnabled: SwitchCompat
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
@@ -94,6 +95,8 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       view.findViewById(R.id.settingsVersionDevFailNextBootSwitch)
     this.hasSeenLibrarySelection =
       view.findViewById(R.id.settingsVersionDevSeenLibrarySelectionScreen)
+    this.isManualLCPPassphraseEnabled =
+      view.findViewById(R.id.settingsVersionDevIsManualLCPPassphraseEnabled)
     this.cardCreatorFakeLocation =
       view.findViewById(R.id.settingsVersionDevCardCreatorLocationSwitch)
     this.showOnlySupportedBooks =
@@ -132,6 +135,8 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       this.viewModel.hasSeenLibrarySelection
     this.cardCreatorFakeLocation.isChecked =
       this.viewModel.cardCreatorFakeLocation
+    this.isManualLCPPassphraseEnabled.isChecked =
+      this.viewModel.isManualLCPPassphraseEnabled
     this.showOnlySupportedBooks.isChecked =
       this.viewModel.showOnlySupportedBooks
     this.crashlyticsId.text =
@@ -231,6 +236,9 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
 
     this.showOnlySupportedBooks.setOnCheckedChangeListener { _, isChecked ->
       this.viewModel.showOnlySupportedBooks = isChecked
+    }
+    this.isManualLCPPassphraseEnabled.setOnCheckedChangeListener { _, isChecked ->
+      this.viewModel.isManualLCPPassphraseEnabled = isChecked
     }
 
     /*

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
@@ -136,6 +136,18 @@ class SettingsDebugViewModel(application: Application) : AndroidViewModel(applic
       }
     }
 
+  var isManualLCPPassphraseEnabled: Boolean
+    get() =
+      this.profilesController
+        .profileCurrent()
+        .preferences()
+        .isManualLCPPassphraseEnabled
+    set(value) {
+      this.profilesController.profileUpdate { description ->
+        description.copy(preferences = description.preferences.copy(isManualLCPPassphraseEnabled = value))
+      }
+    }
+
   var isBootFailureEnabled: Boolean
     get() =
       BootFailureTesting.isBootFailureEnabled(getApplication())

--- a/simplified-ui-settings/src/main/res/layout/settings_debug.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_debug.xml
@@ -158,6 +158,16 @@
       android:textStyle="bold" />
 
     <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/settingsVersionDevIsManualLCPPassphraseEnabled"
+        android:theme="@style/Enabled.Switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:checked="false"
+        android:enabled="true"
+        android:text="@string/settingsDevEnableManualLCPPassphrase" />
+
+    <androidx.appcompat.widget.SwitchCompat
       android:id="@+id/settingsVersionDevProductionLibrariesSwitch"
       android:theme="@style/Enabled.Switch"
       android:layout_width="match_parent"

--- a/simplified-ui-settings/src/main/res/values/strings.xml
+++ b/simplified-ui-settings/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
   <string name="settingsDevCrashlyticsCurrentUserId">Current Crashlytics User ID</string>
   <string name="settingsDevDrmSupport">DRM Support</string>
   <string name="settingsDevEnableHiddenLibraries">Enable Hidden Libraries</string>
+  <string name="settingsDevEnableManualLCPPassphrase">Enable Manual LCP Passphrase</string>
   <string name="settingsDevFailNextStartup">Cause the next application startup to fail</string>
   <string name="settingsDevForgetAllAnnouncements">Forget All Announcements</string>
   <string name="settingsDevPlaceholder">Placeholder</string>

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -387,7 +387,12 @@ class AudioBookPlayerActivity :
     val contentProtections = BookContentProtections.create(
       context = this,
       contentProtectionProviders = this.contentProtectionProviders,
-      drmInfo = this.parameters.drmInfo
+      drmInfo = this.parameters.drmInfo,
+      isManualPassphraseEnabled =
+        profilesController.profileCurrent().preferences().isManualLCPPassphraseEnabled,
+      onLCPDialogDismissed = {
+        finish()
+      }
     )
 
     /*
@@ -401,7 +406,9 @@ class AudioBookPlayerActivity :
         filter = { true },
         downloadProvider = DownloadProvider.create(this.downloadExecutor),
         userAgent = PlayerUserAgent(this.parameters.userAgent),
-        contentProtections = contentProtections
+        contentProtections = contentProtections,
+        manualPassphrase =
+          profilesController.profileCurrent().preferences().isManualLCPPassphraseEnabled
       )
     )
 

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
@@ -118,7 +118,10 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
   private var viewSubscription: Disposable? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
-    this.logger.debug("loaded {} content protection providers", this.contentProtectionProviders.size)
+    this.logger.debug(
+      "loaded {} content protection providers",
+      this.contentProtectionProviders.size
+    )
     this.contentProtectionProviders.forEachIndexed { index, provider ->
       this.logger.debug("[{}] available provider {}", index, provider.javaClass.canonicalName)
     }
@@ -163,9 +166,15 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
 
     if (savedInstanceState == null) {
       this.readerFragment =
-        this.supportFragmentManager.fragmentFactory.instantiate(this.classLoader, SR2ReaderFragment::class.java.name)
+        this.supportFragmentManager.fragmentFactory.instantiate(
+          this.classLoader,
+          SR2ReaderFragment::class.java.name
+        )
       this.tocFragment =
-        this.supportFragmentManager.fragmentFactory.instantiate(this.classLoader, SR2TOCFragment::class.java.name)
+        this.supportFragmentManager.fragmentFactory.instantiate(
+          this.classLoader,
+          SR2TOCFragment::class.java.name
+        )
 
       this.supportFragmentManager.beginTransaction()
         .replace(R.id.reader2FragmentHost, this.readerFragment, READER_FRAGMENT_TAG)
@@ -220,7 +229,12 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
     val contentProtections = BookContentProtections.create(
       context = this,
       contentProtectionProviders = this.contentProtectionProviders,
-      drmInfo = this.parameters.drmInfo
+      drmInfo = this.parameters.drmInfo,
+      isManualPassphraseEnabled =
+        profilesController.profileCurrent().preferences().isManualLCPPassphraseEnabled,
+      onLCPDialogDismissed = {
+        finish()
+      }
     )
 
     /*
@@ -493,7 +507,10 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
 
     val currentTocFragment = this.tocFragment
     this.tocFragment =
-      this.supportFragmentManager.fragmentFactory.instantiate(this.classLoader, SR2TOCFragment::class.java.name)
+      this.supportFragmentManager.fragmentFactory.instantiate(
+        this.classLoader,
+        SR2TOCFragment::class.java.name
+      )
     this.supportFragmentManager.beginTransaction()
       .remove(currentTocFragment)
       .add(R.id.reader2FragmentHost, this.tocFragment)
@@ -520,7 +537,13 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
 
     AlertDialog.Builder(this)
       .setTitle(R.string.bookOpenFailedTitle)
-      .setMessage(this.getString(R.string.bookOpenFailedMessage, actualException.javaClass.name, actualException.message))
+      .setMessage(
+        this.getString(
+          R.string.bookOpenFailedMessage,
+          actualException.javaClass.name,
+          actualException.message
+        )
+      )
       .setOnDismissListener { this.finish() }
       .create()
       .show()


### PR DESCRIPTION
**What's this do?**
This PR adds the option to manually insert a LCP passphrase to the debug options. It also adds the dialog where the user can type the password and logic to handle it on eBooks and PDFs.
Finally, this PR also fixes a crash when retrieving the user's holds periodically.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://ebce-lyrasis.atlassian.net/browse/PP-13) to add the ability of manually inserting a LCP passphrase so some tests can be performed using specific passphrases.

**How should this be tested? / Do these changes have associated tests?**
In order to test this, we need to reset the LCP passphrases everytime a valid passphrase is manually input. Which means that after successfully testing the passphrase for the Ebooks, we need to reset the passphrases before testing for the Audiobooks and PDFs. This being said, the first step is to either clear the app's data on the app settings on your device or uninstall/install the app.
After this, reopen the app

_Ebooks_
Select LYRASIS Reads
Login
Go to settings and enable the debug options
Enable the option to manually insert a LCP passphrase
Go to the catalog and open the "Palace Marketplace Test" lane
Open any Ebook (p.e., "Writing Wild" by Kathryn Aalto)
Confirm the [LCP passphrase dialog is shown](https://github.com/ThePalaceProject/android-core/assets/79104027/0b060991-bec8-4c1e-b3f1-d583ba651657)
Cancel and confirm the dialog is closed and you're redirected to the previous screen
Open the Ebook again
Type a random passphrase and click on "Done"
Confirm the dialog is shown again because the passphrase is invalid
Insert a valid passphrase and confirm the book is correctly opened

_Audiobook_
Select LYRASIS Reads
Login
Go to settings and enable the debug options
Enable the option to manually insert a LCP passphrase
Enable the option to show the hidden libraries
Return and add the library "Palace Marketplace Integration Library"
Go to the catalog and open any Audiobook (p.e., "The Way of Peace" by James Allen)
Confirm the [LCP passphrase dialog is shown](https://github.com/ThePalaceProject/android-core/assets/79104027/0b060991-bec8-4c1e-b3f1-d583ba651657)
Cancel and confirm the dialog is closed and you're redirected to the previous screen
Open the Audiobook again
Type a random passphrase and click on "Done"
Confirm the dialog is shown again because the passphrase is invalid
Insert a valid passphrase and confirm the audiobook is correctly opened

_PDF_
Select LYRASIS Reads
Login
Go to settings and enable the debug options
Enable the option to manually insert a LCP passphrase
Go to the catalog and open the "Palace Marketplace Test" lane
Open any PDF (p.e., "Commanders in Crisis Vol.2")
Confirm the [LCP passphrase dialog is shown](https://github.com/ThePalaceProject/android-core/assets/79104027/0b060991-bec8-4c1e-b3f1-d583ba651657)
Cancel and confirm the dialog is closed and you're redirected to the previous screen
Open the PDF again
Type a random passphrase and click on "Done"
Confirm the dialog is shown again because the passphrase is invalid
Insert a valid passphrase and confirm the audiobook is correctly opened

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-audiobook/pull/67) also needs to be merged so the audiobooks can handle these changes.

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 