### PR TITLE
Fixed audiobook bookmarks being incorrectly displayed and failing to be deleted

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,7 +270,7 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-05-11T13:48:54+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-06-16T13:25:32+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
@@ -283,8 +283,9 @@
         <c:change date="2023-04-27T00:00:00+00:00" summary="Added support to audiobook bookmarks."/>
         <c:change date="2023-05-02T00:00:00+00:00" summary="Added badge to holds tab with the number of available holds."/>
         <c:change date="2023-05-09T00:00:00+00:00" summary="Always show audio controls on lock screen."/>
-        <c:change date="2023-05-11T13:48:54+00:00" summary="Removed old pdf reader."/>
+        <c:change date="2023-05-11T00:00:00+00:00" summary="Removed old pdf reader."/>
         <c:change date="2023-05-10T00:00:00+00:00" summary="Bluetooth media controls now support play/pause on more devices and now support fast forwarding and rewinding."/>
+        <c:change date="2023-06-16T13:25:32+00:00" summary="Fixed audiobook bookmarks being incorrectly displayed and failing to be deleted."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BHTTPCalls.kt
+++ b/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BHTTPCalls.kt
@@ -67,16 +67,17 @@ class BHTTPCalls(
         .setMethod(Delete)
         .build()
 
-    return request.execute().use { response ->
+    request.execute().use { response ->
       when (val status = response.status) {
         is LSHTTPResponseStatus.Responded.OK -> {
-          this.deserializeBookmarksFromStream(status.bodyStream ?: this.emptyStream())
-          Unit
+          // do nothing
         }
-        is LSHTTPResponseStatus.Responded.Error ->
+        is LSHTTPResponseStatus.Responded.Error -> {
           this.logAndFail(bookmarkURI, status)
-        is LSHTTPResponseStatus.Failed ->
+        }
+        is LSHTTPResponseStatus.Failed -> {
           throw status.exception
+        }
       }
     }
   }

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookHelpers.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookHelpers.kt
@@ -105,7 +105,11 @@ internal object AudioBookHelpers {
     )
   }
 
-  fun fromPlayerBookmark(opdsId: String, deviceID: String, playerBookmark: PlayerBookmark): Bookmark.AudiobookBookmark {
+  fun fromPlayerBookmark(
+    opdsId: String,
+    deviceID: String,
+    playerBookmark: PlayerBookmark
+  ): Bookmark.AudiobookBookmark {
     return Bookmark.AudiobookBookmark(
       opdsId = opdsId,
       deviceID = deviceID,

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -572,12 +572,12 @@ class AudioBookPlayerActivity :
         .filterIsInstance<Bookmark.AudiobookBookmark>()
 
       val bookMarkLastReadPosition = audiobookBookmarks.find { bookmark ->
-          bookmark.kind == BookmarkKind.BookmarkLastReadLocation
-        }
+        bookmark.kind == BookmarkKind.BookmarkLastReadLocation
+      }
 
       currentBookmarks.addAll(
-        audiobookBookmarks.filter { bookmark -> bookmark.kind == BookmarkKind.BookmarkExplicit &&
-          bookmark.uri != null
+        audiobookBookmarks.filter { bookmark ->
+          bookmark.kind == BookmarkKind.BookmarkExplicit && bookmark.uri != null
         }
       )
 


### PR DESCRIPTION
**What's this do?**
This PR fixes audiobook bookmarks being incorrectly displayed by hiding those who don't have a valid url. Also, this PR deletes some unnecessary code that could have been causing the bookmarks to be properly deleted.

**Why are we doing this? (w/ JIRA link if applicable)**
There's [a ticket with a bug](https://ebce-lyrasis.atlassian.net/browse/PP-48) saying that some audiobook bookmarks are failing to be deleted and then they seem to be duplicated while being displayed to the user.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Select "LYRASIS Reads" library
Get an audiobook
Tap “Listen”
Add several bookmarks
Open TOC - Bookmarks
Delete all the bookmarks
Close the book
Tap “Listen” again
Open TOC - Bookmarks
Confirm the bookmarks are not duplicated and the ones deleted are not there anymore

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 