### PR TITLE
Removed hardcoded message from LCP passphrase dialog

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,7 +270,7 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-06-21T14:28:41+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-06-26T10:23:13+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
@@ -286,7 +286,8 @@
         <c:change date="2023-05-10T00:00:00+00:00" summary="Bluetooth media controls now support play/pause on more devices and now support fast forwarding and rewinding."/>
         <c:change date="2023-05-11T00:00:00+00:00" summary="Removed old pdf reader."/>
         <c:change date="2023-06-13T00:00:00+00:00" summary="Add option to manually insert a LCP passphrase."/>
-        <c:change date="2023-06-21T14:28:41+00:00" summary="Fixed audiobook bookmarks being incorrectly displayed and failing to be deleted."/>
+        <c:change date="2023-06-21T00:00:00+00:00" summary="Fixed audiobook bookmarks being incorrectly displayed and failing to be deleted."/>
+        <c:change date="2023-06-26T10:23:13+00:00" summary="Removed hardcoded message from LCP passphrase dialog."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-lcp/src/main/java/org/nypl/simplified/lcp/LCPContentProtectionProvider.kt
+++ b/simplified-lcp/src/main/java/org/nypl/simplified/lcp/LCPContentProtectionProvider.kt
@@ -65,14 +65,14 @@ class LCPContentProtectionProvider : ContentProtectionProvider {
   private val logger =
     LoggerFactory.getLogger(LCPContentProtectionProvider::class.java)
 
-  private suspend fun askPassphrase(context: Context): String? {
+  private suspend fun askPassphrase(context: Context, hint: String): String? {
     val view = LayoutInflater.from(context).inflate(R.layout.view_manual_lcp_passphrase, null)
     val inputPassphrase = view.findViewById<TextView>(R.id.inputPassphrase)
 
     return suspendCoroutine { cont ->
       AlertDialog.Builder(context).apply {
         setTitle(R.string.dialog_manual_passphrase_title)
-        setMessage(R.string.dialog_manual_passphrase_message)
+        setMessage(hint)
         setPositiveButton(R.string.dialog_manual_passphrase_done) { dialog, _ ->
           dialog.dismiss()
           try {
@@ -120,7 +120,7 @@ class LCPContentProtectionProvider : ContentProtectionProvider {
             return if (!isManualPassphraseEnabled) {
               this@LCPContentProtectionProvider.passphrase()
             } else {
-              withContext(Dispatchers.Main) { askPassphrase(context) }
+              withContext(Dispatchers.Main) { askPassphrase(context, license.hint) }
             }
           }
         }

--- a/simplified-lcp/src/main/res/values/strings.xml
+++ b/simplified-lcp/src/main/res/values/strings.xml
@@ -4,6 +4,5 @@
   <string name="dialog_manual_passphrase_cancel">Cancel</string>
   <string name="dialog_manual_passphrase_done">Done</string>
   <string name="dialog_manual_passphrase_hint">Passphrase</string>
-  <string name="dialog_manual_passphrase_message">Please contact your administrator to restore the passphrase</string>
   <string name="dialog_manual_passphrase_title">Enter LCP Passphrase</string>
 </resources>


### PR DESCRIPTION
**What's this do?**
This PR removes the hardcoded string for the LCP passphrase dialog message and sets it as the `hint` field inside the LCPLicense object

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://ebce-lyrasis.atlassian.net/browse/PP-13) saying the message is always the same for every library with LCP protected books and that it should be dynamically shown depending on the response we receive.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Go to debug options and activate "Enable manual LCP passphrase" option
Select a library with books with LCP protection
Open a book with LCP protection
Confirm the dialog opens and still displays a message

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 