### PR TITLE
Fixed bug of bookmarks not being deleted

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,7 +270,7 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-06-26T10:23:13+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-07-04T08:49:55+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
@@ -281,14 +281,15 @@
         <c:change date="2023-04-11T00:00:00+00:00" summary="Fixed WebView audiobook preview not pausing when earphones are unplugged."/>
         <c:change date="2023-04-26T00:00:00+00:00" summary="Added support for Bluetooth audio controls to play, pause, and skip tracks."/>
         <c:change date="2023-04-27T00:00:00+00:00" summary="Added support to audiobook bookmarks."/>
-        <c:change date="2023-05-02T22:31:26+00:00" summary="Added badge to holds tab with the number of available holds."/>
-        <c:change date="2023-05-09T22:31:26+00:00" summary="Always show audio controls on lock screen."/>
+        <c:change date="2023-05-02T00:00:00+00:00" summary="Added badge to holds tab with the number of available holds."/>
+        <c:change date="2023-05-09T00:00:00+00:00" summary="Always show audio controls on lock screen."/>
         <c:change date="2023-05-10T00:00:00+00:00" summary="Bluetooth media controls now support play/pause on more devices and now support fast forwarding and rewinding."/>
-        <c:change date="2023-05-11T13:48:54+00:00" summary="Removed old pdf reader."/>
-        <c:change date="2023-05-23T22:31:26+00:00" summary="Support deep links to library login screen with automatic entry of barcode."/>
-        <c:change date="2023-06-13T10:16:17+00:00" summary="Add option to manually insert a LCP passphrase."/>
+        <c:change date="2023-05-11T00:00:00+00:00" summary="Removed old pdf reader."/>
+        <c:change date="2023-05-23T00:00:00+00:00" summary="Support deep links to library login screen with automatic entry of barcode."/>
+        <c:change date="2023-06-13T00:00:00+00:00" summary="Add option to manually insert a LCP passphrase."/>
         <c:change date="2023-06-21T00:00:00+00:00" summary="Fixed audiobook bookmarks being incorrectly displayed and failing to be deleted."/>
-        <c:change date="2023-06-26T10:23:13+00:00" summary="Removed hardcoded message from LCP passphrase dialog."/>
+        <c:change date="2023-06-26T00:00:00+00:00" summary="Removed hardcoded message from LCP passphrase dialog."/>
+        <c:change date="2023-07-04T08:49:55+00:00" summary="Fixed bug of bookmarks not being deleted."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-bookmarks-api/src/main/java/org/nypl/simplified/bookmarks/api/BookmarkHTTPCallsType.kt
+++ b/simplified-bookmarks-api/src/main/java/org/nypl/simplified/bookmarks/api/BookmarkHTTPCallsType.kt
@@ -54,7 +54,7 @@ interface BookmarkHTTPCallsType {
     annotationsURI: URI,
     credentials: AccountAuthenticationCredentials,
     bookmark: BookmarkAnnotation
-  )
+  ): URI?
 
   /**
    * Delete a bookmark for the given account. This call will fail with an exception if
@@ -68,5 +68,5 @@ interface BookmarkHTTPCallsType {
   fun bookmarkDelete(
     bookmarkURI: URI,
     credentials: AccountAuthenticationCredentials
-  )
+  ): Boolean
 }

--- a/simplified-bookmarks-api/src/main/java/org/nypl/simplified/bookmarks/api/BookmarkServiceUsableType.kt
+++ b/simplified-bookmarks-api/src/main/java/org/nypl/simplified/bookmarks/api/BookmarkServiceUsableType.kt
@@ -78,7 +78,7 @@ interface BookmarkServiceUsableType {
   fun bookmarkCreateRemote(
     accountID: AccountID,
     bookmark: Bookmark
-  ): FluentFuture<Unit>
+  ): FluentFuture<Bookmark?>
 
   /**
    * The user has requested that a bookmark be deleted.
@@ -87,5 +87,5 @@ interface BookmarkServiceUsableType {
   fun bookmarkDelete(
     accountID: AccountID,
     bookmark: Bookmark
-  ): FluentFuture<Unit>
+  ): FluentFuture<Boolean>
 }

--- a/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BService.kt
+++ b/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BService.kt
@@ -344,7 +344,7 @@ class BService(
   override fun bookmarkCreateRemote(
     accountID: AccountID,
     bookmark: Bookmark
-  ): FluentFuture<Unit> {
+  ): FluentFuture<Bookmark?> {
     return try {
       FluentFuture.from(
         this.executor.submit(
@@ -367,7 +367,7 @@ class BService(
   override fun bookmarkDelete(
     accountID: AccountID,
     bookmark: Bookmark
-  ): FluentFuture<Unit> {
+  ): FluentFuture<Boolean> {
     return try {
       FluentFuture.from(
         this.executor.submit(

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/NullBookmarkService.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/NullBookmarkService.kt
@@ -51,12 +51,15 @@ class NullBookmarkService(
     return FluentFuture.from(Futures.immediateFuture(Unit))
   }
 
-  override fun bookmarkCreateRemote(accountID: AccountID, bookmark: Bookmark): FluentFuture<Unit> {
-    return FluentFuture.from(Futures.immediateFuture(Unit))
+  override fun bookmarkCreateRemote(
+    accountID: AccountID,
+    bookmark: Bookmark
+  ): FluentFuture<Bookmark?> {
+    return FluentFuture.from(Futures.immediateFuture(bookmark))
   }
 
-  override fun bookmarkDelete(accountID: AccountID, bookmark: Bookmark): FluentFuture<Unit> {
-    return FluentFuture.from(Futures.immediateFuture(Unit))
+  override fun bookmarkDelete(accountID: AccountID, bookmark: Bookmark): FluentFuture<Boolean> {
+    return FluentFuture.from(Futures.immediateFuture(true))
   }
 
   override fun bookmarkLoad(

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookHelpers.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookHelpers.kt
@@ -70,6 +70,34 @@ internal object AudioBookHelpers {
   }
 
   /**
+   * Add a bookmark remotely.
+   */
+  fun addBookmarkRemotely(
+    bookmarkService: BookmarkServiceUsableType,
+    accountID: AccountID,
+    bookmark: Bookmark
+  ): Bookmark? {
+    return bookmarkService.bookmarkCreateRemote(
+      accountID = accountID,
+      bookmark = bookmark
+    ).get(15L, TimeUnit.SECONDS)
+  }
+
+  /**
+   * Delete a bookmark.
+   */
+  fun deleteBookmark(
+    bookmarkService: BookmarkServiceUsableType,
+    accountID: AccountID,
+    bookmark: Bookmark
+  ): Boolean {
+    return bookmarkService.bookmarkDelete(
+      accountID = accountID,
+      bookmark = bookmark
+    ).get(15L, TimeUnit.SECONDS)
+  }
+
+  /**
    * Load bookmarks from the given bookmark service.
    */
 

--- a/simplified-viewer-audiobook/src/main/res/values/strings.xml
+++ b/simplified-viewer-audiobook/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 
 <resources>
   <string name="audio_book_player">Audiobook Player</string>
+  <string name="audio_book_player_bookmark_adding">Adding bookmark…</string>
   <string name="audio_book_player_bookmark_added">Bookmark added</string>
   <string name="audio_book_player_bookmark_already_added">A bookmark has already been saved at this location.</string>
   <string name="audio_book_player_bookmark_error_adding">There was an error while adding the bookmark</string>

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Bookmarks.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Bookmarks.kt
@@ -39,6 +39,32 @@ object Reader2Bookmarks {
   }
 
   /**
+   * Create a bookmark.
+   */
+
+  fun createBookmarkRemotely(
+    bookmarkService: BookmarkServiceUsableType,
+    accountID: AccountID,
+    bookmark: Bookmark
+  ): Bookmark? {
+    return bookmarkService.bookmarkCreateRemote(
+      accountID = accountID,
+      bookmark = bookmark
+    ).get(15L, TimeUnit.SECONDS)
+  }
+
+  fun deleteBookmarkRemotely(
+    bookmarkService: BookmarkServiceUsableType,
+    accountID: AccountID,
+    bookmark: Bookmark
+  ): Boolean {
+    return bookmarkService.bookmarkDelete(
+      accountID = accountID,
+      bookmark = bookmark
+    ).get(15L, TimeUnit.SECONDS)
+  }
+
+  /**
    * Load bookmarks from the given bookmark service.
    */
 
@@ -102,7 +128,7 @@ object Reader2Bookmarks {
       chapterTitle = source.title,
       bookProgress = source.bookProgress,
       deviceID = deviceId,
-      uri = null
+      uri = source.uri
     )
   }
 
@@ -141,6 +167,7 @@ object Reader2Bookmarks {
         chapterHref = location.progress.chapterHref,
         chapterProgress = location.progress.chapterProgress
       ),
-      bookProgress = source.bookProgress
+      bookProgress = source.bookProgress,
+      uri = source.uri
     )
 }

--- a/simplified-viewer-epub-readium2/src/main/res/values/strings.xml
+++ b/simplified-viewer-epub-readium2/src/main/res/values/strings.xml
@@ -5,6 +5,10 @@
   <string name="bookOpenFailedTitle">Book loading failed</string>
   <string name="bookOpenFailedMessage">There was an error opening the book: (%1$s): %2$s.</string>
 
+  <string name="reader_bookmark_added">Bookmark added</string>
+  <string name="reader_bookmark_adding">Adding bookmark…</string>
+  <string name="reader_bookmark_error_adding">There was an error while adding the bookmark</string>
+
   <string name="reader_position_title">Sync Reading Position</string>
   <string name="reader_position_message">Do you want to move to the page on which you left off?</string>
   <string name="reader_position_move">Move</string>


### PR DESCRIPTION
**What's this do?**
When adding a bookmark, an object of the type  Bookmark was created but it was given 'null' as the URI field value which was causing the bookmark to not be able to be deleted since it needs a non-null URI in order to perform the operation on the server. However, the UI was being updated as if it was actually deleted, so when the user left the audiobook/ebook and returned, they'd still be seeing the "deleted" bookmarks. This PR fixes this bug by receiving the created bookmark from the server and saving it with a valid URI so it can be properly deleted right after being added or later. This PR also updates the UI in order to give some feedback to the user when the bookmark is being created/deleted.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [report of a bug](https://ebce-lyrasis.atlassian.net/browse/PP-48) saying the bookmarks are deleted but reappear after reopening a book/audiobook.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads"
Open any eBook/audiobook
Create a bookmark and confirm it's added
Go to the bookmarks and confirm it's there
Delete it
Go back and leave the book/audiobook
Reopen the book/audiobook and go to Bookmarks
Confirm there are no bookmarks
Go back and add a new bookmark
Leave the book/audiobook, reopen it and go to Bookmarks
Confirm the bookmark is there
Delete it
Go back and leave the book/audiobook
Reopen the book/audiobook and go to Bookmarks
Confirm there are no bookmarks

**Dependencies for merging? Releasing to production?**
This [audiobook PR](https://github.com/ThePalaceProject/android-audiobook/pull/69) and this [reader PR](https://github.com/ThePalaceProject/android-r2/pull/21) need to be merged first.

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 