### PR TITLE
Added default LCP passphrase to be returned when the feed entry doesn't have one and the manual input is enabled

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,7 +270,7 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-07-04T08:49:55+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-07-11T21:38:36+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
@@ -289,7 +289,8 @@
         <c:change date="2023-06-13T00:00:00+00:00" summary="Add option to manually insert a LCP passphrase."/>
         <c:change date="2023-06-21T00:00:00+00:00" summary="Fixed audiobook bookmarks being incorrectly displayed and failing to be deleted."/>
         <c:change date="2023-06-26T00:00:00+00:00" summary="Removed hardcoded message from LCP passphrase dialog."/>
-        <c:change date="2023-07-04T08:49:55+00:00" summary="Fixed bug of bookmarks not being deleted."/>
+        <c:change date="2023-07-04T00:00:00+00:00" summary="Fixed bug of bookmarks not being deleted."/>
+        <c:change date="2023-07-11T21:38:36+00:00" summary="Added default LCP passphrase to be returned when the feed entry doesn't have one and the manual input is enabled."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/BorrowContextType.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/BorrowContextType.kt
@@ -232,4 +232,9 @@ interface BorrowContextType {
    */
 
   val samlDownloadContext: SAMLDownloadContext?
+
+  /**
+   * Information about if the LCP passphrase manual input is enabled or not.
+   */
+  val isManualLCPPassphraseEnabled: Boolean
 }

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/BorrowTask.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/BorrowTask.kt
@@ -31,6 +31,7 @@ import org.nypl.simplified.content.api.ContentResolverType
 import org.nypl.simplified.opds.core.OPDSAcquisitionFeedEntry
 import org.nypl.simplified.opds.core.OPDSAcquisitionPath
 import org.nypl.simplified.opds.core.OPDSAcquisitionPathElement
+import org.nypl.simplified.opds.core.getOrNull
 import org.nypl.simplified.profiles.api.ProfileID
 import org.nypl.simplified.profiles.api.ProfileReadableType
 import org.nypl.simplified.taskrecorder.api.TaskRecorder
@@ -193,6 +194,9 @@ class BorrowTask private constructor(
         contentResolver = this.requirements.contentResolver,
         currentOPDSAcquisitionPathElement = path.elements.first(),
         httpClient = this.requirements.httpClient,
+        isManualLCPPassphraseEnabled =
+          this.requirements.profiles.currentProfile().getOrNull()
+            ?.preferences()?.isManualLCPPassphraseEnabled ?: false,
         logger = this.logger,
         opdsAcquisitionPath = path,
         samlDownloadContext = samlDownloadContext,
@@ -403,6 +407,7 @@ class BorrowTask private constructor(
     override val bundledContent: BundledContentResolverType,
     override val bookDatabaseEntry: BookDatabaseEntryType,
     override val httpClient: LSHTTPClientType,
+    override val isManualLCPPassphraseEnabled: Boolean,
     override val taskRecorder: TaskRecorderType,
     override val opdsAcquisitionPath: OPDSAcquisitionPath,
     override val samlDownloadContext: SAMLDownloadContext? = null,

--- a/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLCP.kt
+++ b/simplified-books-borrowing/src/main/java/org/nypl/simplified/books/borrowing/internal/BorrowLCP.kt
@@ -67,7 +67,19 @@ class BorrowLCP private constructor() : BorrowSubtaskType {
         bytesPerSecond = 1L
       )
 
-      val passphrase = this.findPassphrase(context)
+      val passphrase = if (context.isManualLCPPassphraseEnabled) {
+
+        // if the manual input for the LCP passphrase is enabled, we need to catch a possible
+        // exception while fetching the current passphrase as it may be possible for the user to
+        // manually input it and if the exception isn't caught, the download will immediately fail.
+        try {
+          this.findPassphrase(context)
+        } catch (e: Exception) {
+          ""
+        }
+      } else {
+        this.findPassphrase(context)
+      }
 
       val currentURI = context.currentURICheck()
       context.logDebug("downloading {}", currentURI)

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowTaskTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowTaskTest.kt
@@ -285,7 +285,7 @@ class BorrowTaskTest {
     Mockito.`when`(this.profile.id)
       .thenReturn(profileId)
     Mockito.`when`(this.profiles.currentProfile())
-      .thenReturn(Option.some(null))
+      .thenReturn(Option.none())
     Mockito.`when`(this.profile.account(this.accountId))
       .thenReturn(this.account)
     Mockito.`when`(this.account.bookDatabase)

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowTaskTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowTaskTest.kt
@@ -1,6 +1,7 @@
 package org.nypl.simplified.tests.books.borrowing
 
 import android.content.Context
+import com.io7m.jfunctional.Option
 import io.reactivex.disposables.Disposable
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -279,11 +280,12 @@ class BorrowTaskTest {
         .subtasks
 
     val profileId = ProfileID.generate()
-
     Mockito.`when`(this.profiles.profiles())
       .thenReturn(sortedMapOf(Pair(profileId, this.profile)))
     Mockito.`when`(this.profile.id)
       .thenReturn(profileId)
+    Mockito.`when`(this.profiles.currentProfile())
+      .thenReturn(Option.some(null))
     Mockito.`when`(this.profile.account(this.accountId))
       .thenReturn(this.account)
     Mockito.`when`(this.account.bookDatabase)

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBorrowContext.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockBorrowContext.kt
@@ -43,6 +43,7 @@ class MockBorrowContext(
   override var bookDatabaseEntry: BookDatabaseEntryType,
   override var samlDownloadContext: SAMLDownloadContext? = null,
   override var lcpService: LcpService? = null,
+  override val isManualLCPPassphraseEnabled: Boolean = false,
   bookInitial: Book,
 ) : BorrowContextType {
 


### PR DESCRIPTION
**What's this do?**
This PR adds an empty passphrase as a default value to return when two conditions are met: no LCP passphrase on the feed entry and the LCP passphrase manual input setting is enabled.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a comment on [this ticket](https://ebce-lyrasis.atlassian.net/browse/PP-13) saying that there are some LCP protected books that are failing to be downloaded on the Android app while the same books are downloaded on the iOS version

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Enable the hidden libraries option on the Debug options
Go to Libraries and select _Cerberus Test Library 1_
Open any book from _EDRLab LCP Test_ lane
Download it and confirm the download is successful even if the book fails to be opened

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 