### PR TITLE
PP-187: Fix some bookmark issues

### DIFF
--- a/simplified-futures/src/main/java/org/nypl/simplified/futures/FluentFutureExtensions.kt
+++ b/simplified-futures/src/main/java/org/nypl/simplified/futures/FluentFutureExtensions.kt
@@ -33,6 +33,15 @@ object FluentFutureExtensions {
   }
 
   /**
+   * Apply a function `f` to the value of the current future. This is the same as #map except
+   * that the passed in value might be null.
+   */
+
+  fun <A, B> FluentFuture<A?>.mapNulllable(f: (A?) -> B): FluentFuture<B> {
+    return this.transform(Function<A?, B> { x -> f.invoke(x) }, MoreExecutors.directExecutor())
+  }
+
+  /**
    * Apply a function `f` to the value of the current future, yielding a new future.
    */
 

--- a/simplified-futures/src/main/java/org/nypl/simplified/futures/FluentFutureExtensions.kt
+++ b/simplified-futures/src/main/java/org/nypl/simplified/futures/FluentFutureExtensions.kt
@@ -37,7 +37,7 @@ object FluentFutureExtensions {
    * that the passed in value might be null.
    */
 
-  fun <A, B> FluentFuture<A?>.mapNulllable(f: (A?) -> B): FluentFuture<B> {
+  fun <A, B> FluentFuture<A?>.mapNullable(f: (A?) -> B): FluentFuture<B> {
     return this.transform(Function<A?, B> { x -> f.invoke(x) }, MoreExecutors.directExecutor())
   }
 

--- a/simplified-viewer-epub-readium2/build.gradle
+++ b/simplified-viewer-epub-readium2/build.gradle
@@ -3,6 +3,7 @@ dependencies {
   implementation project(":simplified-analytics-api")
   implementation project(":simplified-bookmarks-api")
   implementation project(":simplified-feeds-api")
+  implementation project(":simplified-futures")
   implementation project(":simplified-services-api")
   implementation project(":simplified-ui-thread-api")
   implementation project(":simplified-viewer-spi")

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Activity.kt
@@ -54,7 +54,7 @@ import org.nypl.simplified.books.api.BookDRMInformation
 import org.nypl.simplified.books.api.bookmark.Bookmark
 import org.nypl.simplified.books.api.bookmark.BookmarkKind
 import org.nypl.simplified.futures.FluentFutureExtensions.map
-import org.nypl.simplified.futures.FluentFutureExtensions.mapNulllable
+import org.nypl.simplified.futures.FluentFutureExtensions.mapNullable
 import org.nypl.simplified.futures.FluentFutureExtensions.onAnyError
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.nypl.simplified.ui.thread.api.UIThreadServiceType
@@ -448,8 +448,8 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
           accountID = parameters.accountId,
           bookmark = localBookmark
         ).onAnyError { localBookmark }
-          .mapNulllable { possiblyRemoteBookmark ->
-            onBookmarkWasCreated(possiblyRemoteBookmark, localBookmark, event)
+          .mapNullable { possiblyRemoteBookmark ->
+            onBookmarkWasCreated(possiblyRemoteBookmark ?: localBookmark, event)
           }
       }
 
@@ -500,18 +500,16 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
   }
 
   private fun onBookmarkWasCreated(
-    possiblyRemoteBookmark: Bookmark?,
-    localBookmark: Bookmark.ReaderBookmark,
+    bookmark: Bookmark,
     event: SR2Event.SR2BookmarkEvent.SR2BookmarkCreate
   ) {
-    val savedBookmark = possiblyRemoteBookmark ?: localBookmark
     this.bookmarkService.bookmarkCreateLocal(
       accountID = this.parameters.accountId,
-      bookmark = savedBookmark
+      bookmark = bookmark
     )
-    event.onBookmarkCreationCompleted(Reader2Bookmarks.toSR2Bookmark(savedBookmark))
+    event.onBookmarkCreationCompleted(Reader2Bookmarks.toSR2Bookmark(bookmark))
 
-    return when (savedBookmark.kind) {
+    return when (bookmark.kind) {
       BookmarkKind.BookmarkExplicit -> showToastMessage(R.string.reader_bookmark_added)
       BookmarkKind.BookmarkLastReadLocation -> Unit
     }

--- a/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Bookmarks.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/nypl/simplified/viewer/epub/readium2/Reader2Bookmarks.kt
@@ -39,32 +39,6 @@ object Reader2Bookmarks {
   }
 
   /**
-   * Create a bookmark.
-   */
-
-  fun createBookmarkRemotely(
-    bookmarkService: BookmarkServiceUsableType,
-    accountID: AccountID,
-    bookmark: Bookmark
-  ): Bookmark? {
-    return bookmarkService.bookmarkCreateRemote(
-      accountID = accountID,
-      bookmark = bookmark
-    ).get(15L, TimeUnit.SECONDS)
-  }
-
-  fun deleteBookmarkRemotely(
-    bookmarkService: BookmarkServiceUsableType,
-    accountID: AccountID,
-    bookmark: Bookmark
-  ): Boolean {
-    return bookmarkService.bookmarkDelete(
-      accountID = accountID,
-      bookmark = bookmark
-    ).get(15L, TimeUnit.SECONDS)
-  }
-
-  /**
    * Load bookmarks from the given bookmark service.
    */
 


### PR DESCRIPTION


Affects: https://ebce-lyrasis.atlassian.net/browse/PP-185

**What's this do?**

This corrects a number of bookmarking issues.

* The existing code leaked a thread on every controller event by creating an executor each time but not shutting it down.
* The SR2 code has been updated to publish the correct event on each page turn.
* The code now unconditionally creates a local bookmark even if saving the remote bookmark failed.
* Toast messages are not shown for page turns because this tends to result in an endless queue of toast messages.

**Why are we doing this? (w/ JIRA link if applicable)**

https://ebce-lyrasis.atlassian.net/browse/PP-187

**How should this be tested? / Do these changes have associated tests?**

Open an ePub and verify that turning pages and creating bookmarks works. Verify that they still work even if annotation syncing is disabled.

**Dependencies for merging? Releasing to production?**

https://github.com/ThePalaceProject/android-r2/pull/22

**Have you updated the changelog?**

Nope!

**Has the application documentation been updated for these changes?**

Nope!

**Did someone actually run this code to verify it works?**

@io7m tested locally.