### PR TITLE
Fixed crash after setting an audiobook timer more than once in a short time

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,7 +270,7 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-07-13T10:12:58+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-08-02T13:28:21+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
@@ -291,7 +291,8 @@
         <c:change date="2023-06-26T00:00:00+00:00" summary="Removed hardcoded message from LCP passphrase dialog."/>
         <c:change date="2023-07-04T00:00:00+00:00" summary="Fixed bug of bookmarks not being deleted."/>
         <c:change date="2023-07-11T00:00:00+00:00" summary="Added default LCP passphrase to be returned when the feed entry doesn't have one and the manual input is enabled."/>
-        <c:change date="2023-07-13T10:12:58+00:00" summary="Updated library card creation flow by requesting permissions and opening a WebView with the user's current location."/>
+        <c:change date="2023-07-13T00:00:00+00:00" summary="Updated library card creation flow by requesting permissions and opening a WebView with the user's current location."/>
+        <c:change date="2023-08-02T13:28:21+00:00" summary="Fixed crash after setting an audiobook timer more than once in a short time."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
+++ b/simplified-main/src/main/java/org/nypl/simplified/main/MainFragmentViewModel.kt
@@ -168,7 +168,6 @@ class MainFragmentViewModel(
         } catch (exception: Exception) {
           logger.debug(exception.message.orEmpty())
         }
-
       }
       .subscribeOn(Schedulers.io())
       .subscribe(


### PR DESCRIPTION
**What's this do?**
This PR adds a try-catch to the holds call on the MainFragmentViewModel because the app was crashing everytime the call was interrupted.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket reporting a bug](https://ebce-lyrasis.atlassian.net/browse/PP-116) that when an audiobook timer was set more than once in a short time the app was crashing. This was one of the reasons causing the call interruption and consequent crash, but there were more since this crash was reported several times on Crashlytics.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select any library
Open any audiobook
Start playing it
Change the playback speed
Set a timer
Set a different time right after setting the first one
Confirm the app is not crashing

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 