### PR TITLE
Fixed crash when saving a bookmark on the server

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,7 +270,7 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-08-02T13:28:21+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-08-02T17:23:07+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
@@ -292,7 +292,8 @@
         <c:change date="2023-07-04T00:00:00+00:00" summary="Fixed bug of bookmarks not being deleted."/>
         <c:change date="2023-07-11T00:00:00+00:00" summary="Added default LCP passphrase to be returned when the feed entry doesn't have one and the manual input is enabled."/>
         <c:change date="2023-07-13T00:00:00+00:00" summary="Updated library card creation flow by requesting permissions and opening a WebView with the user's current location."/>
-        <c:change date="2023-08-02T13:28:21+00:00" summary="Fixed crash after setting an audiobook timer more than once in a short time."/>
+        <c:change date="2023-08-02T00:00:00+00:00" summary="Fixed crash after setting an audiobook timer more than once in a short time."/>
+        <c:change date="2023-08-02T17:23:07+00:00" summary="Fixed crash when saving a bookmark on the server."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookHelpers.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookHelpers.kt
@@ -77,10 +77,15 @@ internal object AudioBookHelpers {
     accountID: AccountID,
     bookmark: Bookmark
   ): Bookmark? {
-    return bookmarkService.bookmarkCreateRemote(
-      accountID = accountID,
-      bookmark = bookmark
-    ).get(15L, TimeUnit.SECONDS)
+    return try {
+      bookmarkService.bookmarkCreateRemote(
+        accountID = accountID,
+        bookmark = bookmark
+      ).get(15L, TimeUnit.SECONDS)
+    } catch (exception: Exception) {
+      this.logger.error("could not add a bookmark remotely: ", exception)
+      null
+    }
   }
 
   /**
@@ -91,10 +96,15 @@ internal object AudioBookHelpers {
     accountID: AccountID,
     bookmark: Bookmark
   ): Boolean {
-    return bookmarkService.bookmarkDelete(
-      accountID = accountID,
-      bookmark = bookmark
-    ).get(15L, TimeUnit.SECONDS)
+    return try {
+      bookmarkService.bookmarkDelete(
+        accountID = accountID,
+        bookmark = bookmark
+      ).get(15L, TimeUnit.SECONDS)
+    } catch (exception: Exception) {
+      logger.error("could not delete the bookmark: ", exception)
+      false
+    }
   }
 
   /**


### PR DESCRIPTION
**What's this do?**
This PR adds a try-catch to two calls to the server: deleting and saving a bookmark. This is done to prevent the call from reaching its defined timeout and crashing the app.

**Why are we doing this? (w/ JIRA link if applicable)**
There are two tickets ([here](https://ebce-lyrasis.atlassian.net/browse/PP-218) and [here](https://ebce-lyrasis.atlassian.net/browse/PP-219)) reporting a crash that was happening after saving a bookmark to the server. Even though this [ticket's crash reproducing steps](https://ebce-lyrasis.atlassian.net/browse/PP-219) aren't related with the bookmarks the reason why it's crashing is because there's a timeout while saving the bookmark on the server (because it automatically saves the reading position) as it can be verified on [Crashlytics](https://console.firebase.google.com/project/the-palace-project/crashlytics/app/android:org.thepalaceproject.palace/issues/a3f32a5ad570f0c9076856c2ae0bad3e?time=1689984000000:1690329599000&types=crash&versions=1.5.0-SNAPSHOT-debug%20(73974790)&sessionEventKey=64BEF5AB02B1000102F32E16824C5518_1837955601532794198).

**How should this be tested? / Do these changes have associated tests?**
Just follow both tickets' reproducing steps ([here](https://ebce-lyrasis.atlassian.net/browse/PP-218) and [here](https://ebce-lyrasis.atlassian.net/browse/PP-219))

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 