### PR TITLE
Updated secrets.conf expected SHA value

### DIFF
--- a/simplified-app-palace/build.gradle
+++ b/simplified-app-palace/build.gradle
@@ -9,7 +9,7 @@ def requiredFiles = [:]
 requiredFiles["ReaderClientCert.sig"] =
   "b064e68b96e258e42fe1ca66ae3fc4863dd802c46585462220907ed291e1217d"
 requiredFiles["secrets.conf"] =
-  "9c211ae0d153c29b72baab3bfad9de6c5cecb6b39bcda8206d36a65aaca0db21"
+  "5801d64987fb1eb2fb3e32a5bae1063aa2e444723bc89b8a1230117b631940b7"
 
 android {
   defaultConfig {


### PR DESCRIPTION
**What's this do?**
This PR updates the expected SHA-256 value for the secrets.conf file.

**Why are we doing this? (w/ JIRA link if applicable)**
The pipeline is failing because it's expecting one value and it's given a different one.

**How should this be tested? / Do these changes have associated tests?**
The pipeline should successfully run

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 