### PR TITLE
Fixed crash when time tracking is not enabled

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -270,7 +270,7 @@
         <c:change date="2023-02-28T00:00:00+00:00" summary="Moved the 'Remove' button after the 'Get' button on the Reservations screen."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-08-09T11:40:36+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
+    <c:release date="2023-08-12T09:01:52+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.5.0">
       <c:changes>
         <c:change date="2023-03-30T00:00:00+00:00" summary="Save reading position of audiobooks on play, pause, and stop (which also includes when seeking and changing chapters)."/>
         <c:change date="2023-04-04T00:00:00+00:00" summary="Updated library logos loading source in registry feed."/>
@@ -294,7 +294,8 @@
         <c:change date="2023-07-13T00:00:00+00:00" summary="Updated library card creation flow by requesting permissions and opening a WebView with the user's current location."/>
         <c:change date="2023-08-02T00:00:00+00:00" summary="Fixed crash after setting an audiobook timer more than once in a short time."/>
         <c:change date="2023-08-02T00:00:00+00:00" summary="Fixed crash when saving a bookmark on the server."/>
-        <c:change date="2023-08-09T11:40:36+00:00" summary="Added feature to track playing time on audiobooks."/>
+        <c:change date="2023-08-09T00:00:00+00:00" summary="Added feature to track playing time on audiobooks."/>
+        <c:change date="2023-08-12T09:01:52+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-time-tracking/src/main/java/org/nypl/simplified/books/time/tracking/TimeTrackingService.kt
+++ b/simplified-books-time-tracking/src/main/java/org/nypl/simplified/books/time/tracking/TimeTrackingService.kt
@@ -135,6 +135,10 @@ class TimeTrackingService(
   }
 
   override fun onPlayerEventReceived(playerEvent: PlayerEvent) {
+    if (!isTimeTrackingEnabled()) {
+      return
+    }
+
     when (playerEvent) {
       is PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate,
       is PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted -> {
@@ -163,6 +167,10 @@ class TimeTrackingService(
   }
 
   override fun stopTracking() {
+    if (!isTimeTrackingEnabled()) {
+      return
+    }
+
     logger.debug("Stop tracking playing time")
 
     disposables.clear()


### PR DESCRIPTION
**What's this do?**
This PR fixes a crash when the user hasn't enabled the time traking feature and leaves the audiobook player screen after listening to it for some time.

**Why are we doing this? (w/ JIRA link if applicable)**
There's been a [Crashlytics stability issue](https://console.firebase.google.com/project/the-palace-project/crashlytics/app/android:org.thepalaceproject.palace/issues/4821ffda39f2376b4b9d1efd42a98bb0?time=last-seven-days&sessionEventKey=64D5E61703AD00011A2DDC0F82053334_1844413704638796368) related with this problem.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Go to Debug settings and disable the "Time tracking" option
Go to Minotaur Test Library
Open any audiobook from Biblioboard
Listen to it for some time
Close the audiobook player
Confirm the app is not crashing

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 