### PR TITLE
PP-328: Audio book time tracking is on!

### DIFF
--- a/simplified-books-time-tracking/src/main/java/org/nypl/simplified/books/time/tracking/TimeTrackingService.kt
+++ b/simplified-books-time-tracking/src/main/java/org/nypl/simplified/books/time/tracking/TimeTrackingService.kt
@@ -66,10 +66,6 @@ class TimeTrackingService(
     libraryId: String,
     timeTrackingUri: URI?
   ) {
-    if (!isTimeTrackingEnabled()) {
-      return
-    }
-
     if (timeTrackingUri == null) {
       logger.debug(
         "Account {} and book {} has no time tracking uri",
@@ -135,10 +131,6 @@ class TimeTrackingService(
   }
 
   override fun onPlayerEventReceived(playerEvent: PlayerEvent) {
-    if (!isTimeTrackingEnabled()) {
-      return
-    }
-
     when (playerEvent) {
       is PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate,
       is PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted -> {
@@ -167,10 +159,6 @@ class TimeTrackingService(
   }
 
   override fun stopTracking() {
-    if (!isTimeTrackingEnabled()) {
-      return
-    }
-
     logger.debug("Stop tracking playing time")
 
     disposables.clear()
@@ -202,7 +190,7 @@ class TimeTrackingService(
   private fun handleConnectivityState(hasInternet: Boolean) {
     // if the user is on an audiobook player screen, it means the entries will most likely be sent
     // to the server, so there's no need to do anything else
-    if (isOnAudiobookScreen || !isTimeTrackingEnabled()) {
+    if (isOnAudiobookScreen) {
       return
     }
 
@@ -399,9 +387,5 @@ class TimeTrackingService(
           }
         )
     )
-  }
-
-  private fun isTimeTrackingEnabled(): Boolean {
-    return profilesController.profileCurrent().preferences().isTimeTrackingEnabled
   }
 }

--- a/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
+++ b/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
@@ -50,10 +50,6 @@ data class ProfilePreferences(
 
   val isManualLCPPassphraseEnabled: Boolean = false,
 
-  /** @return `true` if the time tracking feature is enabled. */
-
-  val isTimeTrackingEnabled: Boolean = true,
-
   /** @return `true` if the debug settings should be visible. */
 
   val showDebugSettings: Boolean = false

--- a/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
+++ b/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
@@ -50,9 +50,9 @@ data class ProfilePreferences(
 
   val isManualLCPPassphraseEnabled: Boolean = false,
 
-  /** @return `true` if the time tracking feature. */
+  /** @return `true` if the time tracking feature is enabled. */
 
-  val isTimeTrackingEnabled: Boolean = false,
+  val isTimeTrackingEnabled: Boolean = true,
 
   /** @return `true` if the debug settings should be visible. */
 

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
@@ -207,9 +207,6 @@ object ProfileDescriptionJSON {
     val isManualLCPPassphraseEnabled =
       JSONParserUtilities.getBooleanDefault(objectNode, "isManualLCPPassphraseEnabled", false)
 
-    val isTimeTrackingEnabled =
-      JSONParserUtilities.getBooleanDefault(objectNode, "isTimeTrackingEnabled", true)
-
     val mostRecentAccount =
       JSONParserUtilities.getStringOrNull(objectNode, "mostRecentAccount")
         ?.let { AccountID(UUID.fromString(it)) }
@@ -224,8 +221,7 @@ object ProfileDescriptionJSON {
       showDebugSettings = showDebugSettings,
       playbackRates = playbackRates,
       sleepTimers = sleepTimers,
-      isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled,
-      isTimeTrackingEnabled = isTimeTrackingEnabled
+      isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled
     )
   }
 
@@ -261,9 +257,6 @@ object ProfileDescriptionJSON {
     val isManualLCPPassphraseEnabled =
       JSONParserUtilities.getBooleanDefault(objectNode, "isManualLCPPassphraseEnabled", false)
 
-    val isTimeTrackingEnabled =
-      JSONParserUtilities.getBooleanDefault(objectNode, "isTimeTrackingEnabled", true)
-
     val mostRecentAccount =
       JSONParserUtilities.getStringOrNull(objectNode, "mostRecentAccount")
         ?.let { AccountID(UUID.fromString(it)) }
@@ -277,8 +270,7 @@ object ProfileDescriptionJSON {
       hasSeenLibrarySelectionScreen = true,
       playbackRates = playbackRates,
       sleepTimers = sleepTimers,
-      isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled,
-      isTimeTrackingEnabled = isTimeTrackingEnabled
+      isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled
     )
   }
 
@@ -338,9 +330,6 @@ object ProfileDescriptionJSON {
     val isManualLCPPassphraseEnabled =
       JSONParserUtilities.getBooleanDefault(preferencesNode, "isManualLCPPassphraseEnabled", false)
 
-    val isTimeTrackingEnabled =
-      JSONParserUtilities.getBooleanDefault(preferencesNode, "isTimeTrackingEnabled", false)
-
     val preferences =
       ProfilePreferences(
         dateOfBirth = this.someOrNull(dateOfBirth),
@@ -350,8 +339,7 @@ object ProfileDescriptionJSON {
         hasSeenLibrarySelectionScreen = true,
         playbackRates = playbackRates,
         sleepTimers = sleepTimers,
-        isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled,
-        isTimeTrackingEnabled = isTimeTrackingEnabled,
+        isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled
       )
 
     val attributeMap = mutableMapOf<String, String>()
@@ -499,7 +487,6 @@ object ProfileDescriptionJSON {
     val output = objectMapper.createObjectNode()
     output.put("showTestingLibraries", preferences.showTestingLibraries)
     output.put("isManualLCPPassphraseEnabled", preferences.isManualLCPPassphraseEnabled)
-    output.put("isTimeTrackingEnabled", preferences.isTimeTrackingEnabled)
     output.put("hasSeenLibrarySelectionScreen", preferences.hasSeenLibrarySelectionScreen)
     output.put("showDebugSettings", preferences.showDebugSettings)
     output.put("mostRecentAccount", preferences.mostRecentAccount.uuid.toString())

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
@@ -208,7 +208,7 @@ object ProfileDescriptionJSON {
       JSONParserUtilities.getBooleanDefault(objectNode, "isManualLCPPassphraseEnabled", false)
 
     val isTimeTrackingEnabled =
-      JSONParserUtilities.getBooleanDefault(objectNode, "isTimeTrackingEnabled", false)
+      JSONParserUtilities.getBooleanDefault(objectNode, "isTimeTrackingEnabled", true)
 
     val mostRecentAccount =
       JSONParserUtilities.getStringOrNull(objectNode, "mostRecentAccount")
@@ -262,7 +262,7 @@ object ProfileDescriptionJSON {
       JSONParserUtilities.getBooleanDefault(objectNode, "isManualLCPPassphraseEnabled", false)
 
     val isTimeTrackingEnabled =
-      JSONParserUtilities.getBooleanDefault(objectNode, "isTimeTrackingEnabled", false)
+      JSONParserUtilities.getBooleanDefault(objectNode, "isTimeTrackingEnabled", true)
 
     val mostRecentAccount =
       JSONParserUtilities.getStringOrNull(objectNode, "mostRecentAccount")

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
@@ -502,8 +502,7 @@ object ProfilesDatabases {
               hasSeenLibrarySelectionScreen = false,
               playbackRates = hashMapOf(),
               sleepTimers = hashMapOf(),
-              isManualLCPPassphraseEnabled = false,
-              isTimeTrackingEnabled = false,
+              isManualLCPPassphraseEnabled = false
             ),
             attributes = ProfileAttributes(sortedMapOf())
           )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
@@ -56,8 +56,7 @@ class ProfileDescriptionJSONTest {
           mostRecentAccount = AccountID.generate(),
           playbackRates = hashMapOf(),
           sleepTimers = hashMapOf(),
-          isManualLCPPassphraseEnabled = false,
-          isTimeTrackingEnabled = false
+          isManualLCPPassphraseEnabled = false
         ),
         attributes = ProfileAttributes(
           sortedMapOf(

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
@@ -37,8 +37,7 @@ class MockProfile(
         mostRecentAccount = this.accounts.firstKey(),
         playbackRates = hashMapOf(),
         sleepTimers = hashMapOf(),
-        isManualLCPPassphraseEnabled = false,
-        isTimeTrackingEnabled = false
+        isManualLCPPassphraseEnabled = false
       ),
       attributes = ProfileAttributes(sortedMapOf())
     )

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
@@ -65,7 +65,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
   private lateinit var enableOpenEBooksQA: Button
   private lateinit var toolbar: NeutralToolbar
   private lateinit var isManualLCPPassphraseEnabled: SwitchCompat
-  private lateinit var isTimeTrackingEnabled: SwitchCompat
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
@@ -98,8 +97,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       view.findViewById(R.id.settingsVersionDevSeenLibrarySelectionScreen)
     this.isManualLCPPassphraseEnabled =
       view.findViewById(R.id.settingsVersionDevIsManualLCPPassphraseEnabled)
-    this.isTimeTrackingEnabled =
-      view.findViewById(R.id.settingsVersionDevIsTimeTrackingEnabled)
     this.cardCreatorFakeLocation =
       view.findViewById(R.id.settingsVersionDevCardCreatorLocationSwitch)
     this.showOnlySupportedBooks =
@@ -140,8 +137,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       this.viewModel.cardCreatorFakeLocation
     this.isManualLCPPassphraseEnabled.isChecked =
       this.viewModel.isManualLCPPassphraseEnabled
-    this.isTimeTrackingEnabled.isChecked =
-      this.viewModel.isTimeTrackingEnabled
     this.showOnlySupportedBooks.isChecked =
       this.viewModel.showOnlySupportedBooks
     this.crashlyticsId.text =
@@ -244,9 +239,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
     }
     this.isManualLCPPassphraseEnabled.setOnCheckedChangeListener { _, isChecked ->
       this.viewModel.isManualLCPPassphraseEnabled = isChecked
-    }
-    this.isTimeTrackingEnabled.setOnCheckedChangeListener { _, isChecked ->
-      this.viewModel.isTimeTrackingEnabled = isChecked
     }
 
     /*

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
@@ -148,18 +148,6 @@ class SettingsDebugViewModel(application: Application) : AndroidViewModel(applic
       }
     }
 
-  var isTimeTrackingEnabled: Boolean
-    get() =
-      this.profilesController
-        .profileCurrent()
-        .preferences()
-        .isTimeTrackingEnabled
-    set(value) {
-      this.profilesController.profileUpdate { description ->
-        description.copy(preferences = description.preferences.copy(isTimeTrackingEnabled = value))
-      }
-    }
-
   var isBootFailureEnabled: Boolean
     get() =
       BootFailureTesting.isBootFailureEnabled(getApplication())

--- a/simplified-ui-settings/src/main/res/layout/settings_debug.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_debug.xml
@@ -168,16 +168,6 @@
         android:text="@string/settingsDevEnableManualLCPPassphrase" />
 
     <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/settingsVersionDevIsTimeTrackingEnabled"
-        android:theme="@style/Enabled.Switch"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:checked="false"
-        android:enabled="true"
-        android:text="@string/settingsDevEnableTimeTracking" />
-
-    <androidx.appcompat.widget.SwitchCompat
       android:id="@+id/settingsVersionDevProductionLibrariesSwitch"
       android:theme="@style/Enabled.Switch"
       android:layout_width="match_parent"


### PR DESCRIPTION
**What's this do?**

~This sets the default for audio book time tracking to be on instead of off. Note that, for installations that have been used during development of the time tracking feature, there might already be a setting of "off" saved to the device, so this will require manually toggling the setting back on again. We have no way to know if the setting is "off" because the user turned it off, or if it's "off" because that was the default and the user never even saw the debug settings screen. This shouldn't affect anyone upgrading from a production release, or any new installs.~

This turns on time tracking unconditionally. Any preferences to turn it off have been removed, along with the settings in the debug menu.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-328

**How should this be tested? / Do these changes have associated tests?**
Check that the setting is on, on a fresh install or an upgrade from the Play Store release.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
Nope.

**Has the application documentation been updated for these changes?**
Nope.

**Did someone actually run this code to verify it works?**
@io7m tried it.