### PR TITLE
PP-353: Correct a lateinit issue

### DIFF
--- a/simplified-books-time-tracking/src/main/java/org/nypl/simplified/books/time/tracking/TimeTrackingService.kt
+++ b/simplified-books-time-tracking/src/main/java/org/nypl/simplified/books/time/tracking/TimeTrackingService.kt
@@ -50,6 +50,7 @@ class TimeTrackingService(
   private var isPlaying = false
   private var isOnAudiobookScreen = false
   private var shouldSaveRemotely = false
+  private var tracking = false
 
   init {
     connectivityListener = TimeTrackingConnectivityListener(
@@ -66,6 +67,7 @@ class TimeTrackingService(
     libraryId: String,
     timeTrackingUri: URI?
   ) {
+    this.tracking = timeTrackingUri != null
     if (timeTrackingUri == null) {
       logger.debug(
         "Account {} and book {} has no time tracking uri",
@@ -131,6 +133,10 @@ class TimeTrackingService(
   }
 
   override fun onPlayerEventReceived(playerEvent: PlayerEvent) {
+    if (!this.tracking) {
+      return
+    }
+
     when (playerEvent) {
       is PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackProgressUpdate,
       is PlayerEvent.PlayerEventWithSpineElement.PlayerEventPlaybackStarted -> {
@@ -159,6 +165,10 @@ class TimeTrackingService(
   }
 
   override fun stopTracking() {
+    if (!this.tracking) {
+      return
+    }
+
     logger.debug("Stop tracking playing time")
 
     disposables.clear()


### PR DESCRIPTION
**What's this do?**
This avoids any use of the time tracking service if the current book doesn't have a time tracking URI.

**Why are we doing this? (w/ JIRA link if applicable)**
Affect: https://ebce-lyrasis.atlassian.net/browse/PP-353

**How should this be tested? / Do these changes have associated tests?**
Try an audio book without a time tracking URI.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
No need.

**Has the application documentation been updated for these changes?**
No need.

**Did someone actually run this code to verify it works?**
@io7m tried it