### PR TITLE
Fixed crash when opening an audiobook with a null manifest

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,9 +298,10 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-08-24T16:09:29+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-08-28T15:28:36+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
-        <c:change date="2023-08-24T16:09:29+00:00" summary="Updated Kotlin version to 1.9.0"/>
+        <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
+        <c:change date="2023-08-28T15:28:36+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookLoadingFragment.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookLoadingFragment.kt
@@ -73,7 +73,7 @@ class AudioBookLoadingFragment : Fragment() {
     super.onCreate(state)
 
     this.loadingParameters =
-      this.arguments!!.getSerializable(parametersKey)
+      requireArguments().getSerializable(parametersKey)
         as AudioBookLoadingFragmentParameters
 
     val services = Services.serviceDirectory()
@@ -149,8 +149,9 @@ class AudioBookLoadingFragment : Fragment() {
         )
         strategyResult.result
       }
-      is TaskResult.Failure ->
+      is TaskResult.Failure -> {
         throw IOException(strategyResult.message)
+      }
     }
   }
 }

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -119,7 +119,7 @@ class AudioBookPlayerActivity :
 
     fun startActivity(
       from: Activity,
-      parameters: AudioBookPlayerParameters
+      parameters: AudioBookPlayerParameters?
     ) {
       val b = Bundle()
       b.putSerializable(this.PARAMETER_ID, parameters)
@@ -177,7 +177,16 @@ class AudioBookPlayerActivity :
     val i = this.intent!!
     val a = i.extras!!
 
-    this.parameters = a.getSerializable(PARAMETER_ID) as AudioBookPlayerParameters
+    this.parameters = a.getSerializable(PARAMETER_ID) as? AudioBookPlayerParameters ?: kotlin.run {
+      val title = getString(R.string.audio_book_player_error_book_open)
+      this.showErrorWithRunnable(
+        context = this,
+        title = title,
+        failure = IllegalStateException(title),
+        execute = this::finish
+      )
+      return
+    }
 
     this.log.debug("manifest file: {}", this.parameters.manifestFile)
     this.log.debug("manifest uri:  {}", this.parameters.manifestURI)
@@ -222,8 +231,7 @@ class AudioBookPlayerActivity :
         .findFormatHandle(BookDatabaseEntryFormatHandleAudioBook::class.java)
 
     if (formatHandleOpt == null) {
-      val title =
-        this.resources.getString(R.string.audio_book_player_error_book_open)
+      val title = getString(R.string.audio_book_player_error_book_open)
       this.showErrorWithRunnable(
         context = this,
         title = title,
@@ -429,8 +437,7 @@ class AudioBookPlayerActivity :
     )
 
     if (engine == null) {
-      val title =
-        this.resources.getString(R.string.audio_book_player_error_engine_open)
+      val title = getString(R.string.audio_book_player_error_engine_open)
       this.showErrorWithRunnable(
         context = this,
         title = title,
@@ -464,8 +471,7 @@ class AudioBookPlayerActivity :
       )
 
     if (bookResult is PlayerResult.Failure) {
-      val title =
-        this.resources.getString(R.string.audio_book_player_error_book_open)
+      val title = getString(R.string.audio_book_player_error_book_open)
       this.showErrorWithRunnable(
         context = this,
         title = title,

--- a/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookViewer.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/nypl/simplified/viewer/audiobook/AudioBookViewer.kt
@@ -56,12 +56,12 @@ class AudioBookViewer : ViewerProviderType {
     val file =
       formatAudio.file
     val manifest =
-      formatAudio.manifest!!
+      formatAudio.manifest
     val httpClient =
       Services.serviceDirectory()
         .requireService(LSHTTPClientType::class.java)
 
-    val params =
+    val params = if (manifest != null) {
       AudioBookPlayerParameters(
         accountID = book.account,
         accountProviderID = accountProviderId,
@@ -74,6 +74,9 @@ class AudioBookViewer : ViewerProviderType {
         opdsEntry = book.entry,
         userAgent = httpClient.userAgent()
       )
+    } else {
+      null
+    }
 
     AudioBookPlayerActivity.startActivity(activity, params)
   }


### PR DESCRIPTION
**What's this do?**
This PR adds a fix for a [recurring crash](https://console.firebase.google.com/project/the-palace-project/crashlytics/app/android:org.thepalaceproject.palace/issues/4ad2d33871ca99f04955282e20c54b32) when trying to open a an audiobook with a null manifest.

**Why are we doing this? (w/ JIRA link if applicable)**
There's been a peak of crashes, as reported [here](https://ebce-lyrasis.atlassian.net/browse/PP-382) related to this issue.

**How should this be tested? / Do these changes have associated tests?**
I'm not sure in which book(s) this's been happening with, so I don't know exactly how to replicate this issue, but trying to open a significant number of audiobooks should not result in a crash.

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Not exactly