### PR TITLE
PP-406: Initialize services eagerly

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,12 +298,17 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-11T15:23:28+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-09-18T10:20:04+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
         <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Added support to basic auth token login."/>
-        <c:change date="2023-09-11T15:23:28+00:00" summary="Added support to push notifications and FCM token retrieval."/>
+        <c:change date="2023-09-11T00:00:00+00:00" summary="Added support to push notifications and FCM token retrieval."/>
+        <c:change date="2023-09-18T10:20:04+00:00" summary="Fix an audio book player crash.">
+          <c:tickets>
+            <c:ticket id="PP-406"/>
+          </c:tickets>
+        </c:change>
       </c:changes>
     </c:release>
   </c:releases>


### PR DESCRIPTION
**What's this do?**
This changes the audio book player activity to initialize services eagerly so that they're available to the error handling methods should the activity be called without usable parameters.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-406

**How should this be tested? / Do these changes have associated tests?**
Unfortunately, we don't know why the audio book player activity was being called without usable parameters, because we don't yet know why some manifests are resulting in unexpected null values.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
Yes.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Verified that the audio book player still works.