### PR TITLE
Added missing auth type on authentication object parsing

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,12 +298,13 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-11T15:23:28+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-09-18T10:56:39+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
         <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Added support to basic auth token login."/>
-        <c:change date="2023-09-11T15:23:28+00:00" summary="Added support to push notifications and FCM token retrieval."/>
+        <c:change date="2023-09-11T00:00:00+00:00" summary="Added support to push notifications and FCM token retrieval."/>
+        <c:change date="2023-09-18T10:56:39+00:00" summary="Added missing auth type on authentication object parsing."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountProvidersJSON.kt
@@ -165,6 +165,7 @@ object AccountProvidersJSON {
       is BasicToken -> {
         val authObject = mapper.createObjectNode()
         authObject.put("type", BASIC_TOKEN_TYPE)
+        this.putConditionally(authObject, "authenticationURI", authentication.authenticationURI.toString())
         this.putConditionally(authObject, "barcodeFormat", authentication.barcodeFormat?.uppercase(Locale.ROOT))
         this.putConditionally(authObject, "description", authentication.description)
         this.putConditionally(authObject, "keyboard", authentication.keyboard.name)
@@ -462,6 +463,43 @@ object AccountProvidersJSON {
           passwordMaximumLength = passwordMaximumLength
         )
       }
+
+      BASIC_TOKEN_TYPE -> {
+        val labels =
+          this.toStringMap(JSONParserUtilities.getObject(container, "labels"))
+        val barcodeFormat =
+          JSONParserUtilities.getStringOrNull(container, "barcodeFormat")
+            ?.uppercase(Locale.ROOT)
+        val keyboard =
+          this.parseKeyboardType(JSONParserUtilities.getStringOrNull(container, "keyboard"))
+        val passwordMaximumLength =
+          JSONParserUtilities.getIntegerDefault(container, "passwordMaximumLength", 0)
+        val passwordKeyboard =
+          this.parseKeyboardType(
+            JSONParserUtilities.getStringOrNull(
+              container,
+              "passwordKeyboard"
+            )
+          )
+        val description =
+          JSONParserUtilities.getString(container, "description")
+        val logoURI =
+          JSONParserUtilities.getURIOrNull(container, "logo")
+        val authenticationURI =
+          JSONParserUtilities.getURIOrNull(container, "authenticationURI")
+
+        BasicToken(
+          barcodeFormat = barcodeFormat,
+          description = description,
+          keyboard = keyboard,
+          labels = labels,
+          logoURI = logoURI,
+          passwordKeyboard = passwordKeyboard,
+          passwordMaximumLength = passwordMaximumLength,
+          authenticationURI = authenticationURI
+        )
+      }
+
       COPPA_TYPE -> {
         COPPAAgeGate(
           greaterEqual13 =

--- a/simplified-app-palace/build.gradle.kts
+++ b/simplified-app-palace/build.gradle.kts
@@ -589,7 +589,6 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.transifex.common)
     implementation(libs.transifex.sdk)
-    implementation(libs.transifex.sdk)
     implementation(libs.transport.api)
     implementation(libs.transport.backend.cct)
     implementation(libs.transport.runtime)


### PR DESCRIPTION
**What's this do?**
This PR adds a missing auth type (basic token) to the authentication object parsing.

**Why are we doing this? (w/ JIRA link if applicable)**
There was a auth type that was not being handled on [this feature](https://ebce-lyrasis.atlassian.net/browse/PP-435).

**How should this be tested? / Do these changes have associated tests?**
*NOTE: To avoid previous versions conflicts, I suggest you to uninstall and install the app* 
Perform login/logout on LYRASIS Reads
Perform book opertaions on LYRASIS Reads

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 