### PR TITLE
PP-465: Make the OPDS entry parser tolerant to missing author names

### DIFF
--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryParser.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSAcquisitionFeedEntryParser.java
@@ -68,15 +68,17 @@ public final class OPDSAcquisitionFeedEntryParser implements OPDSAcquisitionFeed
 
   private void findAcquisitionAuthors(
     final Element element,
-    final OPDSAcquisitionFeedEntryBuilderType eb)
-    throws OPDSParseException {
-
+    final OPDSAcquisitionFeedEntryBuilderType eb) {
     final List<Element> e_authors =
       OPDSXML.getChildElementsWithName(element, ATOM_URI, "author");
     for (final Element ea : e_authors) {
-      final String name =
-        OPDSXML.getFirstChildElementTextWithName(Objects.requireNonNull(ea), ATOM_URI, "name");
-      eb.addAuthor(name);
+      final OptionType<Element> name =
+        OPDSXML.getFirstChildElementWithNameOptional(
+          Objects.requireNonNull(ea), ATOM_URI, "name");
+
+      if (name instanceof Some) {
+        eb.addAuthor(((Some<Element>) name).get().getTextContent());
+      }
     }
   }
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedEntryParserTest.java
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/opds/OPDSFeedEntryParserTest.java
@@ -28,6 +28,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
+import java.util.List;
 
 import one.irradia.mime.api.MIMEType;
 import one.irradia.mime.vanilla.MIMEParser;
@@ -462,6 +463,18 @@ public final class OPDSFeedEntryParserTest {
       URI.create("urn:test"),
       OPDSFeedEntryParserTest.getResource("date-bug.xml")
     );
+  }
+
+  @Test
+  public void testBugPP465()
+    throws Exception {
+    final OPDSAcquisitionFeedEntryParserType parser = this.getParser();
+    final OPDSAcquisitionFeedEntry e = parser.parseEntryStream(URI.create("urn:test"),
+      OPDSFeedEntryParserTest.getResource(
+        "bug-pp-465.xml"));
+
+    Assertions.assertEquals(1, e.getAcquisitions().size());
+    Assertions.assertEquals(List.of(), e.getAuthors());
   }
 
   private OPDSAcquisitionFeedEntryParserType getParser() {

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/bug-pp-465.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/bug-pp-465.xml
@@ -1,0 +1,19 @@
+<entry
+  xmlns:schema="http://schema.org/"
+  xmlns="http://www.w3.org/2005/Atom"
+  schema:additionalType="http://schema.org/Book">
+  <id>Open-Access</id>
+  <title>Open-Access</title>
+  <author />
+  <summary type="html"></summary>
+  <updated>2015-08-17T20:37:53Z</updated>
+  <published>2014-08-29T10:46:42Z</published>
+  <link href="https://example.com/Open-Access"
+        type="application/epub+zip"
+        rel="http://opds-spec.org/acquisition/open-access"/>
+  <link href="http://example.com/Open-Access"
+        rel="http://opds-spec.org/acquisition/borrow">
+  </link>
+  <link rel="http://librarysimplified.org/terms/rel/revoke"
+        href="http://example.com/revoke"/>
+</entry>


### PR DESCRIPTION
**What's this do?**
This allows the OPDS parser to handle empty author elements.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-465

**How should this be tested? / Do these changes have associated tests?**
Check the Minotaur front page.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Ran the new test, and checked Minotaur.