### PR TITLE
PP-418: Fix SAML login button accessibility label

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,7 +298,7 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-18T11:02:52+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-09-20T09:47:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
         <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
@@ -309,7 +309,12 @@
             <c:ticket id="PP-406"/>
           </c:tickets>
         </c:change>
-        <c:change date="2023-09-18T11:02:52+00:00" summary="Added missing auth type on authentication object parsing."/>
+        <c:change date="2023-09-18T00:00:00+00:00" summary="Added missing auth type on authentication object parsing."/>
+        <c:change date="2023-09-20T09:47:38+00:00" summary="Fix SAML login button accessibility label.">
+          <c:tickets>
+            <c:ticket id="PP-418"/>
+          </c:tickets>
+        </c:change>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-accounts/src/main/res/layout/auth_saml.xml
+++ b/simplified-ui-accounts/src/main/res/layout/auth_saml.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:id="@+id/authSAML"
-  android:layout_width="match_parent"
-  android:layout_height="wrap_content"
-  android:layout_margin="16dp"
-  android:orientation="vertical">
+    android:id="@+id/authSAML"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="16dp"
+    android:orientation="vertical">
 
-  <Button
-    android:id="@+id/authSAMLLogin"
-    android:layout_width="256dp"
-    android:layout_height="48dp"
-    android:layout_gravity="center"
-    android:layout_marginTop="16dp"
-    android:layout_marginBottom="16dp"
-    android:text="@string/accountPlaceholder" />
+    <Button
+        android:id="@+id/authSAMLLogin"
+        android:layout_width="256dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:contentDescription="@string/accountSAML20LoginLabel"
+        android:text="@string/accountPlaceholder" />
 
-  <TextView
-      android:id="@+id/resetPasswordLabel"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_gravity="center"
-      android:layout_marginBottom="8dp"
-      android:padding="8dp"
-      android:text="@string/accountForgotPassword" />
+    <TextView
+        android:id="@+id/resetPasswordLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginBottom="8dp"
+        android:padding="8dp"
+        android:text="@string/accountForgotPassword" />
 
 </LinearLayout>

--- a/simplified-ui-accounts/src/main/res/values/strings.xml
+++ b/simplified-ui-accounts/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
   <string name="accountUserName">User Name</string>
   <string name="accountCustomOPDS">Custom OPDS Feed URL</string>
   <string name="currentlyBrowsing">You\'re currently browsing</string>
+  <string name="accountSAML20LoginLabel">Sign in with SAML 2.0 WEB SSO</string>
   <string name="accountSAML20NoAccessToken">Failed to retrieve an access token from the URI: %1$s</string>
   <string name="accountSAML20NoPatronInfo">Failed to retrieve patron info from the URI: %1$s</string>
   <string name="accountSearchHint">Search accounts&#8230;</string>


### PR DESCRIPTION
**What's this do?**
This adds a missing accessibility label to the SAML login button.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-418

**How should this be tested? / Do these changes have associated tests?**
Try selecting the button with Talkback enabled and verify that there's a usable button description.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
Yes.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried the button with Samsung Talkback enabled. I assume Google Talkback would work similarly!