### PR TITLE
PP-443: Restrict cover widths

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,7 +298,7 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-20T12:49:37+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-09-20T14:23:59+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
         <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
@@ -315,7 +315,12 @@
             <c:ticket id="PP-418"/>
           </c:tickets>
         </c:change>
-        <c:change date="2023-09-20T12:49:37+00:00" summary="Changed BasicToken login request method to POST."/>
+        <c:change date="2023-09-20T00:00:00+00:00" summary="Changed BasicToken login request method to POST."/>
+        <c:change date="2023-09-20T14:23:59+00:00" summary="Very wide covers have their widths restricted to avoid breaking the UI.">
+          <c:tickets>
+            <c:ticket id="PP-443"/>
+          </c:tickets>
+        </c:change>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/res/layout/book_detail.xml
+++ b/simplified-ui-catalog/src/main/res/layout/book_detail.xml
@@ -32,6 +32,7 @@
                     android:id="@+id/bookDetailCoverImage"
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
+                    android:maxWidth="@dimen/catalogBookDetailCoverMaximumWidth"
                     android:adjustViewBounds="true"
                     android:contentDescription="@null"
                     android:scaleType="fitXY"

--- a/simplified-ui-catalog/src/main/res/layout/feed_lane_item.xml
+++ b/simplified-ui-catalog/src/main/res/layout/feed_lane_item.xml
@@ -1,27 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:clipChildren="false"
-    android:clipToPadding="false"
-    android:orientation="vertical">
+    android:layout_height="@dimen/cover_thumbnail_height"
+    app:cardCornerRadius="@dimen/cover_corner_radius"
+    app:cardElevation="2dp">
 
-    <androidx.cardview.widget.CardView
+    <ImageView
+        android:id="@+id/coverImage"
         android:layout_width="wrap_content"
-        android:layout_height="@dimen/cover_thumbnail_height"
-        app:cardCornerRadius="@dimen/cover_corner_radius"
-        app:cardElevation="2dp">
-
-        <ImageView
-            android:id="@+id/coverImage"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:adjustViewBounds="true"
-            android:contentDescription="@null"
-            android:maxWidth="@dimen/catalogLaneCoverMaximumWidth"
-            android:scaleType="fitXY"
-            app:srcCompat="@drawable/cover_loading" />
-    </androidx.cardview.widget.CardView>
-</LinearLayout>
+        android:layout_height="match_parent"
+        android:adjustViewBounds="true"
+        android:contentDescription="@null"
+        android:maxWidth="@dimen/catalogLaneCoverMaximumWidth"
+        android:scaleType="fitXY"
+        app:srcCompat="@drawable/cover_loading" />
+</androidx.cardview.widget.CardView>

--- a/simplified-ui-catalog/src/main/res/layout/feed_lane_item.xml
+++ b/simplified-ui-catalog/src/main/res/layout/feed_lane_item.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:layout_width="wrap_content"
-  android:layout_height="wrap_content"
-  android:clipChildren="false"
-  android:clipToPadding="false"
-  android:orientation="vertical">
-
-  <androidx.cardview.widget.CardView
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
-    android:layout_height="@dimen/cover_thumbnail_height"
-    app:cardCornerRadius="@dimen/cover_corner_radius"
-    app:cardElevation="2dp">
+    android:layout_height="wrap_content"
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:orientation="vertical">
 
-    <ImageView
-      android:id="@+id/coverImage"
-      android:layout_width="wrap_content"
-      android:layout_height="match_parent"
-      android:adjustViewBounds="true"
-      android:contentDescription="@null"
-      android:scaleType="fitXY"
-      app:srcCompat="@drawable/cover_loading" />
-  </androidx.cardview.widget.CardView>
+    <androidx.cardview.widget.CardView
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/cover_thumbnail_height"
+        app:cardCornerRadius="@dimen/cover_corner_radius"
+        app:cardElevation="2dp">
+
+        <ImageView
+            android:id="@+id/coverImage"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:adjustViewBounds="true"
+            android:contentDescription="@null"
+            android:maxWidth="@dimen/catalogLaneCoverMaximumWidth"
+            android:scaleType="fitXY"
+            app:srcCompat="@drawable/cover_loading" />
+    </androidx.cardview.widget.CardView>
 </LinearLayout>

--- a/simplified-ui-catalog/src/main/res/values/dimensions.xml
+++ b/simplified-ui-catalog/src/main/res/values/dimensions.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <resources>
+  <dimen name="catalogLaneCoverMaximumWidth">96dp</dimen>
+  <dimen name="catalogBookDetailCoverMaximumWidth">128dp</dimen>
+
   <dimen name="catalogBookDetailStatusHeight">64dp</dimen>
   <dimen name="catalogBookDetailButtonsHeight">64dp</dimen>
   <dimen name="catalogFeedCoversSpace">8dp</dimen>


### PR DESCRIPTION
**What's this do?**
This sets maximum widths for covers so that very large covers can no longer break the UI.

Before:

![Screenshot_20230911_104338](https://github.com/ThePalaceProject/android-core/assets/612494/78b5f465-6c55-45e9-b3e7-341f6b6befc5)

![Screenshot_20230911_104354](https://github.com/ThePalaceProject/android-core/assets/612494/dab1d569-701b-4e21-8746-68f313a5e9ef)

After:

![Screenshot_20230920_142139](https://github.com/ThePalaceProject/android-core/assets/612494/aac081e0-35b0-4377-83e0-2f74387e5121)

![Screenshot_20230920_142525](https://github.com/ThePalaceProject/android-core/assets/612494/db1b3fea-7d93-45c2-b888-f8430a629026)

**Why are we doing this? (w/ JIRA link if applicable)**
https://ebce-lyrasis.atlassian.net/browse/PP-443

**How should this be tested? / Do these changes have associated tests?**
Try Minotaur. The book is on the front page now.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
Yes.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Took the screenshots above!