### PR TITLE
PP-86: Add a string that should be translated by Transifex.

### DIFF
--- a/simplified-ui-settings/src/main/res/layout/settings_debug.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_debug.xml
@@ -235,5 +235,11 @@
       android:text="@string/settingsDevToggleOpenEBooksQAAccount" />
 
     <include layout="@layout/settings_debug_library_registry" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/settingsDebugTransifex"/>
   </LinearLayout>
 </ScrollView>

--- a/simplified-ui-settings/src/main/res/values/strings.xml
+++ b/simplified-ui-settings/src/main/res/values/strings.xml
@@ -73,4 +73,5 @@
   <string name="settingsVersionSummary" />
   <string name="settingsVersionCore">Core version</string>
   <string name="settingsVersionCoreSummary" />
+  <string name="settingsDebugTransifex">This string should have been translated by Transifex.</string>
 </resources>


### PR DESCRIPTION
**What's this do?**
This adds a new string at the bottom of the debug menu that should be displayed in Spanish if the device is set to Spanish and Transifex is actually working.

**Why are we doing this? (w/ JIRA link if applicable)**
Helps with testing PP-86.

https://ebce-lyrasis.atlassian.net/browse/PP-86

**How should this be tested? / Do these changes have associated tests?**
Set your device to Spanish and see if the string at the bottom of the debug screen is Spanish.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Ran the app but only in English.
