### PR TITLE
PP-307: Resume account views correctly

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,7 +298,7 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-20T14:23:59+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-09-21T11:16:25+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
         <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
@@ -316,9 +316,14 @@
           </c:tickets>
         </c:change>
         <c:change date="2023-09-20T00:00:00+00:00" summary="Changed BasicToken login request method to POST."/>
-        <c:change date="2023-09-20T14:23:59+00:00" summary="Very wide covers have their widths restricted to avoid breaking the UI.">
+        <c:change date="2023-09-20T00:00:00+00:00" summary="Very wide covers have their widths restricted to avoid breaking the UI.">
           <c:tickets>
             <c:ticket id="PP-443"/>
+          </c:tickets>
+        </c:change>
+        <c:change date="2023-09-21T11:16:25+00:00" summary="Correctly update the Accounts UI when resuming from the lock screen.">
+          <c:tickets>
+            <c:ticket id="PP-307"/>
           </c:tickets>
         </c:change>
       </c:changes>

--- a/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
+++ b/simplified-ui-accounts/src/main/java/org/nypl/simplified/ui/accounts/AccountDetailFragment.kt
@@ -388,12 +388,28 @@ class AccountDetailFragment : Fragment(R.layout.account) {
 
     val barcode = this.parameters.barcode
     if (barcode == null) {
-      this.authenticationViews.setBasicUserAndPass("", "")
+      this.authenticationViews.blank()
     } else {
-      this.authenticationViews.setBasicUserAndPass(
-        user = barcode,
-        password = ""
-      )
+      when (this.viewModel.account.provider.authentication) {
+        is AccountProviderAuthenticationDescription.Basic -> {
+          this.authenticationViews.setBasicUserAndPass(
+            user = barcode,
+            password = ""
+          )
+        }
+        is AccountProviderAuthenticationDescription.BasicToken -> {
+          this.authenticationViews.setBasicTokenUserAndPass(
+            user = barcode,
+            password = ""
+          )
+        }
+        AccountProviderAuthenticationDescription.Anonymous,
+        is AccountProviderAuthenticationDescription.COPPAAgeGate,
+        is AccountProviderAuthenticationDescription.OAuthWithIntermediary,
+        is AccountProviderAuthenticationDescription.SAML2_0 -> {
+          // Nothing to do.
+        }
+      }
     }
 
     /*
@@ -404,6 +420,12 @@ class AccountDetailFragment : Fragment(R.layout.account) {
     } else {
       this.toolbar.visibility = View.VISIBLE
     }
+
+    /*
+     * Eagerly reconfigure the UI to ensure an up-to-date view when resuming from sleep.
+     */
+
+    this.reconfigureAccountUI()
   }
 
   private fun instantiateAlternativeAuthenticationViews() {


### PR DESCRIPTION
**What's this do?**
The current code was failing to set usernames/passwords for token auth,
and also failing to reconfigure the UI in the `onStart()` method. This
would cause inconsistent visuals when resuming the app after having
locked the screen.

**Why are we doing this? (w/ JIRA link if applicable)**
https://ebce-lyrasis.atlassian.net/browse/PP-307

**How should this be tested? / Do these changes have associated tests?**
Try locking the device when on the account details screen, and then unlocking it. See the video in PP-307 for an example of what _shouldn't_ happen. :slightly_smiling_face: 

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
Yes.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried lots of locking and unlocking.