### PR TITLE
Fixed bookmarks not being deleted

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,7 +298,7 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-21T15:45:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-09-25T15:11:46+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
         <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
@@ -326,7 +326,8 @@
             <c:ticket id="PP-307"/>
           </c:tickets>
         </c:change>
-        <c:change date="2023-09-21T15:45:38+00:00" summary="Added support to EPUB text searching."/>
+        <c:change date="2023-09-21T00:00:00+00:00" summary="Added support to EPUB text searching."/>
+        <c:change date="2023-09-25T15:11:46+00:00" summary="Fixed bookmarks not being deleted."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BServiceOpCreateBookmark.kt
+++ b/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BServiceOpCreateBookmark.kt
@@ -27,30 +27,33 @@ internal class BServiceOpCreateBookmark(
 ) : BServiceOp<Bookmark>(logger) {
 
   override fun runActual(): Bookmark {
-    val newBookmark =
-      BServiceOpCreateLocalBookmark(
-        this.logger,
-        this.bookmarkEventsOut,
-        this.profile,
-        this.accountID,
-        this.bookmark
-      ).runActual()
-
     return try {
-      BServiceOpCreateRemoteBookmark(
+      val remoteBookmark = BServiceOpCreateRemoteBookmark(
         this.logger,
         this.objectMapper,
         this.httpCalls,
         this.profile,
         this.accountID,
-        newBookmark
+        bookmark
       ).runActual()
+
+      createLocalBookmarkFrom(remoteBookmark)
     } catch (e: Exception) {
       return if (this.ignoreRemoteFailures) {
-        newBookmark
+        createLocalBookmarkFrom(this.bookmark)
       } else {
         throw e
       }
     }
+  }
+
+  private fun createLocalBookmarkFrom(bookmark: Bookmark): Bookmark {
+    return BServiceOpCreateLocalBookmark(
+      this.logger,
+      this.bookmarkEventsOut,
+      this.profile,
+      this.accountID,
+      bookmark
+    ).runActual()
   }
 }


### PR DESCRIPTION
**What's this do?**
This PR changes the way the bookmarks are created in order to fix the bug of not being able to be deleted. By creating the local bookmark first, the displayed bookmark item had a `null` bookmark which was causing it to fail to be deleted. So, if the user pressed the "add bookmark" button and immediately entered the bookmarks page before the message "bookmark created" was displayed, the bookmark would fail to be deleted.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://ebce-lyrasis.atlassian.net/browse/PP-450) saying the bookmarks are not being deleted sometimes.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any Epub
Add a bookmark and open the TOC page and go to the bookmarks tab before the "Bookmark created" toast is displayed
Confirm the bookmark you added is displayed
Delete the bookmark you created
Close the book and reopen it
Go to the TOC page and to the bookmarks tab and confirm the bookmark is not there
Return to the reader and add a bookmark
This time, wait for the "bookmark added" toast to be shown
Open the TOC page, go to the bookmarks tab and confirm the new bookmark is there
Delete the new bookmark
Close the book and reopen it
Go to the TOC page and to the bookmarks tab and confirm the bookmark is not there

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 