### PR TITLE
Updated OPDS facet parsing by ignoring the content of facetGroupType

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,7 +298,7 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-26T13:54:16+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-09-26T14:26:10+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
         <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
@@ -328,7 +328,8 @@
         </c:change>
         <c:change date="2023-09-21T00:00:00+00:00" summary="Added support to EPUB text searching."/>
         <c:change date="2023-09-22T00:00:00+00:00" summary="Added push notifications option to DEV settings."/>
-        <c:change date="2023-09-26T13:54:16+00:00" summary="Fixed bookmarks not being deleted."/>
+        <c:change date="2023-09-26T00:00:00+00:00" summary="Fixed bookmarks not being deleted."/>
+        <c:change date="2023-09-26T14:26:10+00:00" summary="Updated OPDS facet parsing by ignoring the content of facetGroupType."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedFacets.kt
+++ b/simplified-feeds-api/src/main/java/org/nypl/simplified/feeds/api/FeedFacets.kt
@@ -38,9 +38,9 @@ object FeedFacets {
     groups: Map<String, List<FeedFacet>>
   ): List<FeedFacet>? {
     for (groupName in groups.keys) {
-      val facets = groups[groupName]!!
-      if (!facets.isEmpty()) {
-        val facet = facets.get(0)
+      val facets = groups[groupName].orEmpty()
+      if (facets.isNotEmpty()) {
+        val facet = facets.first()
         if (facetIsEntryPointTyped(facet)) {
           return facets
         }

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSFeedParser.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSFeedParser.java
@@ -34,7 +34,6 @@ import static org.nypl.simplified.opds.core.OPDSFeedConstants.AUTHENTICATION_DOC
 import static org.nypl.simplified.opds.core.OPDSFeedConstants.DRM_URI;
 import static org.nypl.simplified.opds.core.OPDSFeedConstants.FACET_URI_TEXT;
 import static org.nypl.simplified.opds.core.OPDSFeedConstants.OPDS_URI_TEXT;
-import static org.nypl.simplified.opds.core.OPDSFeedConstants.SIMPLIFIED_URI_TEXT;
 
 /**
  * <p>The default implementation of the {@link OPDSFeedParserType}.</p>
@@ -108,8 +107,8 @@ public final class OPDSFeedParser implements OPDSFeedParserType {
   }
 
   private static OptionType<String> parseFacetGroupType(Element e) {
-    if (e.hasAttributeNS(SIMPLIFIED_URI_TEXT, "facetGroupType")) {
-      return Option.some(e.getAttributeNS(SIMPLIFIED_URI_TEXT, "facetGroupType"));
+    if (e.hasAttribute("facetGroupType")) {
+      return Option.some(e.getAttribute("facetGroupType"));
     } else {
       return Option.none();
     }

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/acquisition-facets-1.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/acquisition-facets-1.xml
@@ -55,14 +55,14 @@
   <link
     href="http://circulation.alpha.librarysimplified.org/feed/Picture%20Books?order=title"
     opds:facetGroup="Sort by"
-    simplified:facetGroupType="Something"
+    facetGroupType="Something"
     rel="http://opds-spec.org/facet"
     title="Title" />
   <link
     opds:activeFacet="true"
     href="http://circulation.alpha.librarysimplified.org/feed/Picture%20Books?order=author"
     opds:facetGroup="Sort by"
-    simplified:facetGroupType="Something"
+    facetGroupType="Something"
     rel="http://opds-spec.org/facet"
     title="Author" />
   <link


### PR DESCRIPTION
**What's this do?**
This PR updates the OPDS facet parsing logic by ignoring the content of the facetGroupType.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://ebce-lyrasis.atlassian.net/browse/PP-476) saying the catalog is no longer displaying the tabs. The iOS app is still displaying them because they ignore the content of the attribute `facetGroupType` as long as the key is there.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Confirm there are tabs in the top of the catalog

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 