### PR TITLE
Reverted OPDS Feed parsing

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,7 +298,7 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-26T14:26:10+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-09-26T13:54:16+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
         <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
@@ -328,8 +328,7 @@
         </c:change>
         <c:change date="2023-09-21T00:00:00+00:00" summary="Added support to EPUB text searching."/>
         <c:change date="2023-09-22T00:00:00+00:00" summary="Added push notifications option to DEV settings."/>
-        <c:change date="2023-09-26T00:00:00+00:00" summary="Fixed bookmarks not being deleted."/>
-        <c:change date="2023-09-26T14:26:10+00:00" summary="Updated OPDS facet parsing by ignoring the content of facetGroupType."/>
+        <c:change date="2023-09-26T13:54:16+00:00" summary="Fixed bookmarks not being deleted."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSFeedParser.java
+++ b/simplified-opds-core/src/main/java/org/nypl/simplified/opds/core/OPDSFeedParser.java
@@ -34,6 +34,7 @@ import static org.nypl.simplified.opds.core.OPDSFeedConstants.AUTHENTICATION_DOC
 import static org.nypl.simplified.opds.core.OPDSFeedConstants.DRM_URI;
 import static org.nypl.simplified.opds.core.OPDSFeedConstants.FACET_URI_TEXT;
 import static org.nypl.simplified.opds.core.OPDSFeedConstants.OPDS_URI_TEXT;
+import static org.nypl.simplified.opds.core.OPDSFeedConstants.SIMPLIFIED_URI_TEXT;
 
 /**
  * <p>The default implementation of the {@link OPDSFeedParserType}.</p>
@@ -107,8 +108,8 @@ public final class OPDSFeedParser implements OPDSFeedParserType {
   }
 
   private static OptionType<String> parseFacetGroupType(Element e) {
-    if (e.hasAttribute("facetGroupType")) {
-      return Option.some(e.getAttribute("facetGroupType"));
+    if (e.hasAttributeNS(SIMPLIFIED_URI_TEXT, "facetGroupType")) {
+      return Option.some(e.getAttributeNS(SIMPLIFIED_URI_TEXT, "facetGroupType"));
     } else {
       return Option.none();
     }

--- a/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/acquisition-facets-1.xml
+++ b/simplified-tests/src/test/resources/org/nypl/simplified/tests/opds/acquisition-facets-1.xml
@@ -55,14 +55,14 @@
   <link
     href="http://circulation.alpha.librarysimplified.org/feed/Picture%20Books?order=title"
     opds:facetGroup="Sort by"
-    facetGroupType="Something"
+    simplified:facetGroupType="Something"
     rel="http://opds-spec.org/facet"
     title="Title" />
   <link
     opds:activeFacet="true"
     href="http://circulation.alpha.librarysimplified.org/feed/Picture%20Books?order=author"
     opds:facetGroup="Sort by"
-    facetGroupType="Something"
+    simplified:facetGroupType="Something"
     rel="http://opds-spec.org/facet"
     title="Author" />
   <link


### PR DESCRIPTION
**What's this do?**
This PR reverts the logic added in [this PR](https://github.com/ThePalaceProject/android-core/pull/232)

**Why are we doing this? (w/ JIRA link if applicable)**
The server should adapt the feed response in order to specify all the attributes' namespace, as explained [here](https://ebce-lyrasis.atlassian.net/browse/PP-476?focusedCommentId=11683)

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
In the catalog, the tabs should've disappeared

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes, by removing the previous entry

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 