### PR TITLE
Fixed Audiobook UI freezing after pressing 'play'

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,7 +298,7 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-26T13:54:16+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-10-07T13:46:32+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
         <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
@@ -328,7 +328,8 @@
         </c:change>
         <c:change date="2023-09-21T00:00:00+00:00" summary="Added support to EPUB text searching."/>
         <c:change date="2023-09-22T00:00:00+00:00" summary="Added push notifications option to DEV settings."/>
-        <c:change date="2023-09-26T13:54:16+00:00" summary="Fixed bookmarks not being deleted."/>
+        <c:change date="2023-09-26T00:00:00+00:00" summary="Fixed bookmarks not being deleted."/>
+        <c:change date="2023-10-07T13:46:32+00:00" summary="Fixed Audiobook UI freezing after pressing 'play'."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-palace/build.gradle.kts
+++ b/simplified-app-palace/build.gradle.kts
@@ -521,6 +521,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.coroutines.core.jvm)
     implementation(libs.kotlinx.coroutines.play.services)
+    implementation(libs.kotlinx.datetime)
     implementation(libs.logback.android)
     implementation(libs.moznion.uribuildertiny)
     implementation(libs.nano.httpd)
@@ -608,4 +609,6 @@ dependencies {
     implementation(libs.truevfs.driver.zip)
     implementation(libs.truevfs.kernel.impl)
     implementation(libs.truevfs.kernel.spec)
+    implementation(libs.ulid.kotlin)
+    implementation(libs.ulid.kotlin.jvm)
 }

--- a/simplified-books-time-tracking/build.gradle.kts
+++ b/simplified-books-time-tracking/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(project(":simplified-services-api"))
 
     implementation(libs.irradia.mime.api)
+    implementation(libs.kotlinx.datetime)
     implementation(libs.jackson.core)
     implementation(libs.jackson.databind)
     implementation(libs.joda.time)
@@ -17,5 +18,6 @@ dependencies {
     implementation(libs.rxandroid2)
     implementation(libs.rxjava2)
     implementation(libs.slf4j)
-    implementation(libs.ulid.generator)
+    implementation(libs.ulid.kotlin)
+    implementation(libs.ulid.kotlin.jvm)
 }

--- a/simplified-books-time-tracking/src/main/java/org/nypl/simplified/books/time/tracking/TimeTrackingService.kt
+++ b/simplified-books-time-tracking/src/main/java/org/nypl/simplified/books/time/tracking/TimeTrackingService.kt
@@ -314,6 +314,8 @@ class TimeTrackingService(
           .account(AccountID(UUID.fromString(timeTrackingInfo.accountId)))
       )
     } catch (exception: Exception) {
+      logger.error("Error while saving time tracking info remotely: ", exception)
+
       // in case an exception occurs, we keep the original time entries
       timeTrackingInfo.timeEntries
     }

--- a/simplified-tests/build.gradle.kts
+++ b/simplified-tests/build.gradle.kts
@@ -201,9 +201,10 @@ val dependencyObjects = listOf(
     libs.junit.jupiter.vintage,
     libs.junit.platform.commons,
     libs.junit.platform.engine,
-    libs.kotlinx.coroutines,
     libs.kotlin.reflect,
     libs.kotlin.stdlib,
+    libs.kotlinx.coroutines,
+    libs.kotlinx.datetime,
     libs.logback.classic,
     libs.logback.core,
     libs.mockito.android,
@@ -293,7 +294,8 @@ val dependencyObjects = listOf(
     libs.truevfs.driver.zip,
     libs.truevfs.kernel.impl,
     libs.truevfs.kernel.spec,
-    libs.ulid.generator,
+    libs.ulid.kotlin,
+    libs.ulid.kotlin.jvm,
 )
 
 dependencies {


### PR DESCRIPTION
**What's this do?**
This PR adds missing dependencies related to the ULID generator library which was causing the audiobook UI to freeze when trying to create the first time entry.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://ebce-lyrasis.atlassian.net/browse/PP-541) saying that the audiobook UI is freezing after pressing the "Play" button.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Add Lyrasis Reads
Open a Biblioboard audiobook
Tap "Play" button
Confirm everything is working just fine

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 