### PR TITLE
Fixed crash when creating a library card

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -298,7 +298,7 @@
         <c:change date="2023-08-12T00:00:00+00:00" summary="Fixed crash when time tracking is not enabled."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-10-11T19:26:14+00:00" is-open="false" ticket-system="org.nypl.jira" version="1.6.0">
+    <c:release date="2023-10-11T00:00:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="1.6.0">
       <c:changes>
         <c:change date="2023-08-24T00:00:00+00:00" summary="Updated Kotlin version to 1.9.0"/>
         <c:change date="2023-08-28T00:00:00+00:00" summary="Fixed crash when opening an audiobook with a null manifest."/>
@@ -330,6 +330,11 @@
         <c:change date="2023-09-22T00:00:00+00:00" summary="Added push notifications option to DEV settings."/>
         <c:change date="2023-09-26T00:00:00+00:00" summary="Fixed bookmarks not being deleted."/>
         <c:change date="2023-10-07T00:00:00+00:00" summary="Fixed Audiobook UI freezing after pressing 'play'."/>
+      </c:changes>
+    </c:release>
+    <c:release date="2023-10-16T11:36:56+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.1">
+      <c:changes>
+        <c:change date="2023-10-16T11:36:56+00:00" summary="Fixed crash when creating a library card."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-palace/build.gradle.kts
+++ b/simplified-app-palace/build.gradle.kts
@@ -569,6 +569,7 @@ dependencies {
     implementation(libs.play.services.base)
     implementation(libs.play.services.basement)
     implementation(libs.play.services.cloud.messaging)
+    implementation(libs.play.services.location)
     implementation(libs.play.services.measurement)
     implementation(libs.play.services.measurement.api)
     implementation(libs.play.services.measurement.base)


### PR DESCRIPTION
**What's this do?**
This PR fixes a recurring crash when trying to create a virtual library card

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://ebce-lyrasis.atlassian.net/browse/PP-583) saying there's been a huge number of crashes when creating a library card.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select a library that allows Virtual Library Card creation (p.e., Bethel Public Library)
Click on "Create Card"
Confirm the app is not crashing

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 