### PR TITLE
Adjusted feed tabs navigation to keep the "Catalog" on the screen

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -332,9 +332,10 @@
         <c:change date="2023-10-07T00:00:00+00:00" summary="Fixed Audiobook UI freezing after pressing 'play'."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-10-16T11:36:56+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.1">
+    <c:release date="2023-10-17T18:03:10+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.1">
       <c:changes>
-        <c:change date="2023-10-16T11:36:56+00:00" summary="Fixed crash when creating a library card."/>
+        <c:change date="2023-10-16T00:00:00+00:00" summary="Fixed crash when creating a library card."/>
+        <c:change date="2023-10-17T18:03:10+00:00" summary="Adjusted feed tabs navigation to keep the Catalog on the top of the screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -332,10 +332,14 @@
         <c:change date="2023-10-07T00:00:00+00:00" summary="Fixed Audiobook UI freezing after pressing 'play'."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-10-17T18:03:10+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.6.1">
+    <c:release date="2023-10-18T00:00:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="1.6.1">
       <c:changes>
         <c:change date="2023-10-16T00:00:00+00:00" summary="Fixed crash when creating a library card."/>
-        <c:change date="2023-10-17T18:03:10+00:00" summary="Adjusted feed tabs navigation to keep the Catalog on the top of the screen."/>
+      </c:changes>
+    </c:release>
+    <c:release date="2023-10-19T11:00:16+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.7.0">
+      <c:changes>
+        <c:change date="2023-10-19T11:00:16+00:00" summary="Adjusted feed tabs navigation to keep the Catalog on the top of the screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedFragment.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedFragment.kt
@@ -835,6 +835,7 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
       button.setOnClickListener {
         this.logger.debug("selected entry point facet: {}", facet.title)
         this.viewModel.openFacet(facet)
+        updateSelectedFacet(facetTabs = facetTabs, index = index)
       }
       button.setPadding(0)
       facetTabs.addView(button)
@@ -856,6 +857,12 @@ class CatalogFeedFragment : Fragment(R.layout.feed), AgeGateDialog.BirthYearSele
         facetTabs.check(button.id)
       }
     }
+  }
+
+  private fun updateSelectedFacet(facetTabs: RadioGroup, index: Int) {
+    facetTabs.clearCheck()
+    val button = facetTabs.getChildAt(index) as RadioButton
+    facetTabs.check(button.id)
   }
 
   private fun showFacetSelectDialog(

--- a/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
+++ b/simplified-ui-catalog/src/main/java/org/librarysimplified/ui/catalog/CatalogFeedViewModel.kt
@@ -887,9 +887,9 @@ class CatalogFeedViewModel(
 
   fun openFacet(facet: FeedFacet) {
     val feedArguments = this.resolveFacet(facet)
-    this.listener.post(
-      CatalogFeedEvent.OpenFeed(feedArguments)
-    )
+    val newState = CatalogFeedState.CatalogFeedLoading(feedArguments)
+    this.stateMutable.value = newState
+    reloadFeed()
   }
 
   /**


### PR DESCRIPTION
**What's this do?**
This PR changes how the feed handles a new facet/tab click. Instead of creating and adding a new fragment for the feed, it just updates the UI and reloads the feed with some new arguments.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://ebce-lyrasis.atlassian.net/browse/PP-577) to make this similar as it is on the iOS app

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads"
On the Catalog tab, press "eBooks"
Confirm the title remains as "Catalog" and there's the Palace logo instead of a back arrow
Press "AudioBooks"
Confirm the title remains as "Catalog" and there's the Palace logo instead of a back arrow

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 