### PR TITLE
Enabled push notifications by default

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -337,15 +337,16 @@
         <c:change date="2023-10-16T00:00:00+00:00" summary="Fixed crash when creating a library card."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-10-23T19:27:04+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.7.0">
+    <c:release date="2023-10-24T09:32:44+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.7.0">
       <c:changes>
         <c:change date="2023-10-19T00:00:00+00:00" summary="Adjusted feed tabs navigation to keep the Catalog on the top of the screen."/>
         <c:change date="2023-10-23T00:00:00+00:00" summary="Use a new Material 3 theme."/>
-        <c:change date="2023-10-23T19:27:04+00:00" summary="Fix a missing version name.">
+        <c:change date="2023-10-23T00:00:00+00:00" summary="Fix a missing version name.">
           <c:tickets>
             <c:ticket id="PP-610"/>
           </c:tickets>
         </c:change>
+        <c:change date="2023-10-24T09:32:44+00:00" summary="Enabled push notifications by default."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLoginTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLoginTask.kt
@@ -244,8 +244,7 @@ class ProfileAccountLoginTask(
         this.runDeviceActivation()
         this.account.setLoginState(AccountLoggedIn(this.credentials))
         notificationTokenHttpCalls.registerFCMTokenForProfileAccount(
-          account = account,
-          areNotificationsEnabled = profile.preferences().areNotificationsEnabled
+          account = account
         )
         this.steps.finishSuccess(Unit)
       }
@@ -318,8 +317,7 @@ class ProfileAccountLoginTask(
         this.runDeviceActivation()
         this.account.setLoginState(AccountLoggedIn(this.credentials))
         notificationTokenHttpCalls.registerFCMTokenForProfileAccount(
-          account = account,
-          areNotificationsEnabled = profile.preferences().areNotificationsEnabled
+          account = account
         )
         this.steps.finishSuccess(Unit)
       }
@@ -365,8 +363,7 @@ class ProfileAccountLoginTask(
     this.runDeviceActivation()
     this.account.setLoginState(AccountLoggedIn(this.credentials))
     notificationTokenHttpCalls.registerFCMTokenForProfileAccount(
-      account = account,
-      areNotificationsEnabled = profile.preferences().areNotificationsEnabled
+      account = account
     )
     return this.steps.finishSuccess(Unit)
   }
@@ -407,8 +404,7 @@ class ProfileAccountLoginTask(
           this.runDeviceActivation()
           this.account.setLoginState(AccountLoggedIn(this.credentials))
           notificationTokenHttpCalls.registerFCMTokenForProfileAccount(
-            account = account,
-            areNotificationsEnabled = profile.preferences().areNotificationsEnabled
+            account = account
           )
           return this.steps.finishSuccess(Unit)
         }

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLogoutTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLogoutTask.kt
@@ -145,8 +145,7 @@ class ProfileAccountLogoutTask(
     this.debug("running fcm token deletion")
 
     notificationTokenHttpCalls.deleteFCMTokenForProfileAccount(
-      account = account,
-      areNotificationsEnabled = profile.preferences().areNotificationsEnabled
+      account = account
     )
   }
 

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainActivity.kt
@@ -162,16 +162,6 @@ class MainActivity : AppCompatActivity(R.layout.main_host) {
 
   private fun askForNotificationsPermission() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      val services =
-        Services.serviceDirectory()
-      val profiles =
-        services.requireService(ProfilesControllerType::class.java)
-
-      if (!profiles.profileCurrent().preferences().areNotificationsEnabled) {
-        logger.debug("Notifications are currently disabled, so we won't be asking for permissions")
-        return
-      }
-
       ActivityCompat.requestPermissions(
         this,
         arrayOf(Manifest.permission.POST_NOTIFICATIONS),

--- a/simplified-notifications/src/main/java/NotificationTokenHTTPCalls.kt
+++ b/simplified-notifications/src/main/java/NotificationTokenHTTPCalls.kt
@@ -27,21 +27,14 @@ class NotificationTokenHTTPCalls(
   override fun registerFCMTokenForProfileAccounts(profile: ProfileReadableType) {
     profile.accounts().values.forEach { account ->
       registerFCMTokenForProfileAccount(
-        account = account,
-        areNotificationsEnabled = profile.preferences().areNotificationsEnabled
+        account = account
       )
     }
   }
 
   override fun registerFCMTokenForProfileAccount(
-    account: AccountType,
-    areNotificationsEnabled: Boolean
+    account: AccountType
   ) {
-    if (!areNotificationsEnabled) {
-      logger.debug("Notifications are currently disabled, so we won't be registering a token")
-      return
-    }
-
     firebaseInstance.token
       .addOnSuccessListener { token ->
         logger.debug("Success fetching FCM Token: {}", token)
@@ -105,14 +98,8 @@ class NotificationTokenHTTPCalls(
   }
 
   override fun deleteFCMTokenForProfileAccount(
-    account: AccountType,
-    areNotificationsEnabled: Boolean
+    account: AccountType
   ) {
-    if (!areNotificationsEnabled) {
-      logger.debug("Notifications are currently disabled, so we won't be deleting the token")
-      return
-    }
-
     firebaseInstance.token
       .addOnSuccessListener { token ->
         logger.debug("Success fetching FCM Token: {}", token)

--- a/simplified-notifications/src/main/java/NotificationTokenHTTPCallsType.kt
+++ b/simplified-notifications/src/main/java/NotificationTokenHTTPCallsType.kt
@@ -6,7 +6,7 @@ import org.nypl.simplified.profiles.api.ProfileReadableType
 interface NotificationTokenHTTPCallsType {
   fun registerFCMTokenForProfileAccounts(profile: ProfileReadableType)
 
-  fun registerFCMTokenForProfileAccount(account: AccountType, areNotificationsEnabled: Boolean)
+  fun registerFCMTokenForProfileAccount(account: AccountType)
 
-  fun deleteFCMTokenForProfileAccount(account: AccountType, areNotificationsEnabled: Boolean)
+  fun deleteFCMTokenForProfileAccount(account: AccountType)
 }

--- a/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
+++ b/simplified-profiles-api/src/main/java/org/nypl/simplified/profiles/api/ProfilePreferences.kt
@@ -50,10 +50,6 @@ data class ProfilePreferences(
 
   val isManualLCPPassphraseEnabled: Boolean = false,
 
-  /** @return `true` if the push notifications are enabled. */
-
-  val areNotificationsEnabled: Boolean = false,
-
   /** @return `true` if the debug settings should be visible. */
 
   val showDebugSettings: Boolean = false

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfileDescriptionJSON.kt
@@ -207,9 +207,6 @@ object ProfileDescriptionJSON {
     val isManualLCPPassphraseEnabled =
       JSONParserUtilities.getBooleanDefault(objectNode, "isManualLCPPassphraseEnabled", false)
 
-    val areNotificationsEnabled =
-      JSONParserUtilities.getBooleanDefault(objectNode, "areNotificationsEnabled", false)
-
     val mostRecentAccount =
       JSONParserUtilities.getStringOrNull(objectNode, "mostRecentAccount")
         ?.let { AccountID(UUID.fromString(it)) }
@@ -224,7 +221,6 @@ object ProfileDescriptionJSON {
       showDebugSettings = showDebugSettings,
       playbackRates = playbackRates,
       sleepTimers = sleepTimers,
-      areNotificationsEnabled = areNotificationsEnabled,
       isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled
     )
   }
@@ -261,9 +257,6 @@ object ProfileDescriptionJSON {
     val isManualLCPPassphraseEnabled =
       JSONParserUtilities.getBooleanDefault(objectNode, "isManualLCPPassphraseEnabled", false)
 
-    val areNotificationsEnabled =
-      JSONParserUtilities.getBooleanDefault(objectNode, "areNotificationsEnabled", false)
-
     val mostRecentAccount =
       JSONParserUtilities.getStringOrNull(objectNode, "mostRecentAccount")
         ?.let { AccountID(UUID.fromString(it)) }
@@ -277,7 +270,6 @@ object ProfileDescriptionJSON {
       hasSeenLibrarySelectionScreen = true,
       playbackRates = playbackRates,
       sleepTimers = sleepTimers,
-      areNotificationsEnabled = areNotificationsEnabled,
       isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled
     )
   }
@@ -338,9 +330,6 @@ object ProfileDescriptionJSON {
     val isManualLCPPassphraseEnabled =
       JSONParserUtilities.getBooleanDefault(preferencesNode, "isManualLCPPassphraseEnabled", false)
 
-    val areNotificationsEnabled =
-      JSONParserUtilities.getBooleanDefault(preferencesNode, "areNotificationsEnabled", false)
-
     val preferences =
       ProfilePreferences(
         dateOfBirth = this.someOrNull(dateOfBirth),
@@ -350,7 +339,6 @@ object ProfileDescriptionJSON {
         hasSeenLibrarySelectionScreen = true,
         playbackRates = playbackRates,
         sleepTimers = sleepTimers,
-        areNotificationsEnabled = areNotificationsEnabled,
         isManualLCPPassphraseEnabled = isManualLCPPassphraseEnabled
       )
 
@@ -496,7 +484,6 @@ object ProfileDescriptionJSON {
   ): ObjectNode {
     val output = objectMapper.createObjectNode()
     output.put("showTestingLibraries", preferences.showTestingLibraries)
-    output.put("areNotificationsEnabled", preferences.areNotificationsEnabled)
     output.put("isManualLCPPassphraseEnabled", preferences.isManualLCPPassphraseEnabled)
     output.put("hasSeenLibrarySelectionScreen", preferences.hasSeenLibrarySelectionScreen)
     output.put("showDebugSettings", preferences.showDebugSettings)

--- a/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
+++ b/simplified-profiles/src/main/java/org/nypl/simplified/profiles/ProfilesDatabases.kt
@@ -502,7 +502,6 @@ object ProfilesDatabases {
               hasSeenLibrarySelectionScreen = false,
               playbackRates = hashMapOf(),
               sleepTimers = hashMapOf(),
-              areNotificationsEnabled = false,
               isManualLCPPassphraseEnabled = false
             ),
             attributes = ProfileAttributes(sortedMapOf())

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLoginTaskContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLoginTaskContract.kt
@@ -114,10 +114,6 @@ abstract class ProfileAccountLoginTaskContract {
     this.server = MockWebServer()
     this.server.start()
 
-    val preferences = Mockito.mock(ProfilePreferences::class.java)
-    Mockito.`when`(this.profile.preferences()).thenReturn(preferences)
-    Mockito.`when`(preferences.areNotificationsEnabled).thenReturn(true)
-
     this.profileWithoutDRM = """
 {
   "simplified:authorization_identifier": "6120696828384",
@@ -724,7 +720,7 @@ abstract class ProfileAccountLoginTaskContract {
     assertEquals(1, this.server.requestCount)
 
     Mockito.verify(tokenHttp, Mockito.times(1))
-      .registerFCMTokenForProfileAccount(account, true)
+      .registerFCMTokenForProfileAccount(account)
   }
 
   /**

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLogoutTaskContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLogoutTaskContract.kt
@@ -153,10 +153,6 @@ abstract class ProfileAccountLogoutTaskContract {
 
     this.server = MockWebServer()
     this.server.start()
-
-    val preferences = Mockito.mock(ProfilePreferences::class.java)
-    Mockito.`when`(this.profile.preferences()).thenReturn(preferences)
-    Mockito.`when`(preferences.areNotificationsEnabled).thenReturn(true)
   }
 
   @AfterEach
@@ -288,7 +284,7 @@ abstract class ProfileAccountLogoutTaskContract {
       this.bookRegistry.books().values.all { it.status is BookStatus.Loaned.LoanedNotDownloaded }
     )
 
-    Mockito.verify(tokenHttp, Mockito.times(1)).deleteFCMTokenForProfileAccount(account, true)
+    Mockito.verify(tokenHttp, Mockito.times(1)).deleteFCMTokenForProfileAccount(account)
   }
 
   /**

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileDescriptionJSONTest.kt
@@ -56,7 +56,6 @@ class ProfileDescriptionJSONTest {
           mostRecentAccount = AccountID.generate(),
           playbackRates = hashMapOf(),
           sleepTimers = hashMapOf(),
-          areNotificationsEnabled = false,
           isManualLCPPassphraseEnabled = false
         ),
         attributes = ProfileAttributes(

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/mocking/MockProfile.kt
@@ -37,7 +37,6 @@ class MockProfile(
         mostRecentAccount = this.accounts.firstKey(),
         playbackRates = hashMapOf(),
         sleepTimers = hashMapOf(),
-        areNotificationsEnabled = false,
         isManualLCPPassphraseEnabled = false
       ),
       attributes = ProfileAttributes(sortedMapOf())

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugFragment.kt
@@ -65,7 +65,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
   private lateinit var syncAccountsButton: Button
   private lateinit var enableOpenEBooksQA: Button
   private lateinit var toolbar: PalaceToolbar
-  private lateinit var areNotificationsEnabled: SwitchCompat
   private lateinit var isManualLCPPassphraseEnabled: SwitchCompat
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -99,8 +98,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       view.findViewById(R.id.settingsVersionDevSeenLibrarySelectionScreen)
     this.isManualLCPPassphraseEnabled =
       view.findViewById(R.id.settingsVersionDevIsManualLCPPassphraseEnabled)
-    this.areNotificationsEnabled =
-      view.findViewById(R.id.settingsVersionDevAreNotificationsEnabled)
     this.cardCreatorFakeLocation =
       view.findViewById(R.id.settingsVersionDevCardCreatorLocationSwitch)
     this.showOnlySupportedBooks =
@@ -141,8 +138,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
       this.viewModel.cardCreatorFakeLocation
     this.isManualLCPPassphraseEnabled.isChecked =
       this.viewModel.isManualLCPPassphraseEnabled
-    this.areNotificationsEnabled.isChecked =
-      this.viewModel.areNotificationsEnabled
     this.showOnlySupportedBooks.isChecked =
       this.viewModel.showOnlySupportedBooks
     this.crashlyticsId.text =
@@ -245,9 +240,6 @@ class SettingsDebugFragment : Fragment(R.layout.settings_debug) {
     }
     this.isManualLCPPassphraseEnabled.setOnCheckedChangeListener { _, isChecked ->
       this.viewModel.isManualLCPPassphraseEnabled = isChecked
-    }
-    this.areNotificationsEnabled.setOnCheckedChangeListener { _, isChecked ->
-      this.viewModel.areNotificationsEnabled = isChecked
     }
 
     /*

--- a/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
+++ b/simplified-ui-settings/src/main/java/org/nypl/simplified/ui/settings/SettingsDebugViewModel.kt
@@ -141,18 +141,6 @@ class SettingsDebugViewModel(application: Application) : AndroidViewModel(applic
       }
     }
 
-  var areNotificationsEnabled: Boolean
-    get() =
-      this.profilesController
-        .profileCurrent()
-        .preferences()
-        .areNotificationsEnabled
-    set(value) {
-      this.profilesController.profileUpdate { description ->
-        description.copy(preferences = description.preferences.copy(areNotificationsEnabled = value))
-      }
-    }
-
   var isBootFailureEnabled: Boolean
     get() =
       BootFailureTesting.isBootFailureEnabled(getApplication())

--- a/simplified-ui-settings/src/main/res/layout/settings_debug.xml
+++ b/simplified-ui-settings/src/main/res/layout/settings_debug.xml
@@ -167,15 +167,6 @@
         android:text="@string/settingsDevEnableManualLCPPassphrase" />
 
     <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/settingsVersionDevAreNotificationsEnabled"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:checked="false"
-        android:enabled="true"
-        android:text="@string/settingsDevEnablePushNotifications" />
-
-    <androidx.appcompat.widget.SwitchCompat
       android:id="@+id/settingsVersionDevProductionLibrariesSwitch"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"

--- a/simplified-ui-settings/src/main/res/values/strings.xml
+++ b/simplified-ui-settings/src/main/res/values/strings.xml
@@ -34,7 +34,6 @@
   <string name="settingsDevDrmSupport">DRM Support</string>
   <string name="settingsDevEnableHiddenLibraries">Enable Hidden Libraries</string>
   <string name="settingsDevEnableManualLCPPassphrase">Enable Manual LCP Passphrase</string>
-  <string name="settingsDevEnablePushNotifications">Enable Push Notifications</string>
   <string name="settingsDevEnableTimeTracking">Enable Time Tracking</string>
   <string name="settingsDevFailNextStartup">Cause the next application startup to fail</string>
   <string name="settingsDevForgetAllAnnouncements">Forget All Announcements</string>


### PR DESCRIPTION
**What's this do?**
This PR enables the push notifications by default and removes the option from the debug settings.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://ebce-lyrasis.atlassian.net/browse/PP-571) to enable the push notifications by default now that they're tested

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app in two different devices
Log in two different accounts but in the same library
With one account borrow a book that only has on copy
With the other account, reserve the same book
Again with the first account, return the book
Confirm a push notification is received in the second account

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 