### PR TITLE
Fixed crash on Reader screen due to more than one Fragment instance

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -337,7 +337,7 @@
         <c:change date="2023-10-16T00:00:00+00:00" summary="Fixed crash when creating a library card."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-10-24T09:32:44+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.7.0">
+    <c:release date="2023-10-25T17:53:40+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.7.0">
       <c:changes>
         <c:change date="2023-10-19T00:00:00+00:00" summary="Adjusted feed tabs navigation to keep the Catalog on the top of the screen."/>
         <c:change date="2023-10-23T00:00:00+00:00" summary="Use a new Material 3 theme."/>
@@ -346,7 +346,8 @@
             <c:ticket id="PP-610"/>
           </c:tickets>
         </c:change>
-        <c:change date="2023-10-24T09:32:44+00:00" summary="Enabled push notifications by default."/>
+        <c:change date="2023-10-24T00:00:00+00:00" summary="Enabled push notifications by default."/>
+        <c:change date="2023-10-25T17:53:40+00:00" summary="Fixed crash on Reader screen due to more than one Fragment instance."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
@@ -193,25 +193,27 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
       WebView.setWebContentsDebuggingEnabled(true)
     }
 
-    this.readerFragment =
-      this.supportFragmentManager.fragmentFactory.instantiate(
-        this.classLoader,
-        SR2ReaderFragment::class.java.name
-      )
-    this.searchFragment =
-      this.supportFragmentManager.fragmentFactory.instantiate(
-        this.classLoader,
-        SR2SearchFragment::class.java.name
-      )
-    this.tocFragment =
-      this.supportFragmentManager.fragmentFactory.instantiate(
-        this.classLoader,
-        SR2TOCFragment::class.java.name
-      )
+    if (savedInstanceState == null) {
+      this.readerFragment =
+        this.supportFragmentManager.fragmentFactory.instantiate(
+          this.classLoader,
+          SR2ReaderFragment::class.java.name
+        )
+      this.searchFragment =
+        this.supportFragmentManager.fragmentFactory.instantiate(
+          this.classLoader,
+          SR2SearchFragment::class.java.name
+        )
+      this.tocFragment =
+        this.supportFragmentManager.fragmentFactory.instantiate(
+          this.classLoader,
+          SR2TOCFragment::class.java.name
+        )
 
-    this.supportFragmentManager.beginTransaction()
-      .add(R.id.reader2FragmentHost, this.readerFragment)
-      .commit()
+      this.supportFragmentManager.beginTransaction()
+        .add(R.id.reader2FragmentHost, this.readerFragment)
+        .commit()
+    }
   }
 
   override fun onStart() {


### PR DESCRIPTION
**What's this do?**
This PR fixes a recurring crash on the ReaderFragment when more than one fragment tries to listen to a ViewModel observable that can only be subscribed once.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://ebce-lyrasis.atlassian.net/browse/PP-633) mentioning there's been a significant number of crashes because of this

**How should this be tested? / Do these changes have associated tests?**
First you need to enable the Developer Options of your mobile phone (please Google how to do it as it's different from device to device)
Open the Developer Options
Enable the option "Don't keep activities"
Open the Palace app
Open any Ebook
Minimize the app
Reopen the app
Confirm the app didn't crash

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 