### PR TITLE
Removed the Android 12+ devices default splash screen

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -337,7 +337,7 @@
         <c:change date="2023-10-16T00:00:00+00:00" summary="Fixed crash when creating a library card."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-10-27T15:08:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.7.0">
+    <c:release date="2023-10-30T00:00:00+00:00" is-open="false" ticket-system="org.nypl.jira" version="1.7.0">
       <c:changes>
         <c:change date="2023-10-19T00:00:00+00:00" summary="Adjusted feed tabs navigation to keep the Catalog on the top of the screen."/>
         <c:change date="2023-10-23T00:00:00+00:00" summary="Use a new Material 3 theme."/>
@@ -348,7 +348,11 @@
         </c:change>
         <c:change date="2023-10-24T00:00:00+00:00" summary="Enabled push notifications by default."/>
         <c:change date="2023-10-25T00:00:00+00:00" summary="Fixed crash on Reader screen due to more than one Fragment instance."/>
-        <c:change date="2023-10-27T15:08:43+00:00" summary="Removed the Android 12+ devices default splash screen."/>
+      </c:changes>
+    </c:release>
+    <c:release date="2023-10-30T14:34:27+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.8.0">
+      <c:changes>
+        <c:change date="2023-10-30T14:34:27+00:00" summary="Removed the Android 12+ devices default splash screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -337,7 +337,7 @@
         <c:change date="2023-10-16T00:00:00+00:00" summary="Fixed crash when creating a library card."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-10-25T17:53:40+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.7.0">
+    <c:release date="2023-10-27T15:08:43+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.7.0">
       <c:changes>
         <c:change date="2023-10-19T00:00:00+00:00" summary="Adjusted feed tabs navigation to keep the Catalog on the top of the screen."/>
         <c:change date="2023-10-23T00:00:00+00:00" summary="Use a new Material 3 theme."/>
@@ -347,7 +347,8 @@
           </c:tickets>
         </c:change>
         <c:change date="2023-10-24T00:00:00+00:00" summary="Enabled push notifications by default."/>
-        <c:change date="2023-10-25T17:53:40+00:00" summary="Fixed crash on Reader screen due to more than one Fragment instance."/>
+        <c:change date="2023-10-25T00:00:00+00:00" summary="Fixed crash on Reader screen due to more than one Fragment instance."/>
+        <c:change date="2023-10-27T15:08:43+00:00" summary="Removed the Android 12+ devices default splash screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-app-palace/build.gradle.kts
+++ b/simplified-app-palace/build.gradle.kts
@@ -416,6 +416,7 @@ dependencies {
     implementation(libs.androidx.core.common)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.runtime)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.cursoradapter)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.customview.poolingcontainer)

--- a/simplified-app-palace/src/main/AndroidManifest.xml
+++ b/simplified-app-palace/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
     android:contentDescription="@string/app_name"
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"
-    android:theme="@style/PalaceTheme.WithoutActionBar"
+    android:theme="@style/PalaceTheme"
     android:usesCleartextTraffic="true"
     tools:replace="android:allowBackup">
 

--- a/simplified-app-palace/src/main/res/values-v31/themes.xml
+++ b/simplified-app-palace/src/main/res/values-v31/themes.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="PalaceTheme" parent="PalaceTheme.WithoutActionBar">
-        <item name="android:windowIsTranslucent">true</item>
-
-        <!-- The theme to set after the default splash screen is dismissed-->
-        <item name="postSplashScreenTheme">@style/PalaceTheme.WithoutActionBar</item>
-    </style>
-</resources>

--- a/simplified-app-palace/src/main/res/values-v31/themes.xml
+++ b/simplified-app-palace/src/main/res/values-v31/themes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="PalaceTheme" parent="PalaceTheme.WithoutActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+
+        <!-- The theme to set after the default splash screen is dismissed-->
+        <item name="postSplashScreenTheme">@style/PalaceTheme.WithoutActionBar</item>
+    </style>
+</resources>

--- a/simplified-app-palace/src/main/res/values/themes.xml
+++ b/simplified-app-palace/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="PalaceTheme" parent="PalaceTheme.WithoutActionBar" />
+</resources>

--- a/simplified-app-palace/src/main/res/values/themes.xml
+++ b/simplified-app-palace/src/main/res/values/themes.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="PalaceTheme" parent="PalaceTheme.WithoutActionBar" />
-</resources>

--- a/simplified-main/build.gradle.kts
+++ b/simplified-main/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.drawerlayout)
     implementation(libs.androidx.fragment)

--- a/simplified-tests/build.gradle.kts
+++ b/simplified-tests/build.gradle.kts
@@ -127,6 +127,7 @@ val dependencyObjects = listOf(
     libs.androidx.coordinatorlayout,
     libs.androidx.core,
     libs.androidx.core.ktx,
+    libs.androidx.core.splashscreen,
     libs.androidx.customview,
     libs.androidx.drawerlayout,
     libs.androidx.fragment,

--- a/simplified-ui-accounts/build.gradle.kts
+++ b/simplified-ui-accounts/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview.poolingcontainer)
     implementation(libs.androidx.drawerlayout)
     implementation(libs.androidx.emoji2)

--- a/simplified-ui-catalog/build.gradle.kts
+++ b/simplified-ui-catalog/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.customview.poolingcontainer)
     implementation(libs.androidx.drawerlayout)

--- a/simplified-ui-errorpage/build.gradle.kts
+++ b/simplified-ui-errorpage/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.drawerlayout)
     implementation(libs.androidx.fragment)

--- a/simplified-ui-navigation-tabs/build.gradle.kts
+++ b/simplified-ui-navigation-tabs/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.drawerlayout)
     implementation(libs.androidx.fragment)

--- a/simplified-ui-onboarding/build.gradle.kts
+++ b/simplified-ui-onboarding/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.drawerlayout)
     implementation(libs.androidx.fragment)

--- a/simplified-ui-settings/build.gradle.kts
+++ b/simplified-ui-settings/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.drawerlayout)
     implementation(libs.androidx.fragment)

--- a/simplified-ui-splash/build.gradle.kts
+++ b/simplified-ui-splash/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.drawerlayout)
     implementation(libs.androidx.fragment)

--- a/simplified-viewer-audiobook/build.gradle.kts
+++ b/simplified-viewer-audiobook/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.drawerlayout)
     implementation(libs.androidx.fragment)

--- a/simplified-viewer-epub-readium2/build.gradle.kts
+++ b/simplified-viewer-epub-readium2/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.cursoradapter)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.drawerlayout)

--- a/simplified-viewer-pdf-pdfjs/build.gradle.kts
+++ b/simplified-viewer-pdf-pdfjs/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.customview.poolingcontainer)

--- a/simplified-viewer-preview/build.gradle.kts
+++ b/simplified-viewer-preview/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.androidx.coordinatorlayout)
     implementation(libs.androidx.core)
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.drawerlayout)
     implementation(libs.androidx.emoji2)


### PR DESCRIPTION
**What's this do?**
This PR updates the app's default theme in order to remove the default SplashScreen added in all the Android 12+ devices.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://ebce-lyrasis.atlassian.net/browse/PP-585) saying that in some devices there are two splash screens being shown: the device's default and the app's splash screen.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app on an Android 12+ device
Confirm there's just the app's splash screen
Open the Palace app on an Android 11- device
Confirm there's just the app's splash screen

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-theme/pull/11) needs to be merged first

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 