### PR TITLE
PP-693 (partial): Switch to a new ULID library

### DIFF
--- a/simplified-app-palace/build.gradle.kts
+++ b/simplified-app-palace/build.gradle.kts
@@ -475,6 +475,7 @@ dependencies {
     implementation(libs.androidx.viewpager)
     implementation(libs.androidx.viewpager2)
     implementation(libs.androidx.webkit)
+    implementation(libs.azam.ulidj)
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.annotations)
     implementation(libs.firebase.common)
@@ -616,6 +617,4 @@ dependencies {
     implementation(libs.truevfs.driver.zip)
     implementation(libs.truevfs.kernel.impl)
     implementation(libs.truevfs.kernel.spec)
-    implementation(libs.ulid.kotlin)
-    implementation(libs.ulid.kotlin.jvm)
 }

--- a/simplified-books-time-tracking/build.gradle.kts
+++ b/simplified-books-time-tracking/build.gradle.kts
@@ -18,6 +18,5 @@ dependencies {
     implementation(libs.rxandroid2)
     implementation(libs.rxjava2)
     implementation(libs.slf4j)
-    implementation(libs.ulid.kotlin)
-    implementation(libs.ulid.kotlin.jvm)
+    implementation(libs.azam.ulidj)
 }

--- a/simplified-books-time-tracking/src/main/java/org/nypl/simplified/books/time/tracking/TimeTrackingService.kt
+++ b/simplified-books-time-tracking/src/main/java/org/nypl/simplified/books/time/tracking/TimeTrackingService.kt
@@ -1,6 +1,7 @@
 package org.nypl.simplified.books.time.tracking
 
 import android.content.Context
+import io.azam.ulidj.ULID
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
@@ -11,7 +12,6 @@ import org.librarysimplified.audiobook.api.PlayerEvent
 import org.nypl.simplified.accounts.api.AccountID
 import org.nypl.simplified.profiles.controller.api.ProfilesControllerType
 import org.slf4j.LoggerFactory
-import ulid.ULID
 import java.io.File
 import java.net.URI
 import java.util.concurrent.TimeUnit
@@ -183,7 +183,7 @@ class TimeTrackingService(
 
   private fun createTimeTrackingEntry() {
     currentTimeTrackingEntry = TimeTrackingEntry(
-      id = ULID.randomULID(),
+      id = ULID.random(),
       duringMinute = dateFormatter.print(DateTime.now()),
       secondsPlayed = 0
     )

--- a/simplified-tests/build.gradle.kts
+++ b/simplified-tests/build.gradle.kts
@@ -295,8 +295,7 @@ val dependencyObjects = listOf(
     libs.truevfs.driver.zip,
     libs.truevfs.kernel.impl,
     libs.truevfs.kernel.spec,
-    libs.ulid.kotlin,
-    libs.ulid.kotlin.jvm,
+    libs.azam.ulidj,
 )
 
 dependencies {


### PR DESCRIPTION
**What's this do?**
This is a partial fix for PP-693. We were using a ULID library that can't work on old devices due to them missing the standard `java.time` package.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-693

**How should this be tested? / Do these changes have associated tests?**
Unfortunately, the player still appears to be broken (and I'm debugging right now). This at least makes it slightly less broken.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
Not until the problem is actually fixed.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Verified one of the problems went away.