### PR TITLE
Started using device registration URI from patron authentication document

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -370,7 +370,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-11-09T16:49:31+00:00" is-open="true" ticket-system="org.lyrasis.jira" version="1.8.0">
+    <c:release date="2023-11-10T10:00:46+00:00" is-open="true" ticket-system="org.lyrasis.jira" version="1.8.0">
       <c:changes>
         <c:change date="2023-11-07T00:00:00+00:00" summary="Book sample buttons are no longer displayed for loaned books.">
           <c:tickets>
@@ -387,7 +387,8 @@
             <c:ticket id="PP-662"/>
           </c:tickets>
         </c:change>
-        <c:change date="2023-11-09T16:49:31+00:00" summary="Started using device registration URI from patron authentication document."/>
+        <c:change date="2023-11-09T00:00:00+00:00" summary="Started using device registration URI from patron authentication document."/>
+        <c:change date="2023-11-10T10:00:46+00:00" summary="Updated notification calls to be run in a background thread."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -370,7 +370,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-11-09T13:47:42+00:00" is-open="true" ticket-system="org.lyrasis.jira" version="1.8.0">
+    <c:release date="2023-11-09T16:49:31+00:00" is-open="true" ticket-system="org.lyrasis.jira" version="1.8.0">
       <c:changes>
         <c:change date="2023-11-07T00:00:00+00:00" summary="Book sample buttons are no longer displayed for loaned books.">
           <c:tickets>
@@ -382,11 +382,12 @@
             <c:ticket id="PP-687"/>
           </c:tickets>
         </c:change>
-        <c:change date="2023-11-09T13:47:42+00:00" summary="Allow seeking when paused in Findaway audio books.">
+        <c:change date="2023-11-09T00:00:00+00:00" summary="Allow seeking when paused in Findaway audio books.">
           <c:tickets>
             <c:ticket id="PP-662"/>
           </c:tickets>
         </c:change>
+        <c:change date="2023-11-09T16:49:31+00:00" summary="Started using device registration URI from patron authentication document."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountAuthenticationCredentials.kt
+++ b/simplified-accounts-api/src/main/java/org/nypl/simplified/accounts/api/AccountAuthenticationCredentials.kt
@@ -42,6 +42,13 @@ sealed class AccountAuthenticationCredentials {
   abstract val annotationsURI: URI?
 
   /**
+   * The device registration URI for the account. This is used to register or unregister a device
+   * to start/stop receiving push notifications.
+   */
+
+  abstract val deviceRegistrationURI: URI?
+
+  /**
    * The user used basic authentication to authenticate.
    */
 
@@ -50,7 +57,8 @@ sealed class AccountAuthenticationCredentials {
     val password: AccountPassword,
     override val adobeCredentials: AccountAuthenticationAdobePreActivationCredentials?,
     override val authenticationDescription: String?,
-    override val annotationsURI: URI?
+    override val annotationsURI: URI?,
+    override val deviceRegistrationURI: URI?
   ) : AccountAuthenticationCredentials() {
     override fun withoutAdobePostActivationCredentials(): AccountAuthenticationCredentials {
       return this.copy(
@@ -75,7 +83,8 @@ sealed class AccountAuthenticationCredentials {
     val authenticationTokenInfo: AccountAuthenticationTokenInfo,
     override val adobeCredentials: AccountAuthenticationAdobePreActivationCredentials?,
     override val authenticationDescription: String?,
-    override val annotationsURI: URI?
+    override val annotationsURI: URI?,
+    override val deviceRegistrationURI: URI?
   ) : AccountAuthenticationCredentials() {
     override fun withoutAdobePostActivationCredentials(): AccountAuthenticationCredentials {
       return this.copy(
@@ -110,7 +119,8 @@ sealed class AccountAuthenticationCredentials {
     val accessToken: String,
     override val adobeCredentials: AccountAuthenticationAdobePreActivationCredentials?,
     override val authenticationDescription: String?,
-    override val annotationsURI: URI?
+    override val annotationsURI: URI?,
+    override val deviceRegistrationURI: URI?
   ) : AccountAuthenticationCredentials() {
     override fun withoutAdobePostActivationCredentials(): AccountAuthenticationCredentials {
       return this.copy(
@@ -135,7 +145,8 @@ sealed class AccountAuthenticationCredentials {
     val cookies: List<AccountCookie>,
     override val adobeCredentials: AccountAuthenticationAdobePreActivationCredentials?,
     override val authenticationDescription: String?,
-    override val annotationsURI: URI?
+    override val annotationsURI: URI?,
+    override val deviceRegistrationURI: URI?
   ) : AccountAuthenticationCredentials() {
     override fun withoutAdobePostActivationCredentials(): AccountAuthenticationCredentials {
       return this.copy(

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountAuthenticationCredentialsJSON.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/AccountAuthenticationCredentialsJSON.kt
@@ -62,6 +62,10 @@ object AccountAuthenticationCredentialsJSON {
       authObject.put("annotationsURI", uri.toString())
     }
 
+    credentials.deviceRegistrationURI?.let { uri ->
+      authObject.put("deviceRegistrationURI", uri.toString())
+    }
+
     when (credentials) {
       is AccountAuthenticationCredentials.Basic -> {
         authObject.put("@type", "basic")

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/internal/AccountAuthenticationCredentialsJSON20190424.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/internal/AccountAuthenticationCredentialsJSON20190424.kt
@@ -39,7 +39,8 @@ object AccountAuthenticationCredentialsJSON20190424 : AccountAuthenticationCrede
       password = pass,
       adobeCredentials = adobeCredentials,
       authenticationDescription = null,
-      annotationsURI = null
+      annotationsURI = null,
+      deviceRegistrationURI = null
     )
   }
 }

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/internal/AccountAuthenticationCredentialsJSON20200604.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/internal/AccountAuthenticationCredentialsJSON20200604.kt
@@ -50,7 +50,8 @@ object AccountAuthenticationCredentialsJSON20200604 : AccountAuthenticationCrede
       accessToken = JSONParserUtilities.getString(obj, "accessToken"),
       adobeCredentials = adobeCredentials,
       authenticationDescription = JSONParserUtilities.getStringOrNull(obj, "authenticationDescription"),
-      annotationsURI = null
+      annotationsURI = null,
+      deviceRegistrationURI = null
     )
   }
 
@@ -66,7 +67,8 @@ object AccountAuthenticationCredentialsJSON20200604 : AccountAuthenticationCrede
       password = AccountPassword(JSONParserUtilities.getString(obj, "password")),
       adobeCredentials = adobeCredentials,
       authenticationDescription = JSONParserUtilities.getStringOrNull(obj, "authenticationDescription"),
-      annotationsURI = null
+      annotationsURI = null,
+      deviceRegistrationURI = null
     )
   }
 }

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/internal/AccountAuthenticationCredentialsJSON20200805.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/internal/AccountAuthenticationCredentialsJSON20200805.kt
@@ -54,7 +54,8 @@ object AccountAuthenticationCredentialsJSON20200805 : AccountAuthenticationCrede
       accessToken = JSONParserUtilities.getString(obj, "accessToken"),
       adobeCredentials = adobeCredentials,
       authenticationDescription = JSONParserUtilities.getStringOrNull(obj, "authenticationDescription"),
-      annotationsURI = null
+      annotationsURI = null,
+      deviceRegistrationURI = null
     )
   }
 
@@ -70,7 +71,8 @@ object AccountAuthenticationCredentialsJSON20200805 : AccountAuthenticationCrede
       password = AccountPassword(JSONParserUtilities.getString(obj, "password")),
       adobeCredentials = adobeCredentials,
       authenticationDescription = JSONParserUtilities.getStringOrNull(obj, "authenticationDescription"),
-      annotationsURI = null
+      annotationsURI = null,
+      deviceRegistrationURI = null
     )
   }
 
@@ -85,7 +87,8 @@ object AccountAuthenticationCredentialsJSON20200805 : AccountAuthenticationCrede
       authenticationDescription = JSONParserUtilities.getStringOrNull(obj, "authenticationDescription"),
       patronInfo = JSONParserUtilities.getString(obj, "patronInfo"),
       cookies = deserializeCookies(JSONParserUtilities.getArray(obj, "cookies")),
-      annotationsURI = null
+      annotationsURI = null,
+      deviceRegistrationURI = null
     )
   }
 

--- a/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/internal/AccountAuthenticationCredentialsJSON20210512.kt
+++ b/simplified-accounts-json/src/main/java/org/nypl/simplified/accounts/json/internal/AccountAuthenticationCredentialsJSON20210512.kt
@@ -63,7 +63,8 @@ object AccountAuthenticationCredentialsJSON20210512 : AccountAuthenticationCrede
       accessToken = JSONParserUtilities.getString(obj, "accessToken"),
       adobeCredentials = adobeCredentials,
       authenticationDescription = JSONParserUtilities.getStringOrNull(obj, "authenticationDescription"),
-      annotationsURI = JSONParserUtilities.getURIOrNull(obj, "annotationsURI")
+      annotationsURI = JSONParserUtilities.getURIOrNull(obj, "annotationsURI"),
+      deviceRegistrationURI = JSONParserUtilities.getURIOrNull(obj, "deviceRegistrationURI")
     )
   }
 
@@ -79,7 +80,8 @@ object AccountAuthenticationCredentialsJSON20210512 : AccountAuthenticationCrede
       password = AccountPassword(JSONParserUtilities.getString(obj, "password")),
       adobeCredentials = adobeCredentials,
       authenticationDescription = JSONParserUtilities.getStringOrNull(obj, "authenticationDescription"),
-      annotationsURI = JSONParserUtilities.getURIOrNull(obj, "annotationsURI")
+      annotationsURI = JSONParserUtilities.getURIOrNull(obj, "annotationsURI"),
+      deviceRegistrationURI = JSONParserUtilities.getURIOrNull(obj, "deviceRegistrationURI")
     )
   }
 
@@ -103,7 +105,8 @@ object AccountAuthenticationCredentialsJSON20210512 : AccountAuthenticationCrede
       ),
       adobeCredentials = adobeCredentials,
       authenticationDescription = JSONParserUtilities.getStringOrNull(obj, "authenticationDescription"),
-      annotationsURI = JSONParserUtilities.getURIOrNull(obj, "annotationsURI")
+      annotationsURI = JSONParserUtilities.getURIOrNull(obj, "annotationsURI"),
+      deviceRegistrationURI = JSONParserUtilities.getURIOrNull(obj, "deviceRegistrationURI")
     )
   }
 
@@ -118,7 +121,8 @@ object AccountAuthenticationCredentialsJSON20210512 : AccountAuthenticationCrede
       authenticationDescription = JSONParserUtilities.getStringOrNull(obj, "authenticationDescription"),
       patronInfo = JSONParserUtilities.getString(obj, "patronInfo"),
       cookies = deserializeCookies(JSONParserUtilities.getArray(obj, "cookies")),
-      annotationsURI = JSONParserUtilities.getURIOrNull(obj, "annotationsURI")
+      annotationsURI = JSONParserUtilities.getURIOrNull(obj, "annotationsURI"),
+      deviceRegistrationURI = JSONParserUtilities.getURIOrNull(obj, "deviceRegistrationURI")
     )
   }
 

--- a/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLoginTask.kt
+++ b/simplified-books-controller/src/main/java/org/nypl/simplified/books/controller/ProfileAccountLoginTask.kt
@@ -237,7 +237,8 @@ class ProfileAccountLoginTask(
             authenticationDescription = this.findCurrentDescription().description,
             patronInfo = request.patronInfo,
             cookies = request.cookies,
-            annotationsURI = null
+            annotationsURI = null,
+            deviceRegistrationURI = null
           )
 
         this.handlePatronUserProfile()
@@ -310,7 +311,8 @@ class ProfileAccountLoginTask(
             accessToken = request.token,
             adobeCredentials = null,
             authenticationDescription = this.findCurrentDescription().description,
-            annotationsURI = null
+            annotationsURI = null,
+            deviceRegistrationURI = null
           )
 
         this.handlePatronUserProfile()
@@ -356,7 +358,8 @@ class ProfileAccountLoginTask(
         password = request.password,
         authenticationDescription = request.description.description,
         adobeCredentials = null,
-        annotationsURI = null
+        annotationsURI = null,
+        deviceRegistrationURI = null
       )
 
     this.handlePatronUserProfile()
@@ -397,7 +400,8 @@ class ProfileAccountLoginTask(
             ),
             adobeCredentials = null,
             authenticationDescription = request.description.description,
-            annotationsURI = null
+            annotationsURI = null,
+            deviceRegistrationURI = null
           )
 
           this.handlePatronUserProfile()
@@ -452,19 +456,31 @@ class ProfileAccountLoginTask(
 
     this.credentials = when (val currentCredentials = this.credentials) {
       is AccountAuthenticationCredentials.Basic -> {
-        currentCredentials.copy(annotationsURI = patronProfile.annotationsURI)
+        currentCredentials.copy(
+          annotationsURI = patronProfile.annotationsURI,
+          deviceRegistrationURI = patronProfile.deviceRegistrationURI
+        )
       }
 
       is AccountAuthenticationCredentials.BasicToken -> {
-        currentCredentials.copy(annotationsURI = patronProfile.annotationsURI)
+        currentCredentials.copy(
+          annotationsURI = patronProfile.annotationsURI,
+          deviceRegistrationURI = patronProfile.deviceRegistrationURI
+        )
       }
 
       is AccountAuthenticationCredentials.OAuthWithIntermediary -> {
-        currentCredentials.copy(annotationsURI = patronProfile.annotationsURI)
+        currentCredentials.copy(
+          annotationsURI = patronProfile.annotationsURI,
+          deviceRegistrationURI = patronProfile.deviceRegistrationURI
+        )
       }
 
       is AccountAuthenticationCredentials.SAML2_0 -> {
-        currentCredentials.copy(annotationsURI = patronProfile.annotationsURI)
+        currentCredentials.copy(
+          annotationsURI = patronProfile.annotationsURI,
+          deviceRegistrationURI = patronProfile.deviceRegistrationURI
+        )
       }
     }
   }

--- a/simplified-main/src/main/java/org/librarysimplified/main/MainServices.kt
+++ b/simplified-main/src/main/java/org/librarysimplified/main/MainServices.kt
@@ -883,7 +883,8 @@ internal object MainServices {
         interfaceType = NotificationTokenHTTPCallsType::class.java,
         serviceConstructor = {
           NotificationTokenHTTPCalls(
-            http = lsHTTP
+            http = lsHTTP,
+            executor = NamedThreadPools.namedThreadPool(1, "http-notifications", 19)
           )
         }
       )

--- a/simplified-notifications/src/main/java/NotificationTokenHTTPCalls.kt
+++ b/simplified-notifications/src/main/java/NotificationTokenHTTPCalls.kt
@@ -71,7 +71,7 @@ class NotificationTokenHTTPCalls(
 
             is LSHTTPResponseStatus.Responded.Error -> {
               if (status.properties.status == HttpURLConnection.HTTP_NOT_FOUND) {
-                logger.error(
+                logger.debug(
                   "The account {} doesn't have the FCM token {}. Let's send it...",
                   account.id,
                   token

--- a/simplified-patron-api/src/main/java/org/nypl/simplified/patron/api/PatronUserProfile.kt
+++ b/simplified-patron-api/src/main/java/org/nypl/simplified/patron/api/PatronUserProfile.kt
@@ -20,7 +20,7 @@ data class PatronUserProfile(
    * The annotations link, if one was present.
    */
 
-  val annotationsLink: Link? =
+  private val annotationsLink: Link? =
     this.links.find { link -> link.relation == "http://www.w3.org/ns/oa#annotationService" }
 
   /**
@@ -29,4 +29,18 @@ data class PatronUserProfile(
 
   val annotationsURI: URI? =
     this.annotationsLink?.hrefURI
+
+  /**
+   * The device registration link, if one was present.
+   */
+
+  private val deviceRegistrationLink: Link? =
+    this.links.find { link -> link.relation == "http://palaceproject.io/terms/deviceRegistration" }
+
+  /**
+   * The device registration URI, if one was present.
+   */
+
+  val deviceRegistrationURI: URI? =
+    this.deviceRegistrationLink?.hrefURI
 }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountAuthenticationCredentialsJSONTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountAuthenticationCredentialsJSONTest.kt
@@ -33,7 +33,8 @@ class AccountAuthenticationCredentialsJSONTest {
         password = AccountPassword("5678"),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val creds1 = deserializeFromJSON(serializeToJSON(creds0))
@@ -48,7 +49,8 @@ class AccountAuthenticationCredentialsJSONTest {
         accessToken = "bm90IGFuIGFjY2VzcyB0b2tlbgo=",
         authenticationDescription = null,
         adobeCredentials = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val creds1 = deserializeFromJSON(serializeToJSON(creds0))
@@ -72,7 +74,8 @@ class AccountAuthenticationCredentialsJSONTest {
         password = AccountPassword("5678"),
         adobeCredentials = adobe,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val creds1 = deserializeFromJSON(serializeToJSON(creds0))
@@ -101,7 +104,8 @@ class AccountAuthenticationCredentialsJSONTest {
         password = AccountPassword("5678"),
         adobeCredentials = adobe,
         authenticationDescription = "fake",
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val creds1 = deserializeFromJSON(serializeToJSON(creds0))
@@ -130,6 +134,7 @@ class AccountAuthenticationCredentialsJSONTest {
         adobeCredentials = adobe,
         authenticationDescription = "fake",
         annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com"),
         patronInfo = "{}",
         cookies = listOf(
           AccountCookie("https://example", "cookie0=23"),
@@ -155,7 +160,8 @@ class AccountAuthenticationCredentialsJSONTest {
         ),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val creds1 = deserializeFromJSON(serializeToJSON(creds0))
@@ -183,7 +189,8 @@ class AccountAuthenticationCredentialsJSONTest {
         ),
         adobeCredentials = adobe,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val creds1 = deserializeFromJSON(serializeToJSON(creds0))
@@ -216,7 +223,8 @@ class AccountAuthenticationCredentialsJSONTest {
         ),
         adobeCredentials = adobe,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val creds1 = deserializeFromJSON(serializeToJSON(creds0))

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountAuthenticationCredentialsStoreTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountAuthenticationCredentialsStoreTest.kt
@@ -59,7 +59,8 @@ class AccountAuthenticationCredentialsStoreTest {
         password = AccountPassword("1234"),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     store0.put(accountID, credentials)
@@ -132,7 +133,8 @@ class AccountAuthenticationCredentialsStoreTest {
           password = AccountPassword("1234"),
           adobeCredentials = null,
           authenticationDescription = null,
-          annotationsURI = URI("https://www.example.com")
+          annotationsURI = URI("https://www.example.com"),
+          deviceRegistrationURI = URI("https://www.example.com")
         )
       )
     cred1.remove("username")
@@ -149,7 +151,8 @@ class AccountAuthenticationCredentialsStoreTest {
           password = AccountPassword("1234"),
           adobeCredentials = null,
           authenticationDescription = null,
-          annotationsURI = URI("https://www.example.com")
+          annotationsURI = URI("https://www.example.com"),
+          deviceRegistrationURI = URI("https://www.example.com")
         )
       )
     creds.set<ObjectNode>("not a uuid", cred2)
@@ -165,7 +168,8 @@ class AccountAuthenticationCredentialsStoreTest {
           password = AccountPassword("1234"),
           adobeCredentials = null,
           authenticationDescription = null,
-          annotationsURI = URI("https://www.example.com")
+          annotationsURI = URI("https://www.example.com"),
+          deviceRegistrationURI = URI("https://www.example.com")
         )
       )
     creds.set<ObjectNode>("37452e48-2235-4098-ad67-e72bce45ccb6", cred3)
@@ -195,7 +199,8 @@ class AccountAuthenticationCredentialsStoreTest {
         password = AccountPassword("1234"),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     store.put(accountID, credentials)
@@ -222,7 +227,8 @@ class AccountAuthenticationCredentialsStoreTest {
         ),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     store.put(accountID, credentials)

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountsDatabaseContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/accounts/AccountsDatabaseContract.kt
@@ -436,7 +436,8 @@ abstract class AccountsDatabaseContract {
         password = AccountPassword("1234"),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     acc0.setLoginState(AccountLoginState.AccountLoggedIn(creds))
@@ -445,22 +446,39 @@ abstract class AccountsDatabaseContract {
     acc0.updateCredentialsIfAvailable {
       when (it) {
         is AccountAuthenticationCredentials.Basic ->
-          creds.copy(annotationsURI = URI.create("https://www.example.com/annotations"))
+          creds.copy(
+            annotationsURI = URI.create("https://www.example.com/annotations"),
+            deviceRegistrationURI = URI.create("https://www.example.com/deviceRegistration")
+          )
 
         is AccountAuthenticationCredentials.BasicToken ->
-          creds.copy(annotationsURI = URI.create("https://www.example.com/annotations"))
+          creds.copy(
+            annotationsURI = URI.create("https://www.example.com/annotations"),
+            deviceRegistrationURI = URI.create("https://www.example.com/deviceRegistration")
+          )
 
         is AccountAuthenticationCredentials.OAuthWithIntermediary ->
-          creds.copy(annotationsURI = URI.create("https://www.example.com/annotations"))
+          creds.copy(
+            annotationsURI = URI.create("https://www.example.com/annotations"),
+            deviceRegistrationURI = URI.create("https://www.example.com/deviceRegistration")
+          )
 
         is AccountAuthenticationCredentials.SAML2_0 ->
-          creds.copy(annotationsURI = URI.create("https://www.example.com/annotations"))
+          creds.copy(
+            annotationsURI = URI.create("https://www.example.com/annotations"),
+            deviceRegistrationURI = URI.create("https://www.example.com/deviceRegistration")
+          )
       }
     }
 
     Assertions.assertEquals(
       URI.create("https://www.example.com/annotations"),
       acc0.loginState.credentials?.annotationsURI
+    )
+
+    Assertions.assertEquals(
+      URI.create("https://www.example.com/deviceRegistration"),
+      acc0.loginState.credentials?.deviceRegistrationURI
     )
   }
 
@@ -500,7 +518,8 @@ abstract class AccountsDatabaseContract {
         ),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     acc0.setLoginState(AccountLoginState.AccountLoggedIn(creds))

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/BHTTPCallsTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/BHTTPCallsTest.kt
@@ -53,7 +53,8 @@ class BHTTPCallsTest {
         ),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val targetURI =
@@ -82,7 +83,8 @@ class BHTTPCallsTest {
         password = AccountPassword("1234"),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val targetURI =
@@ -305,7 +307,8 @@ class BHTTPCallsTest {
         password = AccountPassword("1234"),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val targetURI = this.server.url("me").toUri()
@@ -333,7 +336,8 @@ class BHTTPCallsTest {
         password = AccountPassword("1234"),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val targetURI = this.server.url("annotations").toUri()
@@ -361,7 +365,8 @@ class BHTTPCallsTest {
         password = AccountPassword("1234"),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val targetURI = this.server.url("annotations").toUri()

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/BookmarkServiceContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/BookmarkServiceContract.kt
@@ -74,6 +74,7 @@ abstract class BookmarkServiceContract {
   private lateinit var serverDispatcher: EndpointDispatcher
   private lateinit var http: LSHTTPClientType
   private lateinit var annotationsURI: URI
+  private lateinit var deviceRegistrationURI: URI
   private lateinit var patronURI: URI
 
   private val annotationsEmpty = """
@@ -118,7 +119,8 @@ abstract class BookmarkServiceContract {
       password = AccountPassword("1234"),
       adobeCredentials = null,
       authenticationDescription = null,
-      annotationsURI = null
+      annotationsURI = null,
+      deviceRegistrationURI = null
     )
 
   private fun addResponse(
@@ -162,6 +164,8 @@ abstract class BookmarkServiceContract {
     this.server.dispatcher = this.serverDispatcher
     this.annotationsURI =
       URI.create("http://localhost:10000/annotations")
+    this.deviceRegistrationURI =
+      URI.create("http://localhost:10000/deviceRegistration")
     this.patronURI =
       URI.create("http://localhost:10000/patron")
   }
@@ -218,7 +222,10 @@ abstract class BookmarkServiceContract {
     Mockito.`when`(account.loginState)
       .thenReturn(
         AccountLoggedIn(
-          this.accountCredentials.copy(annotationsURI = this.annotationsURI)
+          this.accountCredentials.copy(
+            annotationsURI = this.annotationsURI,
+            deviceRegistrationURI = deviceRegistrationURI
+          )
         )
       )
     Mockito.`when`(account.id)
@@ -282,7 +289,13 @@ abstract class BookmarkServiceContract {
       },
       "At least one request made to ${this.annotationsURI}"
     )
-    Assertions.assertEquals(2, allRequests.size)
+    Assertions.assertTrue(
+      allRequests.any { request ->
+        request.requestUrl?.toUri() == this.deviceRegistrationURI
+      },
+      "At least one request made to ${this.deviceRegistrationURI}"
+    )
+    Assertions.assertEquals(3, allRequests.size)
   }
 
   private fun takeAllRequests(): List<RecordedRequest> {
@@ -415,7 +428,10 @@ abstract class BookmarkServiceContract {
     Mockito.`when`(account.loginState)
       .thenReturn(
         AccountLoggedIn(
-          this.accountCredentials.copy(annotationsURI = this.annotationsURI)
+          this.accountCredentials.copy(
+            annotationsURI = this.annotationsURI,
+            deviceRegistrationURI = deviceRegistrationURI
+          )
         )
       )
     Mockito.`when`(account.id)
@@ -474,7 +490,10 @@ abstract class BookmarkServiceContract {
     )
 
     Assertions.assertEquals(1, receivedBookmarks.size)
-    Assertions.assertEquals("urn:example.com/terms/id/c083c0a6-54c6-4cc5-9d3a-425317da662a", receivedBookmarks[0].opdsId)
+    Assertions.assertEquals(
+      "urn:example.com/terms/id/c083c0a6-54c6-4cc5-9d3a-425317da662a",
+      receivedBookmarks[0].opdsId
+    )
 
     val allRequests = this.takeAllRequests()
     Assertions.assertTrue(
@@ -489,7 +508,13 @@ abstract class BookmarkServiceContract {
       },
       "At least one request made to ${this.annotationsURI}"
     )
-    Assertions.assertEquals(2, allRequests.size)
+    Assertions.assertTrue(
+      allRequests.any { request ->
+        request.requestUrl?.toUri() == this.deviceRegistrationURI
+      },
+      "At least one request made to ${this.deviceRegistrationURI}"
+    )
+    Assertions.assertEquals(3, allRequests.size)
   }
 
   /**
@@ -625,7 +650,10 @@ abstract class BookmarkServiceContract {
     Mockito.`when`(account.loginState)
       .thenReturn(
         AccountLoggedIn(
-          this.accountCredentials.copy(annotationsURI = this.annotationsURI)
+          this.accountCredentials.copy(
+            annotationsURI = this.annotationsURI,
+            deviceRegistrationURI = deviceRegistrationURI
+          )
         )
       )
     Mockito.`when`(account.id)
@@ -687,8 +715,14 @@ abstract class BookmarkServiceContract {
     )
 
     Assertions.assertEquals(2, receivedBookmarks.size)
-    Assertions.assertEquals("urn:example.com/terms/id/c083c0a6-54c6-4cc5-9d3a-425317da662a", receivedBookmarks[0].opdsId)
-    Assertions.assertEquals("urn:example.com/terms/id/c083c0a6-54c6-4cc5-9d3a-425317da662a", receivedBookmarks[1].opdsId)
+    Assertions.assertEquals(
+      "urn:example.com/terms/id/c083c0a6-54c6-4cc5-9d3a-425317da662a",
+      receivedBookmarks[0].opdsId
+    )
+    Assertions.assertEquals(
+      "urn:example.com/terms/id/c083c0a6-54c6-4cc5-9d3a-425317da662a",
+      receivedBookmarks[1].opdsId
+    )
 
     val allRequests = this.takeAllRequests()
     Assertions.assertTrue(
@@ -703,7 +737,13 @@ abstract class BookmarkServiceContract {
       },
       "At least one request made to ${this.annotationsURI}"
     )
-    Assertions.assertEquals(2, allRequests.size)
+    Assertions.assertTrue(
+      allRequests.any { request ->
+        this.matchesEndpoint(request, "/deviceRegistration")
+      },
+      "At least one request made to ${this.deviceRegistrationURI}"
+    )
+    Assertions.assertEquals(3, allRequests.size)
   }
 
   /**

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/BookmarkServiceContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/BookmarkServiceContract.kt
@@ -289,13 +289,7 @@ abstract class BookmarkServiceContract {
       },
       "At least one request made to ${this.annotationsURI}"
     )
-    Assertions.assertTrue(
-      allRequests.any { request ->
-        request.requestUrl?.toUri() == this.deviceRegistrationURI
-      },
-      "At least one request made to ${this.deviceRegistrationURI}"
-    )
-    Assertions.assertEquals(3, allRequests.size)
+    Assertions.assertEquals(2, allRequests.size)
   }
 
   private fun takeAllRequests(): List<RecordedRequest> {
@@ -508,13 +502,7 @@ abstract class BookmarkServiceContract {
       },
       "At least one request made to ${this.annotationsURI}"
     )
-    Assertions.assertTrue(
-      allRequests.any { request ->
-        request.requestUrl?.toUri() == this.deviceRegistrationURI
-      },
-      "At least one request made to ${this.deviceRegistrationURI}"
-    )
-    Assertions.assertEquals(3, allRequests.size)
+    Assertions.assertEquals(2, allRequests.size)
   }
 
   /**
@@ -737,13 +725,7 @@ abstract class BookmarkServiceContract {
       },
       "At least one request made to ${this.annotationsURI}"
     )
-    Assertions.assertTrue(
-      allRequests.any { request ->
-        this.matchesEndpoint(request, "/deviceRegistration")
-      },
-      "At least one request made to ${this.deviceRegistrationURI}"
-    )
-    Assertions.assertEquals(3, allRequests.size)
+    Assertions.assertEquals(2, allRequests.size)
   }
 
   /**

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/BookmarkServiceSupportedDisableTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/BookmarkServiceSupportedDisableTest.kt
@@ -68,6 +68,7 @@ class BookmarkServiceSupportedDisableTest {
   private lateinit var server: MockWebServer
   private lateinit var http: LSHTTPClientType
   private lateinit var annotationsURI: URI
+  private lateinit var deviceRegistrationURI: URI
   private lateinit var patronURI: URI
   private lateinit var serverDispatcher: EndpointDispatcher
 
@@ -148,6 +149,8 @@ class BookmarkServiceSupportedDisableTest {
     this.server.dispatcher = this.serverDispatcher
     this.annotationsURI =
       URI.create("http://localhost:10000/annotations")
+    this.deviceRegistrationURI =
+      URI.create("http://localhost:10000/deviceRegistration")
     this.patronURI =
       URI.create("http://localhost:10000/patron")
   }
@@ -196,7 +199,8 @@ class BookmarkServiceSupportedDisableTest {
           password = AccountPassword("tycho"),
           adobeCredentials = null,
           authenticationDescription = null,
-          annotationsURI = this.annotationsURI
+          annotationsURI = this.annotationsURI,
+          deviceRegistrationURI = this.deviceRegistrationURI
         )
       )
     )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/BookmarkServiceSupportedEnableTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/bookmarks/BookmarkServiceSupportedEnableTest.kt
@@ -68,6 +68,7 @@ class BookmarkServiceSupportedEnableTest {
   private lateinit var server: MockWebServer
   private lateinit var http: LSHTTPClientType
   private lateinit var annotationsURI: URI
+  private lateinit var deviceRegistrationURI: URI
   private lateinit var patronURI: URI
   private lateinit var serverDispatcher: EndpointDispatcher
 
@@ -148,6 +149,8 @@ class BookmarkServiceSupportedEnableTest {
     this.server.dispatcher = this.serverDispatcher
     this.annotationsURI =
       URI.create("http://localhost:10000/annotations")
+    this.deviceRegistrationURI =
+      URI.create("http://localhost:10000/deviceRegistration")
     this.patronURI =
       URI.create("http://localhost:10000/patron")
   }
@@ -196,7 +199,8 @@ class BookmarkServiceSupportedEnableTest {
           password = AccountPassword("tycho"),
           adobeCredentials = null,
           authenticationDescription = null,
-          annotationsURI = this.annotationsURI
+          annotationsURI = this.annotationsURI,
+          deviceRegistrationURI = this.deviceRegistrationURI
         )
       )
     )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowACSMTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowACSMTest.kt
@@ -191,7 +191,8 @@ class BorrowACSMTest {
               )
             ),
             authenticationDescription = "Basic",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )
@@ -394,7 +395,8 @@ class BorrowACSMTest {
             password = AccountPassword("password"),
             adobeCredentials = null,
             authenticationDescription = "Basic",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )
@@ -439,7 +441,8 @@ class BorrowACSMTest {
               null
             ),
             authenticationDescription = "Basic",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowAudioBookTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowAudioBookTest.kt
@@ -130,7 +130,8 @@ class BorrowAudioBookTest {
             password = AccountPassword("password"),
             adobeCredentials = null,
             authenticationDescription = "Basic",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowAxisNowTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowAxisNowTest.kt
@@ -147,7 +147,8 @@ class BorrowAxisNowTest {
             password = AccountPassword("password"),
             adobeCredentials = null,
             authenticationDescription = "Basic",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowDirectDownloadTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowDirectDownloadTest.kt
@@ -123,7 +123,8 @@ class BorrowDirectDownloadTest {
             password = AccountPassword("not a password"),
             adobeCredentials = null,
             authenticationDescription = "Basic",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLCPTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLCPTest.kt
@@ -113,7 +113,8 @@ class BorrowLCPTest {
             password = AccountPassword("not a password"),
             adobeCredentials = null,
             authenticationDescription = "Basic",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLimitLoanTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLimitLoanTest.kt
@@ -98,7 +98,8 @@ class BorrowLimitLoanTest {
             password = AccountPassword("not a password"),
             adobeCredentials = null,
             authenticationDescription = "Basic",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLoanCreateTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowLoanCreateTest.kt
@@ -129,7 +129,8 @@ class BorrowLoanCreateTest {
             password = AccountPassword("not a password"),
             adobeCredentials = null,
             authenticationDescription = "Basic",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowSAMLDownloadTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowSAMLDownloadTest.kt
@@ -128,7 +128,8 @@ class BorrowSAMLDownloadTest {
             ),
             adobeCredentials = null,
             authenticationDescription = "SAML",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowTaskTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/borrowing/BorrowTaskTest.kt
@@ -313,7 +313,8 @@ class BorrowTaskTest {
               )
             ),
             authenticationDescription = "Basic",
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskAdobeDRMTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BookRevokeTaskAdobeDRMTest.kt
@@ -531,7 +531,8 @@ class BookRevokeTaskAdobeDRMTest {
               )
             ),
             authenticationDescription = null,
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )
@@ -689,7 +690,8 @@ class BookRevokeTaskAdobeDRMTest {
               )
             ),
             authenticationDescription = null,
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )
@@ -838,7 +840,8 @@ class BookRevokeTaskAdobeDRMTest {
               )
             ),
             authenticationDescription = null,
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )
@@ -988,7 +991,8 @@ class BookRevokeTaskAdobeDRMTest {
               )
             ),
             authenticationDescription = null,
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )
@@ -1142,7 +1146,8 @@ class BookRevokeTaskAdobeDRMTest {
               postActivationCredentials = null
             ),
             authenticationDescription = null,
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )
@@ -1394,7 +1399,8 @@ class BookRevokeTaskAdobeDRMTest {
               )
             ),
             authenticationDescription = null,
-            annotationsURI = URI("https://www.example.com")
+            annotationsURI = URI("https://www.example.com"),
+            deviceRegistrationURI = URI("https://www.example.com")
           )
         )
       )

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
@@ -159,7 +159,8 @@ abstract class BooksControllerContract {
       password = AccountPassword("1234"),
       adobeCredentials = null,
       authenticationDescription = null,
-      annotationsURI = URI("https://www.example.com")
+      annotationsURI = URI("https://www.example.com"),
+      deviceRegistrationURI = URI("https://www.example.com")
     )
   }
 

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/BooksControllerContract.kt
@@ -128,6 +128,7 @@ abstract class BooksControllerContract {
   private lateinit var executorBooks: ListeningExecutorService
   private lateinit var executorDownloads: ListeningExecutorService
   private lateinit var executorFeeds: ListeningExecutorService
+  private lateinit var executorNotifications: ListeningExecutorService
   private lateinit var executorTimer: ListeningExecutorService
   private lateinit var lsHTTP: LSHTTPClientType
   private lateinit var patronUserProfileParsers: PatronUserProfileParsersType
@@ -211,7 +212,7 @@ abstract class BooksControllerContract {
     services.putService(ContentResolverType::class.java, this.contentResolver)
     services.putService(FeedLoaderType::class.java, feedLoader)
     services.putService(LSHTTPClientType::class.java, this.lsHTTP)
-    services.putService(NotificationTokenHTTPCallsType::class.java, NotificationTokenHTTPCalls(this.lsHTTP))
+    services.putService(NotificationTokenHTTPCallsType::class.java, NotificationTokenHTTPCalls(this.lsHTTP, this.executorNotifications))
     services.putService(OPDSFeedParserType::class.java, parser)
     services.putService(PatronUserProfileParsersType::class.java, patronUserProfileParsers)
     services.putService(ProfileAccountCreationStringResourcesType::class.java, profileAccountCreationStringResources)
@@ -275,7 +276,7 @@ abstract class BooksControllerContract {
     services.putService(FeedLoaderType::class.java, feedLoader)
     services.putService(LSHTTPClientType::class.java, this.lsHTTP)
     services.putService(OPDSFeedParserType::class.java, parser)
-    services.putService(NotificationTokenHTTPCallsType::class.java, NotificationTokenHTTPCalls(this.lsHTTP))
+    services.putService(NotificationTokenHTTPCallsType::class.java, NotificationTokenHTTPCalls(this.lsHTTP, this.executorNotifications))
     services.putService(PatronUserProfileParsersType::class.java, patronUserProfileParsers)
     services.putService(ProfileAccountCreationStringResourcesType::class.java, profileAccountCreationStringResources)
     services.putService(ProfileAccountDeletionStringResourcesType::class.java, profileAccountDeletionStringResources)
@@ -313,6 +314,7 @@ abstract class BooksControllerContract {
     this.executorBooks = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool())
     this.executorDownloads = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool())
     this.executorFeeds = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool())
+    this.executorNotifications = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool())
     this.executorTimer = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool())
     this.patronUserProfileParsers = Mockito.mock(PatronUserProfileParsersType::class.java)
     this.profileEvents = PublishSubject.create<ProfileEvent>()

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/ProfilesControllerContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/controller/ProfilesControllerContract.kt
@@ -107,6 +107,7 @@ abstract class ProfilesControllerContract {
   private lateinit var directoryProfiles: File
   private lateinit var executorBooks: ExecutorService
   private lateinit var executorFeeds: ListeningExecutorService
+  private lateinit var executorNotifications: ExecutorService
   private lateinit var executorTimer: ExecutorService
   private lateinit var lsHTTP: LSHTTPClientType
   private lateinit var patronUserProfileParsers: PatronUserProfileParsersType
@@ -174,7 +175,7 @@ abstract class ProfilesControllerContract {
     services.putService(FeedLoaderType::class.java, feedLoader)
     services.putService(LSHTTPClientType::class.java, this.lsHTTP)
     services.putService(OPDSFeedParserType::class.java, parser)
-    services.putService(NotificationTokenHTTPCallsType::class.java, NotificationTokenHTTPCalls(this.lsHTTP))
+    services.putService(NotificationTokenHTTPCallsType::class.java, NotificationTokenHTTPCalls(this.lsHTTP, this.executorNotifications))
     services.putService(PatronUserProfileParsersType::class.java, this.patronUserProfileParsers)
     services.putService(ProfileAccountCreationStringResourcesType::class.java, this.profileAccountCreationStringResources)
     services.putService(ProfileAccountDeletionStringResourcesType::class.java, this.profileAccountDeletionStringResources)
@@ -199,6 +200,7 @@ abstract class ProfilesControllerContract {
     this.authDocumentParsers = Mockito.mock(AuthenticationDocumentParsersType::class.java)
     this.executorFeeds = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool())
     this.executorBooks = Executors.newCachedThreadPool()
+    this.executorNotifications = Executors.newCachedThreadPool()
     this.executorTimer = Executors.newCachedThreadPool()
     this.directoryDownloads = DirectoryUtilities.directoryCreateTemporary()
     this.directoryProfiles = DirectoryUtilities.directoryCreateTemporary()

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLoginTaskContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLoginTaskContract.kt
@@ -710,7 +710,8 @@ abstract class ProfileAccountLoginTaskContract {
         password = request.password,
         adobeCredentials = null,
         authenticationDescription = "Description",
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       ),
       state.credentials
     )
@@ -843,7 +844,8 @@ abstract class ProfileAccountLoginTaskContract {
         password = request.password,
         adobeCredentials = null,
         authenticationDescription = "Library Login",
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val newCredentials =
@@ -1000,7 +1002,8 @@ abstract class ProfileAccountLoginTaskContract {
         ),
         adobeCredentials = null,
         authenticationDescription = "Library Login",
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val newCredentials =
@@ -1110,7 +1113,8 @@ abstract class ProfileAccountLoginTaskContract {
         password = request.password,
         adobeCredentials = null,
         authenticationDescription = "Description",
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val newCredentials =
@@ -1375,7 +1379,8 @@ abstract class ProfileAccountLoginTaskContract {
         password = request.password,
         adobeCredentials = null,
         authenticationDescription = "Library Login",
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     val newCredentials =
@@ -1748,7 +1753,8 @@ abstract class ProfileAccountLoginTaskContract {
         adobeCredentials = null,
         authenticationDescription = "Description",
         accessToken = "A TOKEN!",
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       ),
       state.credentials
     )
@@ -2105,7 +2111,8 @@ abstract class ProfileAccountLoginTaskContract {
           AccountCookie("https://example", "cookie0=23"),
           AccountCookie("https://fake", "cookie1=24; Path=/; Secure"),
           AccountCookie("http://something", "cookie2=25; Path=/abc; Expires=Wed, 23 Dec 2020 07:28:00 GMT")
-        )
+        ),
+        deviceRegistrationURI = URI("https://www.example.com")
       ),
       state.credentials
     )
@@ -2351,9 +2358,6 @@ abstract class ProfileAccountLoginTaskContract {
 
     val result1 = task1.call()
     TaskDumps.dump(logger, result1)
-
-    val state =
-      this.account.loginState as AccountNotLoggedIn
 
     assertEquals(0, this.server.requestCount)
   }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLoginTaskContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLoginTaskContract.kt
@@ -127,6 +127,11 @@ abstract class ProfileAccountLoginTaskContract {
        "href" : "https://www.example.com",
        "rel" : "http://www.w3.org/ns/oa#annotationService",
        "type" : "application/ld+json; profile=\"http://www.w3.org/ns/anno.jsonld\""
+    },
+    {
+       "href" : "https://www.example.com",
+       "rel" : "http://palaceproject.io/terms/deviceRegistration",
+       "type" : "application/ld+json; profile=\"http://www.w3.org/ns/anno.jsonld\""
     }
   ]
 }
@@ -152,6 +157,11 @@ abstract class ProfileAccountLoginTaskContract {
     {
        "href" : "https://www.example.com",
        "rel" : "http://www.w3.org/ns/oa#annotationService",
+       "type" : "application/ld+json; profile=\"http://www.w3.org/ns/anno.jsonld\""
+    },
+    {
+       "href" : "https://www.example.com",
+       "rel" : "http://palaceproject.io/terms/deviceRegistration",
        "type" : "application/ld+json; profile=\"http://www.w3.org/ns/anno.jsonld\""
     }
   ],
@@ -541,9 +551,6 @@ abstract class ProfileAccountLoginTaskContract {
 
     val result = task.call()
     TaskDumps.dump(this.logger, result)
-
-    val state =
-      this.account.loginState as AccountLoginFailed
 
     assertEquals(0, this.server.requestCount)
   }

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLogoutTaskContract.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/profiles/ProfileAccountLogoutTaskContract.kt
@@ -252,7 +252,8 @@ abstract class ProfileAccountLogoutTaskContract {
         password = AccountPassword("1234"),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     this.account.setLoginState(AccountLoggedIn(credentials))
@@ -333,7 +334,8 @@ abstract class ProfileAccountLogoutTaskContract {
           )
         ),
         annotationsURI = URI("https://www.example.com"),
-        authenticationDescription = null
+        authenticationDescription = null,
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     this.account.setLoginState(AccountLoggedIn(credentials))
@@ -432,7 +434,8 @@ abstract class ProfileAccountLogoutTaskContract {
           )
         ),
         annotationsURI = URI("https://www.example.com"),
-        authenticationDescription = null
+        authenticationDescription = null,
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     this.account.setLoginState(AccountLoggedIn(credentials))
@@ -550,7 +553,8 @@ abstract class ProfileAccountLogoutTaskContract {
           )
         ),
         annotationsURI = URI("https://www.example.com"),
-        authenticationDescription = null
+        authenticationDescription = null,
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     this.account.setLoginState(AccountLoggedIn(credentials))

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/books/time_tracking/TimeTrackingHttpCallsTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/books/time_tracking/TimeTrackingHttpCallsTest.kt
@@ -52,7 +52,8 @@ class TimeTrackingHttpCallsTest {
         password = AccountPassword("1234"),
         adobeCredentials = null,
         authenticationDescription = null,
-        annotationsURI = URI("https://www.example.com")
+        annotationsURI = URI("https://www.example.com"),
+        deviceRegistrationURI = URI("https://www.example.com")
       )
 
     Mockito.`when`(account.loginState).thenReturn(loginState)

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/bugs/Simply3635Test.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/bugs/Simply3635Test.kt
@@ -240,7 +240,10 @@ class Simply3635Test {
     b.addService(ContentResolverType::class.java, this.contentResolverSane)
     b.addService(FeedLoaderType::class.java, this.feedLoader)
     b.addService(LSHTTPClientType::class.java, this.http)
-    b.addService(NotificationTokenHTTPCallsType::class.java, NotificationTokenHTTPCalls(this.http))
+    b.addService(
+      NotificationTokenHTTPCallsType::class.java,
+      NotificationTokenHTTPCalls(this.http, this.executorService)
+    )
     b.addService(OPDSFeedParserType::class.java, this.opdsParser)
     b.addService(PatronUserProfileParsersType::class.java, PatronUserProfileParsers())
     b.addService(ProfileIdleTimerType::class.java, this.profileIdleTimer)

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/bookmarks/BookmarkRefreshTokenTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/bookmarks/BookmarkRefreshTokenTest.kt
@@ -88,7 +88,8 @@ class BookmarkRefreshTokenTest {
       ),
       adobeCredentials = null,
       authenticationDescription = null,
-      annotationsURI = URI("https://www.example.com")
+      annotationsURI = URI("https://www.example.com"),
+      deviceRegistrationURI = URI("https://www.example.com")
     )
 
     this.account.setLoginState(AccountLoginState.AccountLoggedIn(credentials))

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/borrow/BorrowBookRefreshTokenTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/borrow/BorrowBookRefreshTokenTest.kt
@@ -135,7 +135,8 @@ class BorrowBookRefreshTokenTest {
         )
       ),
       authenticationDescription = "BasicToken",
-      annotationsURI = URI("https://www.example.com")
+      annotationsURI = URI("https://www.example.com"),
+      deviceRegistrationURI = URI("https://www.example.com")
     )
 
     this.account.setLoginState(AccountLoginState.AccountLoggedIn(credentials))

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/revoke/RevokeBookRefreshTokenTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/revoke/RevokeBookRefreshTokenTest.kt
@@ -107,7 +107,8 @@ class RevokeBookRefreshTokenTest {
         )
       ),
       authenticationDescription = "BasicToken",
-      annotationsURI = URI("https://www.example.com")
+      annotationsURI = URI("https://www.example.com"),
+      deviceRegistrationURI = URI("https://www.example.com")
     )
 
     this.account.setLoginState(AccountLoginState.AccountLoggedIn(credentials))

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/sync/SyncBookRefreshToken.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/sync/SyncBookRefreshToken.kt
@@ -102,6 +102,7 @@ class SyncBookRefreshToken {
   private lateinit var executorBooks: ListeningExecutorService
   private lateinit var executorDownloads: ListeningExecutorService
   private lateinit var executorFeeds: ListeningExecutorService
+  private lateinit var executorNotifications: ListeningExecutorService
   private lateinit var httpClient: LSHTTPClientType
   private lateinit var patronUserProfileParsers: PatronUserProfileParsersType
   private lateinit var profileEvents: PublishSubject<ProfileEvent>
@@ -173,6 +174,7 @@ class SyncBookRefreshToken {
     this.executorBooks = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool())
     this.executorDownloads = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool())
     this.executorFeeds = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool())
+    this.executorNotifications = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool())
     this.patronUserProfileParsers = Mockito.mock(PatronUserProfileParsersType::class.java)
     this.profileEvents = PublishSubject.create()
     this.profileEventsReceived = Collections.synchronizedList(ArrayList())
@@ -294,7 +296,7 @@ class SyncBookRefreshToken {
     services.putService(ContentResolverType::class.java, this.contentResolver)
     services.putService(FeedLoaderType::class.java, feedLoader)
     services.putService(LSHTTPClientType::class.java, this.httpClient)
-    services.putService(NotificationTokenHTTPCallsType::class.java, NotificationTokenHTTPCalls(this.httpClient))
+    services.putService(NotificationTokenHTTPCallsType::class.java, NotificationTokenHTTPCalls(this.httpClient, this.executorNotifications))
     services.putService(OPDSFeedParserType::class.java, parser)
     services.putService(PatronUserProfileParsersType::class.java, patronUserProfileParsers)
     services.putService(ProfileAccountCreationStringResourcesType::class.java, profileAccountCreationStringResources)

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/sync/SyncBookRefreshToken.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/sync/SyncBookRefreshToken.kt
@@ -151,7 +151,8 @@ class SyncBookRefreshToken {
       ),
       adobeCredentials = null,
       authenticationDescription = "BasicToken",
-      annotationsURI = URI("https://www.example.com")
+      annotationsURI = URI("https://www.example.com"),
+      deviceRegistrationURI = URI("https://www.example.com")
     )
 
     this.account.setLoginState(AccountLoginState.AccountLoggedIn(credentials))

--- a/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/time_tracking/TimeTrackingRefreshTokenTest.kt
+++ b/simplified-tests/src/test/java/org/nypl/simplified/tests/http/refresh_token/time_tracking/TimeTrackingRefreshTokenTest.kt
@@ -73,7 +73,8 @@ class TimeTrackingRefreshTokenTest {
         )
       ),
       authenticationDescription = "BasicToken",
-      annotationsURI = URI("https://www.example.com")
+      annotationsURI = URI("https://www.example.com"),
+      deviceRegistrationURI = URI("https://www.example.com")
     )
 
     this.account.setLoginState(AccountLoginState.AccountLoggedIn(credentials))


### PR DESCRIPTION
**What's this do?**
This PR adds logic to use the device registration URI, if any, on the patron authentication document instead of having it hardcoded. It also changes the notification http calls to be done on a background thread.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://ebce-lyrasis.atlassian.net/browse/PP-654) to implement this now the backend supports it and there's a [bug report](https://ebce-lyrasis.atlassian.net/browse/PP-705) saying the notification http calls are being called in the main thread.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app in two different devices
Logout and login (or just log in if you were not authenticated) from any library (but it has to be the same) on both devices
With one account borrow a book that only has on copy
With the other account, reserve the same book
Again with the first account, return the book
Confirm a push notification is received in the second account

**Dependencies for merging? Releasing to production?**
None

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 