### PR TITLE
PP-663 (Partial): Reduce logging volume

### DIFF
--- a/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BServiceOpSyncOneAccount.kt
+++ b/simplified-bookmarks/src/main/java/org/nypl/simplified/bookmarks/internal/BServiceOpSyncOneAccount.kt
@@ -170,6 +170,15 @@ internal class BServiceOpSyncOneAccount(
           bookmark.bookmarkId.value
         )
 
+        if (!syncable.account.bookDatabase.books().contains(bookmark.book)) {
+          this.logger.debug(
+            "[{}]: we no longer have book {}",
+            this.profile.id.uuid,
+            bookmark.bookmarkId.value
+          )
+          continue
+        }
+
         val entry = syncable.account.bookDatabase.entry(bookmark.book)
 
         when (bookmark) {

--- a/simplified-ui-images/src/main/java/org/nypl/simplified/ui/images/ImageAccountIcons.kt
+++ b/simplified-ui-images/src/main/java/org/nypl/simplified/ui/images/ImageAccountIcons.kt
@@ -28,8 +28,6 @@ object ImageAccountIcons {
     iconView: ImageView,
   ) {
     val uri = account.logoURI?.hrefURI
-    this.logger.debug("configuring account logo: {}", uri)
-
     if (uri == null) {
       iconView.setImageResource(defaultIcon)
       return


### PR DESCRIPTION
**What's this do?**
This makes a couple of changes to assist with (but not solve PP-663):
  * We no longer log account list icons, because some of them are still giant base64 encoded PNGs that end up in logs.
  * We accept the fact that book database entries can disappear when syncing bookmarks

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-663

**How should this be tested? / Do these changes have associated tests?**
Nothing, really. There's just less noise in the logs now.

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Enjoyed the peace and quiet.