### PR TITLE
PP-714: Make BottomNavigator bug non-fatal

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -370,7 +370,7 @@
         <c:change date="2022-04-29T00:00:00+00:00" summary="Fixed &quot;Unable to initialize audio engine&quot; error playing some audio books."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-11-10T10:00:46+00:00" is-open="true" ticket-system="org.lyrasis.jira" version="1.8.0">
+    <c:release date="2023-11-10T14:25:49+00:00" is-open="true" ticket-system="org.lyrasis.jira" version="1.8.0">
       <c:changes>
         <c:change date="2023-11-07T00:00:00+00:00" summary="Book sample buttons are no longer displayed for loaned books.">
           <c:tickets>
@@ -388,7 +388,12 @@
           </c:tickets>
         </c:change>
         <c:change date="2023-11-09T00:00:00+00:00" summary="Started using device registration URI from patron authentication document."/>
-        <c:change date="2023-11-10T10:00:46+00:00" summary="Updated notification calls to be run in a background thread."/>
+        <c:change date="2023-11-10T00:00:00+00:00" summary="Updated notification calls to be run in a background thread."/>
+        <c:change date="2023-11-10T14:25:49+00:00" summary="Prevent a crash caused by tabs and the back button.">
+          <c:tickets>
+            <c:ticket id="PP-714"/>
+          </c:tickets>
+        </c:change>
       </c:changes>
     </c:release>
   </c:releases>

--- a/simplified-ui-navigation-tabs/src/main/java/org/librarysimplified/ui/navigation/tabs/TabbedNavigator.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/librarysimplified/ui/navigation/tabs/TabbedNavigator.kt
@@ -70,7 +70,16 @@ class TabbedNavigator private constructor(private val navigator: BottomNavigator
   }
 
   fun popBackStack(): Boolean {
-    return this.navigator.pop()
+    if (this.navigator.currentStackSize() < 1) {
+      return false
+    }
+
+    return try {
+      this.navigator.pop()
+    } catch (e: Exception) {
+      logger.warn("Failed to pop navigator stack: ", e)
+      false
+    }
   }
 
   fun popToRoot(): Boolean {

--- a/simplified-ui-navigation-tabs/src/main/java/org/librarysimplified/ui/navigation/tabs/TabbedNavigator.kt
+++ b/simplified-ui-navigation-tabs/src/main/java/org/librarysimplified/ui/navigation/tabs/TabbedNavigator.kt
@@ -70,12 +70,13 @@ class TabbedNavigator private constructor(private val navigator: BottomNavigator
   }
 
   fun popBackStack(): Boolean {
-    if (this.navigator.currentStackSize() < 1) {
-      return false
-    }
-
     return try {
-      this.navigator.pop()
+      if (this.navigator.currentStackSize() < 1) {
+        this.logger.warn("Trying to pop an empty stack!")
+        false
+      } else {
+        this.navigator.pop()
+      }
     } catch (e: Exception) {
       logger.warn("Failed to pop navigator stack: ", e)
       false


### PR DESCRIPTION
**What's this do?**
Don't attempt to pop the stack unless there's something to pop. 
Catch any NullPointerExceptions that the library might raise.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-714

**How should this be tested? / Do these changes have associated tests?**
Nothing new. Just see if the crashes stop after `1.8.0`...

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
Yes.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Used the catalog for a while. I've not seen the original crash, so I just wanted to check that I didn't break the catalog.