### PR TITLE
Add some missing MDC logs

### DIFF
--- a/simplified-mdc/src/main/java/org/librarysimplified/mdc/MDCKeys.kt
+++ b/simplified-mdc/src/main/java/org/librarysimplified/mdc/MDCKeys.kt
@@ -34,6 +34,13 @@ object MDCKeys {
     "BookInternalID"
 
   /**
+   * The OPDS feed entry ID of the current book.
+   */
+
+  const val BOOK_ID =
+    "BookID"
+
+  /**
    * The internal application ID of the current account.
    */
 

--- a/simplified-viewer-api/src/main/java/org/nypl/simplified/viewer/api/Viewers.kt
+++ b/simplified-viewer-api/src/main/java/org/nypl/simplified/viewer/api/Viewers.kt
@@ -49,6 +49,7 @@ object Viewers {
     MDC.put(MDCKeys.BOOK_DRM, format.drmInformation.kind.name)
     MDC.put(MDCKeys.BOOK_FORMAT, format.contentType.toString())
     MDC.put(MDCKeys.BOOK_INTERNAL_ID, book.id.value())
+    MDC.put(MDCKeys.BOOK_ID, book.entry.id)
     MDC.put(MDCKeys.BOOK_TITLE, book.entry.title)
     MDCKeys.put(MDCKeys.BOOK_PUBLISHER, book.entry.publisher)
 

--- a/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/AudioBookPlayerActivity.kt
+++ b/simplified-viewer-audiobook/src/main/java/org/librarysimplified/viewer/audiobook/AudioBookPlayerActivity.kt
@@ -226,6 +226,7 @@ class AudioBookPlayerActivity :
     MDC.put(MDCKeys.ACCOUNT_INTERNAL_ID, this.parameters.accountID.uuid.toString())
     MDC.put(MDCKeys.ACCOUNT_PROVIDER_ID, this.parameters.accountProviderID.toString())
     MDC.put(MDCKeys.BOOK_INTERNAL_ID, this.parameters.bookID.value())
+    MDC.put(MDCKeys.BOOK_ID, this.parameters.opdsEntry.id)
     MDC.put(MDCKeys.BOOK_TITLE, this.parameters.opdsEntry.title)
     MDCKeys.put(MDCKeys.BOOK_PUBLISHER, this.parameters.opdsEntry.publisher)
     MDC.remove(MDCKeys.BOOK_DRM)

--- a/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
+++ b/simplified-viewer-epub-readium2/src/main/java/org/librarysimplified/viewer/epub/readium2/Reader2Activity.kt
@@ -158,6 +158,7 @@ class Reader2Activity : AppCompatActivity(R.layout.reader2) {
     MDC.put(MDCKeys.ACCOUNT_INTERNAL_ID, this.parameters.accountId.uuid.toString())
     MDC.put(MDCKeys.BOOK_INTERNAL_ID, this.parameters.bookId.value())
     MDC.put(MDCKeys.BOOK_TITLE, this.parameters.entry.feedEntry.title)
+    MDC.put(MDCKeys.BOOK_ID, this.parameters.entry.feedEntry.id)
     MDCKeys.put(MDCKeys.BOOK_PUBLISHER, this.parameters.entry.feedEntry.publisher)
     MDC.put(MDCKeys.BOOK_DRM, this.parameters.drmInfo.kind.name)
     MDC.remove(MDCKeys.BOOK_FORMAT)

--- a/simplified-viewer-pdf-pdfjs/src/main/java/org/librarysimplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
+++ b/simplified-viewer-pdf-pdfjs/src/main/java/org/librarysimplified/viewer/pdf/pdfjs/PdfReaderActivity.kt
@@ -102,6 +102,7 @@ class PdfReaderActivity : AppCompatActivity() {
     MDC.put(MDCKeys.ACCOUNT_INTERNAL_ID, this.accountId.uuid.toString())
     MDC.put(MDCKeys.BOOK_INTERNAL_ID, this.bookID.value())
     MDC.put(MDCKeys.BOOK_TITLE, this.feedEntry.feedEntry.title)
+    MDC.put(MDCKeys.BOOK_ID, this.feedEntry.feedEntry.id)
     MDCKeys.put(MDCKeys.BOOK_PUBLISHER, this.feedEntry.feedEntry.publisher)
     MDC.put(MDCKeys.BOOK_FORMAT, "application/pdf")
     MDC.remove(MDCKeys.BOOK_DRM)

--- a/simplified-viewer-preview/src/main/java/org/librarysimplified/viewer/preview/BookPreviewActivity.kt
+++ b/simplified-viewer-preview/src/main/java/org/librarysimplified/viewer/preview/BookPreviewActivity.kt
@@ -102,6 +102,7 @@ class BookPreviewActivity : AppCompatActivity(R.layout.activity_book_preview) {
     this.feedEntry = intent.getSerializableExtra(EXTRA_ENTRY) as FeedEntry.FeedEntryOPDS
 
     MDC.put(MDCKeys.BOOK_TITLE, this.feedEntry.feedEntry.title)
+    MDC.put(MDCKeys.BOOK_ID, this.feedEntry.feedEntry.id)
     MDCKeys.put(MDCKeys.BOOK_PUBLISHER, this.feedEntry.feedEntry.publisher)
     MDC.remove(MDCKeys.BOOK_DRM)
     MDC.remove(MDCKeys.BOOK_FORMAT)


### PR DESCRIPTION
**What's this do?**
We weren't logging OPDS feed entry IDs. Those are the most useful values when debugging problems with specific books.

**Why are we doing this? (w/ JIRA link if applicable)**
We ran into this earlier when trying to debug a Picasso crash.

**How should this be tested? / Do these changes have associated tests?**
Check that the new fields appear in Crashlytics when there's a crash...

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried it.