### PR TITLE
PP-738: Make account deletion icon visible

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -407,12 +407,17 @@
         </c:change>
       </c:changes>
     </c:release>
-    <c:release date="2023-11-20T20:21:57+00:00" is-open="true" ticket-system="org.lyrasis.jira" version="1.9.0">
+    <c:release date="2023-11-21T15:13:27+00:00" is-open="true" ticket-system="org.lyrasis.jira" version="1.9.0">
       <c:changes>
         <c:change date="2023-11-17T00:00:00+00:00" summary="Updated Readium version."/>
-        <c:change date="2023-11-20T20:21:57+00:00" summary="Fix an LCP audiobook crash.">
+        <c:change date="2023-11-20T00:00:00+00:00" summary="Fix an LCP audiobook crash.">
           <c:tickets>
             <c:ticket id="PP-737"/>
+          </c:tickets>
+        </c:change>
+        <c:change date="2023-11-21T15:13:27+00:00" summary="Make account deletion icon visible.">
+          <c:tickets>
+            <c:ticket id="PP-738"/>
           </c:tickets>
         </c:change>
       </c:changes>

--- a/simplified-ui-accounts/src/main/res/drawable-night/ic_delete.xml
+++ b/simplified-ui-accounts/src/main/res/drawable-night/ic_delete.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#ffffff"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM16.3,16.3c-0.39,0.39 -1.02,0.39 -1.41,0L12,13.41 9.11,16.3c-0.39,0.39 -1.02,0.39 -1.41,0 -0.39,-0.39 -0.39,-1.02 0,-1.41L10.59,12 7.7,9.11c-0.39,-0.39 -0.39,-1.02 0,-1.41 0.39,-0.39 1.02,-0.39 1.41,0L12,10.59l2.89,-2.89c0.39,-0.39 1.02,-0.39 1.41,0 0.39,0.39 0.39,1.02 0,1.41L13.41,12l2.89,2.89c0.38,0.38 0.38,1.02 0,1.41z" />
+</vector>

--- a/simplified-ui-accounts/src/main/res/drawable/ic_delete.xml
+++ b/simplified-ui-accounts/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM16.3,16.3c-0.39,0.39 -1.02,0.39 -1.41,0L12,13.41 9.11,16.3c-0.39,0.39 -1.02,0.39 -1.41,0 -0.39,-0.39 -0.39,-1.02 0,-1.41L10.59,12 7.7,9.11c-0.39,-0.39 -0.39,-1.02 0,-1.41 0.39,-0.39 1.02,-0.39 1.41,0L12,10.59l2.89,-2.89c0.39,-0.39 1.02,-0.39 1.41,0 0.39,0.39 0.39,1.02 0,1.41L13.41,12l2.89,2.89c0.38,0.38 0.38,1.02 0,1.41z" />
+</vector>

--- a/simplified-ui-accounts/src/main/res/layout/account_list_item_old.xml
+++ b/simplified-ui-accounts/src/main/res/layout/account_list_item_old.xml
@@ -59,9 +59,11 @@
         android:layout_height="32dp"
         android:layout_gravity="center_vertical"
         android:layout_marginStart="16dp"
+        android:src="@drawable/ic_delete"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/accountMore"
         android:focusable="true"
         android:visibility="gone"
         tools:visibility="visible" />
+
 </LinearLayout>


### PR DESCRIPTION
**What's this do?**
It seems that no icon was assigned at all to the accounts list deletion button. Now there is!

**Why are we doing this? (w/ JIRA link if applicable)**
Fix: https://ebce-lyrasis.atlassian.net/browse/PP-738

**How should this be tested? / Do these changes have associated tests?**
![Screenshot_20231121_151129](https://github.com/ThePalaceProject/android-core/assets/612494/68f9fb14-1b5d-4b1c-91e5-de0587313e23)

**Dependencies for merging? Releasing to production?**
None.

**Have you updated the changelog?**
Yes.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Took the above screenshot.