### PR TITLE
Fix jira-release-sync.yml workflow by ensuring that the plugin trigge…

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
           TAG_NAME: ${{ env.TAG_NAME }}
           VERSION_NUM: ${{ env.VERSION_NUM }}
         with:
+          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
           tag_name: ${{ env.TAG_NAME }}
           name: ${{ env.VERSION_NUM }}
           body_path: ${{ env.RELEASE_NOTES_PATH }}


### PR DESCRIPTION
…ring the workflow (in android-release.yml)

is using CI_GITHUB_ACCESS_TOKEN rather than GITHUB_TOKEN which, according to the github docs, cannot trigger other workflows.

Here's some background by Claude:
******************
There are actually two things worth noting here:

1. softprops/action-gh-release with draft: false does create a published release — so the event type itself isn't the problem.

2. The real problem: GITHUB_TOKEN cannot trigger other workflows

This is a deliberate GitHub security restriction. When a workflow uses the built-in GITHUB_TOKEN to perform an action (like creating a release), GitHub intentionally does not trigger other workflows from that event, to prevent accidental infinite loops.

...
Fix suggested:
...
Use a PAT or GitHub App token instead of GITHUB_TOKEN in the release step:

- name: Create GitHub release
  uses: softprops/action-gh-release@v2
  with:
    token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}  # PAT already in the repo's secrets
    tag_name: ${{ env.TAG_NAME }}
    name: ${{ env.VERSION_NUM }}
    body_path: ${{ env.RELEASE_NOTES_PATH }}
    draft: false
*******************************

**What's this do?**
Ensures that the jira-release-sync workflow can be triggered by the release plugin.

**Why are we doing this? (w/ JIRA link if applicable)**
This is a bug fix: release workflow is not triggering the jira  release workflow.

**How should this be tested? / Do these changes have associated tests?**
[Description of any tests that need to be performed once merged goes here]
This change will  be tested automatically on the next release: if jira-release-sync.yml fires, it works.
**Dependencies for merging? Releasing to production?**
[Description of any watchouts, dependencies, or issues we should be aware of goes here]
N/A
**Have you updated the changelog?**
No.
**Has the application documentation been updated for these changes?**
Wasn't necessary
**Did someone actually run this code to verify it works?**
Not yet.