### PR TITLE
Replace softprops/action-gh-release with direct GH api create release…

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -17,18 +17,15 @@ jobs:
         run: .ci/ci-verify-release-branch.sh
       - name: Finish release
         run: .ci/ci-release-finish.sh
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+      - name: Create or update release
         env:
+          GITHUB_TOKEN: ${{ GITHUB_TOKEN }}
           RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
-          TAG_NAME: ${{ env.TAG_NAME }}
           VERSION_NUM: ${{ env.VERSION_NUM }}
-        with:
-          token: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
-          tag_name: ${{ env.TAG_NAME }}
-          name: ${{ env.VERSION_NUM }}
-          body_path: ${{ env.RELEASE_NOTES_PATH }}
-          draft: false
+        run: |
+          gh release create "$VERSION_NUM" \
+            --title "$VERSION_NUM" \
+            --notes-file "$RELEASE_NOTES_PATH"
       - name: Build
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -19,7 +19,7 @@ jobs:
         run: .ci/ci-release-finish.sh
       - name: Create or update release
         env:
-          GITHUB_TOKEN: ${{ GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_ACCESS_TOKEN }}
           RELEASE_NOTES_PATH: ${{ env.RELEASE_NOTES_PATH }}
           VERSION_NUM: ${{ env.VERSION_NUM }}
         run: |


### PR DESCRIPTION
… call


**Why are we doing this? (w/ JIRA link if applicable)**
We're trying to get the jira-release-sync workflow to trigger on a "publish" event.

**How should this be tested? / Do these changes have associated tests?**
Should be tested during next release.
**Dependencies for merging? Releasing to production?**
No.

**Did someone actually run this code to verify it works?**
Not yet: but it was taken from ios-core where it has run successfully.